### PR TITLE
Inject additional headers

### DIFF
--- a/langfuse/api/client.py
+++ b/langfuse/api/client.py
@@ -22,7 +22,8 @@ class FintoLangfuse:
         x_langfuse_sdk_version: typing.Optional[str] = None,
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
-        password: str
+        password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -30,6 +31,7 @@ class FintoLangfuse:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
         self.dataset_items = DatasetItemsClient(
             environment=self._environment,
             x_langfuse_sdk_name=self.x_langfuse_sdk_name,
@@ -37,6 +39,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
         self.dataset_run_items = DatasetRunItemsClient(
             environment=self._environment,
@@ -45,6 +48,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
         self.datasets = DatasetsClient(
             environment=self._environment,
@@ -53,6 +57,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
         self.event = EventClient(
             environment=self._environment,
@@ -61,6 +66,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
         self.generations = GenerationsClient(
             environment=self._environment,
@@ -69,6 +75,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
         self.observations = ObservationsClient(
             environment=self._environment,
@@ -77,6 +84,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
         self.score = ScoreClient(
             environment=self._environment,
@@ -85,6 +93,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
         self.span = SpanClient(
             environment=self._environment,
@@ -93,6 +102,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
         self.trace = TraceClient(
             environment=self._environment,
@@ -101,6 +111,7 @@ class FintoLangfuse:
             x_langfuse_public_key=self.x_langfuse_public_key,
             username=self._username,
             password=self._password,
+            additional_headers=additional_headers
         )
 
 

--- a/langfuse/api/resources/dataset_items/client.py
+++ b/langfuse/api/resources/dataset_items/client.py
@@ -29,6 +29,7 @@ class DatasetItemsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -36,6 +37,7 @@ class DatasetItemsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     def create(self, *, request: CreateDatasetItemRequest) -> DatasetItem:
         _response = httpx.request(
@@ -47,6 +49,7 @@ class DatasetItemsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers
                 }
             ),
             auth=(self._username, self._password)
@@ -83,6 +86,7 @@ class AsyncDatasetItemsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -90,6 +94,7 @@ class AsyncDatasetItemsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     async def create(self, *, request: CreateDatasetItemRequest) -> DatasetItem:
         async with httpx.AsyncClient() as _client:
@@ -102,6 +107,7 @@ class AsyncDatasetItemsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/api/resources/dataset_run_items/client.py
+++ b/langfuse/api/resources/dataset_run_items/client.py
@@ -29,6 +29,7 @@ class DatasetRunItemsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -36,6 +37,7 @@ class DatasetRunItemsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     def create(self, *, request: CreateDatasetRunItemRequest) -> DatasetRunItem:
         _response = httpx.request(
@@ -47,6 +49,7 @@ class DatasetRunItemsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers
                 }
             ),
             auth=(self._username, self._password)
@@ -83,6 +86,7 @@ class AsyncDatasetRunItemsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -90,6 +94,7 @@ class AsyncDatasetRunItemsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     async def create(self, *, request: CreateDatasetRunItemRequest) -> DatasetRunItem:
         async with httpx.AsyncClient() as _client:
@@ -102,6 +107,7 @@ class AsyncDatasetRunItemsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/api/resources/datasets/client.py
+++ b/langfuse/api/resources/datasets/client.py
@@ -30,6 +30,7 @@ class DatasetsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -37,6 +38,7 @@ class DatasetsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     def get(self, dataset_name: str) -> Dataset:
         _response = httpx.request(
@@ -47,6 +49,7 @@ class DatasetsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers
                 }
             ),
             auth=(self._username, self._password)
@@ -82,6 +85,7 @@ class DatasetsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers
                 }
             ),
             auth=(self._username, self._password)
@@ -116,6 +120,7 @@ class DatasetsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers
                 }
             ),
             auth=(self._username, self._password)
@@ -152,6 +157,7 @@ class AsyncDatasetsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -159,6 +165,7 @@ class AsyncDatasetsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     async def get(self, dataset_name: str) -> Dataset:
         async with httpx.AsyncClient() as _client:
@@ -170,6 +177,7 @@ class AsyncDatasetsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)
@@ -206,6 +214,7 @@ class AsyncDatasetsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)
@@ -241,6 +250,7 @@ class AsyncDatasetsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/api/resources/event/client.py
+++ b/langfuse/api/resources/event/client.py
@@ -29,6 +29,7 @@ class EventClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -36,6 +37,7 @@ class EventClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     def create(self, *, request: CreateEventRequest) -> Observation:
         _response = httpx.request(
@@ -47,6 +49,7 @@ class EventClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers
                 }
             ),
             auth=(self._username, self._password)
@@ -83,6 +86,7 @@ class AsyncEventClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -90,6 +94,7 @@ class AsyncEventClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     async def create(self, *, request: CreateEventRequest) -> Observation:
         async with httpx.AsyncClient() as _client:
@@ -102,6 +107,7 @@ class AsyncEventClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/api/resources/generations/client.py
+++ b/langfuse/api/resources/generations/client.py
@@ -31,6 +31,7 @@ class GenerationsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -38,6 +39,7 @@ class GenerationsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     def log(self, *, request: CreateGenerationRequest) -> Observation:
         _response = httpx.request(
@@ -49,6 +51,7 @@ class GenerationsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers
                 }
             ),
             auth=(self._username, self._password)
@@ -84,6 +87,7 @@ class GenerationsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers
                 }
             ),
             auth=(self._username, self._password)
@@ -126,6 +130,7 @@ class GenerationsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -162,6 +167,7 @@ class AsyncGenerationsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -169,6 +175,7 @@ class AsyncGenerationsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     async def log(self, *, request: CreateGenerationRequest) -> Observation:
         async with httpx.AsyncClient() as _client:
@@ -181,6 +188,7 @@ class AsyncGenerationsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)
@@ -217,6 +225,7 @@ class AsyncGenerationsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)
@@ -260,6 +269,7 @@ class AsyncGenerationsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/api/resources/observations/client.py
+++ b/langfuse/api/resources/observations/client.py
@@ -27,6 +27,7 @@ class ObservationsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -34,6 +35,7 @@ class ObservationsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     def get(self, observation_id: str) -> Observation:
         _response = httpx.request(
@@ -44,6 +46,7 @@ class ObservationsClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -80,6 +83,7 @@ class AsyncObservationsClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -87,6 +91,7 @@ class AsyncObservationsClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     async def get(self, observation_id: str) -> Observation:
         async with httpx.AsyncClient() as _client:
@@ -98,6 +103,7 @@ class AsyncObservationsClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/api/resources/score/client.py
+++ b/langfuse/api/resources/score/client.py
@@ -30,6 +30,7 @@ class ScoreClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -37,6 +38,7 @@ class ScoreClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     def create(self, *, request: CreateScoreRequest) -> Score:
         _response = httpx.request(
@@ -48,6 +50,7 @@ class ScoreClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -90,6 +93,7 @@ class ScoreClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -126,6 +130,7 @@ class AsyncScoreClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -133,6 +138,7 @@ class AsyncScoreClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     async def create(self, *, request: CreateScoreRequest) -> Score:
         async with httpx.AsyncClient() as _client:
@@ -145,6 +151,7 @@ class AsyncScoreClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)
@@ -188,6 +195,7 @@ class AsyncScoreClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/api/resources/span/client.py
+++ b/langfuse/api/resources/span/client.py
@@ -30,11 +30,13 @@ class SpanClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
         self.x_langfuse_sdk_version = x_langfuse_sdk_version
         self.x_langfuse_public_key = x_langfuse_public_key
+        self.additional_headers = additional_headers
         self._username = username
         self._password = password
 
@@ -48,6 +50,7 @@ class SpanClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -83,6 +86,7 @@ class SpanClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -119,6 +123,7 @@ class AsyncSpanClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -126,6 +131,7 @@ class AsyncSpanClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_header = additional_headers
 
     async def create(self, *, request: CreateSpanRequest) -> Observation:
         async with httpx.AsyncClient() as _client:
@@ -138,6 +144,7 @@ class AsyncSpanClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers,
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/api/resources/trace/client.py
+++ b/langfuse/api/resources/trace/client.py
@@ -31,6 +31,7 @@ class TraceClient:
         x_langfuse_public_key: typing.Optional[str] = None,
         username: str,
         password: str,
+        additional_headers: typing.Optional[typing.Dict] = {}
     ):
         self._environment = environment
         self.x_langfuse_sdk_name = x_langfuse_sdk_name
@@ -38,6 +39,7 @@ class TraceClient:
         self.x_langfuse_public_key = x_langfuse_public_key
         self._username = username
         self._password = password
+        self.additional_headers = additional_headers
 
     def create(self, *, request: CreateTraceRequest) -> Trace:
         _response = httpx.request(
@@ -49,6 +51,7 @@ class TraceClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -83,6 +86,7 @@ class TraceClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -125,6 +129,7 @@ class TraceClient:
                     "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                     "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                     "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                    **self.additional_headers,
                 }
             ),
             auth=(self._username, self._password)
@@ -180,6 +185,7 @@ class AsyncTraceClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers,
                     }
                 ),
                 auth=(self._username, self._password)
@@ -215,6 +221,7 @@ class AsyncTraceClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers,
                     }
                 ),
                 auth=(self._username, self._password)
@@ -258,6 +265,7 @@ class AsyncTraceClient:
                         "X-Langfuse-Sdk-Name": self.x_langfuse_sdk_name,
                         "X-Langfuse-Sdk-Version": self.x_langfuse_sdk_version,
                         "X-Langfuse-Public-Key": self.x_langfuse_public_key,
+                        **self.additional_headers,
                     }
                 ),
                 auth=(self._username, self._password)

--- a/langfuse/callback.py
+++ b/langfuse/callback.py
@@ -30,6 +30,7 @@ class CallbackHandler(BaseCallbackHandler):
         debug: bool = False,
         statefulClient: Optional[Union[StatefulTraceClient, StatefulSpanClient]] = None,
         release: Optional[str] = None,
+        additional_headers: Optional[Dict] = {},
     ) -> None:
         # If we're provided a stateful trace client directly
 
@@ -52,7 +53,7 @@ class CallbackHandler(BaseCallbackHandler):
 
         # Otherwise, initialize stateless using the provided keys
         elif public_key and secret_key:
-            self.langfuse = Langfuse(public_key, secret_key, host, debug=debug, release=release)
+            self.langfuse = Langfuse(public_key, secret_key, host, debug=debug, release=release, additional_headers=additional_headers)
             self.trace = None
             self.rootSpan = None
             self.runs = {}

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -50,6 +50,7 @@ class Langfuse(object):
         host: Optional[str] = None,
         release: Optional[str] = None,
         debug: bool = False,
+        additional_headers: typing.Optional[typing.Dict] = {},
     ):
         if debug:
             # Ensures that debug level messages are logged when debug mode is on.
@@ -88,6 +89,7 @@ class Langfuse(object):
             x_langfuse_sdk_name="python",
             x_langfuse_sdk_version=version,
             x_langfuse_public_key=public_key,
+            additional_headers=additional_headers
         )
 
         self.trace_id = None


### PR DESCRIPTION
# Context

The goal of this change is to enable injecting custom headers to be sent as part of the API request.  Ot is useful when Langfuse is deployed behind a proxy that validates some access policies (for ex: Cloudflare Tunnel). Many other use cases can be covered by this change as well.

# Design

Optionally, the user can specify additional headers as follow:

```python
from langfuse.client import Langfuse

langfuse = Langfuse(
        public_key=env.LANGFUSE_PUBLIC_KEY,
        secret_key=env.LANGFUSE_SECRET_KEY,
        host=env.LANGFUSE_HOST,
       
        # Adding custom headers
        additional_headers = {
            # For example: Inject Cloudflare Service Token
            'CF-Access-Client-Id': env.LANGFUSE_CF_ACCESS_CLIENT_ID,
            'CF-Access-Client-Secret': env.LANGFUSE_CF_ACCESS_CLIENT_SECRET,
        }
)

```