### PR TITLE
Added anthropic-chat as possible llm type returned by Anthropic 

### DIFF
--- a/langfuse/callback.py
+++ b/langfuse/callback.py
@@ -435,7 +435,10 @@ class CallbackHandler(BaseCallbackHandler):
                     metadata=metadata,
                     kwargs=kwargs,
                 )
-            if kwargs["invocation_params"]["_type"] == "anthropic-llm":
+            if (
+                kwargs["invocation_params"]["_type"] == "anthropic-llm"
+                or kwargs["invocation_params"]["_type"] == "anthropic-chat"
+            ):
                 model_name = "anthropic"  # unfortunately no model info by anthropic provided.
             elif kwargs["invocation_params"]["_type"] == "huggingface_hub":
                 model_name = kwargs["invocation_params"]["repo_id"]

--- a/langfuse/callback.py
+++ b/langfuse/callback.py
@@ -435,10 +435,7 @@ class CallbackHandler(BaseCallbackHandler):
                     metadata=metadata,
                     kwargs=kwargs,
                 )
-            if (
-                kwargs["invocation_params"]["_type"] == "anthropic-llm"
-                or kwargs["invocation_params"]["_type"] == "anthropic-chat"
-            ):
+            if kwargs["invocation_params"]["_type"] in ["anthropic-llm", "anthropic-chat"]:
                 model_name = "anthropic"  # unfortunately no model info by anthropic provided.
             elif kwargs["invocation_params"]["_type"] == "huggingface_hub":
                 model_name = kwargs["invocation_params"]["repo_id"]


### PR DESCRIPTION
Added `anthropic-chat` as possible llm type returned by Anthropic to fix error with tracing Anthropic LLM generations. The error comes from the type returned by Anthropic to have changed to `anthropic-chat`.

```
Traceback (most recent call last):
  File "/Users/ruben/git/rag-chatbot-lambda/venv_3.11/lib/python3.11/site-packages/langfuse/callback.py", line 445, in __on_llm_action
    model_name = kwargs["invocation_params"]["model_name"]
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'model_name'
```