### PR TITLE
fix: support more types for JSON serialization

### DIFF
--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime
+from dataclasses import is_dataclass, asdict
 from json import JSONEncoder
 from typing import Any
+from uuid import UUID
 
 from langfuse.api.core import serialize_datetime
 
@@ -19,6 +21,12 @@ class EventSerializer(JSONEncoder):
         if isinstance(obj, (datetime)):
             # Timezone-awareness check
             return serialize_datetime(obj)
+        if is_dataclass(obj):
+            return asdict(obj)
+        if isinstance(obj, UUID):
+            return str(obj)
+        if isinstance(obj, bytes):
+            return obj.decode("utf-8")
         if isinstance(obj, (date)):
             return obj.isoformat()
         if isinstance(obj, BaseModel):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,8 +1,10 @@
 import builtins
+from dataclasses import dataclass
 import importlib
 import json
 from datetime import datetime, timezone, date
 from unittest.mock import patch
+import uuid
 
 import pytest
 from langchain.schema.messages import HumanMessage
@@ -97,3 +99,27 @@ def test_json_decoder_without_langchain_serializer_with_none():
     default = json.dumps(None)
     assert result == "null"
     assert result == default
+
+
+def test_data_class():
+    @dataclass
+    class InventoryItem:
+        """Class for keeping track of an item in inventory."""
+
+        name: str
+        unit_price: float
+        quantity_on_hand: int = 0
+
+    item = InventoryItem("widget", 3.0, 10)
+
+    result = json.dumps(item, cls=EventSerializer)
+
+    assert result == '{"name": "widget", "unit_price": 3.0, "quantity_on_hand": 10}'
+
+
+def test_data_uuid():
+    test_id = uuid.uuid4()
+
+    result = json.dumps(test_id, cls=EventSerializer)
+
+    assert result == f'"{str(test_id)}"'


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/948

For my case, it was a dataclass which I was returning as a chain output, and python default JSON serializer does not support dataclasses dumping.. See [StackOverflow Thread](https://stackoverflow.com/questions/51286748/make-the-python-json-encoder-support-pythons-new-dataclasses).

So, I have fixed that as per answer in the thread.

But, there are many more cases where it might fail later also.. So, I checked how LangSmith folks have done.. Here is the [source](https://github.com/langchain-ai/langsmith-sdk/blob/6ff1369f7c226e79782fbe51106d67fbe466218f/python/langsmith/client.py#L158).. Maybe we can take some more inspirations from there, and make the serializer more robust here...
