### PR TITLE
Add run name override support.

### DIFF
--- a/langfuse/callback.py
+++ b/langfuse/callback.py
@@ -182,6 +182,13 @@ class CallbackHandler(BaseCallbackHandler):
         self.log.debug(
             f"on llm new token: run_id: {run_id} parent_run_id: {parent_run_id}"
         )
+    
+    def get_langchain_run_name(self, serialized: Dict[str, Any], **kwargs: Any) -> str:
+        """Langchain convention to change the display name of entities during tracing is "run_name" property.
+        This "override" reaches callbacks event as "name" key in kwargs.
+        """
+        default_name = serialized.get("name", serialized.get("id", ["<unknown>"])[-1])
+        return kwargs.get("name", default_name)
 
     def on_retriever_error(
         self,
@@ -230,14 +237,14 @@ class CallbackHandler(BaseCallbackHandler):
                 parent_run_id=parent_run_id,
                 tags=tags,
                 metadata=metadata,
-                kwargs=kwargs,
                 version=self.version,
+                **kwargs,
             )
 
             content = {
                 "id": self.next_span_id,
                 "trace_id": self.trace.id,
-                "name": serialized.get("name", serialized.get("id", ["<unknown>"])[-1]),
+                "name": self.get_langchain_run_name(serialized, **kwargs),
                 "metadata": self.__join_tags_and_metadata(tags, metadata),
                 "input": inputs,
                 "version": self.version,
@@ -272,7 +279,7 @@ class CallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ):
         try:
-            class_name = serialized.get("name", serialized.get("id", ["<unknown>"])[-1])
+            class_name = self.get_langchain_run_name(serialized, **kwargs)
 
             # on a new invocation, and not user provided root, we want to initialise a new trace
             # parent_run_id is None when we are at the root of a langchain execution
@@ -484,7 +491,7 @@ class CallbackHandler(BaseCallbackHandler):
 
             self.runs[run_id] = self.runs[parent_run_id].span(
                 id=self.next_span_id,
-                name=serialized.get("name", serialized.get("id", ["<unknown>"])[-1]),
+                name=self.get_langchain_run_name(serialized, **kwargs),
                 input=input_str,
                 metadata=meta,
                 version=self.version,
@@ -514,7 +521,7 @@ class CallbackHandler(BaseCallbackHandler):
 
             self.runs[run_id] = self.runs[parent_run_id].span(
                 id=self.next_span_id,
-                name=serialized.get("name", serialized.get("id", ["<unknown>"])[-1]),
+                name=self.get_langchain_run_name(serialized, **kwargs),
                 input=query,
                 metadata=self.__join_tags_and_metadata(tags, metadata),
                 version=self.version,
@@ -699,7 +706,7 @@ class CallbackHandler(BaseCallbackHandler):
                 )
 
             content = {
-                "name": serialized.get("name", serialized.get("id", ["<unknown>"])[-1]),
+                "name": self.get_langchain_run_name(serialized, **kwargs),
                 "input": prompts,
                 "metadata": self.__join_tags_and_metadata(tags, metadata),
                 "model": model_name,

--- a/langfuse/callback.py
+++ b/langfuse/callback.py
@@ -182,7 +182,7 @@ class CallbackHandler(BaseCallbackHandler):
         self.log.debug(
             f"on llm new token: run_id: {run_id} parent_run_id: {parent_run_id}"
         )
-    
+
     def get_langchain_run_name(self, serialized: Dict[str, Any], **kwargs: Any) -> str:
         """Langchain convention to change the display name of entities during tracing is "run_name" property.
         This "override" reaches callbacks event as "name" key in kwargs.

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -166,6 +166,7 @@ def test_callback_generated_from_trace_chat():
     assert langchain_generation_span.output is not None
     assert langchain_generation_span.output != ""
 
+
 def test_callback_generated_from_lcel_chain():
     api = get_api()
     langfuse = Langfuse(debug=False)
@@ -178,13 +179,14 @@ def test_callback_generated_from_lcel_chain():
 
     chain = prompt | model
 
-    chain.invoke({"topic": "ice cream"},
-                 config={
-                    "callbacks": [handler],
-                    "run_name": run_name_override,
-                }
+    chain.invoke(
+        {"topic": "ice cream"},
+        config={
+            "callbacks": [handler],
+            "run_name": run_name_override,
+        },
     )
-    
+
     langfuse.flush()
     trace_id = handler.get_trace_id()
     trace = api.trace.get(trace_id)
@@ -192,7 +194,6 @@ def test_callback_generated_from_lcel_chain():
     assert trace.name == run_name_override
 
 
-    
 def test_callback_generated_from_span_chain():
     api = get_api()
     langfuse = Langfuse(debug=False)

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -166,7 +166,33 @@ def test_callback_generated_from_trace_chat():
     assert langchain_generation_span.output is not None
     assert langchain_generation_span.output != ""
 
+def test_callback_generated_from_lcel_chain():
+    api = get_api()
+    langfuse = Langfuse(debug=False)
 
+    run_name_override = "This is a custom Run Name"
+    handler = CallbackHandler()
+
+    prompt = ChatPromptTemplate.from_template("tell me a short joke about {topic}")
+    model = ChatOpenAI(temperature=0)
+
+    chain = prompt | model
+
+    chain.invoke({"topic": "ice cream"},
+                 config={
+                    "callbacks": [handler],
+                    "run_name": run_name_override,
+                }
+    )
+    
+    langfuse.flush()
+    trace_id = handler.get_trace_id()
+    trace = api.trace.get(trace_id)
+
+    assert trace.name == run_name_override
+
+
+    
 def test_callback_generated_from_span_chain():
     api = get_api()
     langfuse = Langfuse(debug=False)


### PR DESCRIPTION
Langchain new LCEL runnables allow you to override the name of entities.
https://python.langchain.com/docs/expression_language/interface
![image](https://github.com/langfuse/langfuse-python/assets/1821407/feb0595b-db18-4489-8e2a-65190738835c)

Langfuse is not applying this override into traces.
THis changes take trace and spans names from the override variables by default and fallback to the class names, etc etc.