### PR TITLE
chore: rename client to httpx_client

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -65,7 +65,7 @@ class Langfuse(object):
         max_retries=3,
         timeout=15,
         sdk_integration: str = "default",
-        session: httpx.Client = None
+        httpx_client: httpx.Client = None,
     ):
         set_debug = debug if debug else (os.getenv("LANGFUSE_DEBUG", "False") == "True")
 
@@ -100,9 +100,11 @@ class Langfuse(object):
             raise ValueError(
                 "secret_key is required, set as parameter or environment variable 'LANGFUSE_SECRET_KEY'"
             )
-        
-        self.session = httpx.Client(timeout=timeout) if session is None else session
-        
+
+        self.httpx_client = (
+            httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
+
         self.client = FernLangfuse(
             base_url=self.base_url,
             username=public_key,
@@ -110,7 +112,7 @@ class Langfuse(object):
             x_langfuse_sdk_name="python",
             x_langfuse_sdk_version=version,
             x_langfuse_public_key=public_key,
-            httpx_client=self.session
+            httpx_client=self.httpx_client,
         )
 
         langfuse_client = LangfuseClient(
@@ -119,7 +121,7 @@ class Langfuse(object):
             base_url=self.base_url,
             version=version,
             timeout=timeout,
-            session=self.session
+            session=self.httpx_client,
         )
 
         args = {

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -3,6 +3,7 @@ import logging
 import os
 import typing
 import uuid
+import httpx
 from enum import Enum
 from typing import Literal, Optional
 
@@ -64,6 +65,7 @@ class Langfuse(object):
         max_retries=3,
         timeout=15,
         sdk_integration: str = "default",
+        session: httpx.Client = None
     ):
         set_debug = debug if debug else (os.getenv("LANGFUSE_DEBUG", "False") == "True")
 
@@ -98,7 +100,9 @@ class Langfuse(object):
             raise ValueError(
                 "secret_key is required, set as parameter or environment variable 'LANGFUSE_SECRET_KEY'"
             )
-
+        
+        self.session = httpx.Client(timeout=timeout) if session is None else session
+        
         self.client = FernLangfuse(
             base_url=self.base_url,
             username=public_key,
@@ -106,6 +110,7 @@ class Langfuse(object):
             x_langfuse_sdk_name="python",
             x_langfuse_sdk_version=version,
             x_langfuse_public_key=public_key,
+            httpx_client=self.session
         )
 
         langfuse_client = LangfuseClient(
@@ -114,6 +119,7 @@ class Langfuse(object):
             base_url=self.base_url,
             version=version,
             timeout=timeout,
+            session=self.session
         )
 
         args = {

--- a/langfuse/request.py
+++ b/langfuse/request.py
@@ -7,8 +7,6 @@ import httpx
 
 from langfuse.serializer import EventSerializer
 
-_session = httpx.Client()
-
 
 class LangfuseClient:
     _public_key: str
@@ -16,6 +14,7 @@ class LangfuseClient:
     _base_url: str
     _version: str
     _timeout: int
+    _session: httpx.Client
 
     def __init__(
         self,
@@ -24,12 +23,14 @@ class LangfuseClient:
         base_url: str,
         version: str,
         timeout: int,
+        session: httpx.Client,
     ):
         self._public_key = public_key
         self._secret_key = secret_key
         self._base_url = base_url
         self._version = version
         self._timeout = timeout
+        self._session = session
 
     def generate_headers(self):
         return {
@@ -59,7 +60,9 @@ class LangfuseClient:
         data = json.dumps(kwargs, cls=EventSerializer)
         log.debug("making request: %s to %s", data, url)
         headers = self.generate_headers()
-        res = _session.post(url, content=data, headers=headers, timeout=self._timeout)
+        res = self._session.post(
+            url, content=data, headers=headers, timeout=self._timeout
+        )
 
         if res.status_code == 200:
             log.debug("data uploaded successfully")

--- a/tests/test_sdk_setup.py
+++ b/tests/test_sdk_setup.py
@@ -120,6 +120,32 @@ def test_sdk_default():
     assert langfuse.client._client_wrapper._base_url == host
 
 
+def test_sdk_custom_xhttp_client():
+    public_key, secret_key, host = get_env_variables()
+
+    client = httpx.Client(timeout=9999)
+
+    langfuse = Langfuse(session=client)
+
+    langfuse.auth_check()
+
+    assert langfuse.client._client_wrapper._username == public_key
+    assert langfuse.client._client_wrapper._password == secret_key
+    assert langfuse.client._client_wrapper._base_url == host
+    assert langfuse.task_manager._client._session._timeout.as_dict() == {
+        "connect": 9999,
+        "pool": 9999,
+        "read": 9999,
+        "write": 9999,
+    }
+    assert langfuse.client._client_wrapper.httpx_client._timeout.as_dict() == {
+        "connect": 9999,
+        "pool": 9999,
+        "read": 9999,
+        "write": 9999,
+    }
+
+
 # callback
 def test_callback_setup_without_keys():
     public_key, secret_key, host = get_env_variables()

--- a/tests/test_sdk_setup.py
+++ b/tests/test_sdk_setup.py
@@ -125,7 +125,7 @@ def test_sdk_custom_xhttp_client():
 
     client = httpx.Client(timeout=9999)
 
-    langfuse = Langfuse(session=client)
+    langfuse = Langfuse(httpx_client=client)
 
     langfuse.auth_check()
 


### PR DESCRIPTION
`session` can be ambiguous because it is used in the Langfuse domain.

Related to #329 