### PR TITLE
fix: session_id instead of sessionId on trace methods

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -421,6 +421,7 @@ class Langfuse(object):
         id: typing.Optional[str] = None,
         name: typing.Optional[str] = None,
         user_id: typing.Optional[str] = None,
+        session_id: typing.Optional[str] = None,
         version: typing.Optional[str] = None,
         input: typing.Optional[typing.Any] = None,
         output: typing.Optional[typing.Any] = None,
@@ -437,6 +438,8 @@ class Langfuse(object):
                 "id": new_id,
                 "name": name,
                 "userId": user_id,
+                "sessionId": session_id
+                or kwargs.get("sessionId", None),  # backward compatibility
                 "release": self.release,
                 "version": version,
                 "metadata": metadata,
@@ -1285,6 +1288,7 @@ class StatefulTraceClient(StatefulClient):
         *,
         name: typing.Optional[str] = None,
         user_id: typing.Optional[str] = None,
+        session_id: typing.Optional[str] = None,
         version: typing.Optional[str] = None,
         input: typing.Optional[typing.Any] = None,
         output: typing.Optional[typing.Any] = None,
@@ -1298,6 +1302,8 @@ class StatefulTraceClient(StatefulClient):
                 "id": self.id,
                 "name": name,
                 "userId": user_id,
+                "sessionId": session_id
+                or kwargs.get("sessionId", None),  # backward compatibility
                 "version": version,
                 "input": input,
                 "output": output,

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -573,7 +573,7 @@ def test_create_trace_and_generation():
     generationId = create_uuid()
 
     trace = langfuse.trace(
-        name=trace_name, input={"key": "value"}, session_id="test-session"
+        name=trace_name, input={"key": "value"}, session_id="test-session-id"
     )
     trace.generation(
         id=generationId,
@@ -591,7 +591,7 @@ def test_create_trace_and_generation():
     assert len(dbTrace.observations) == 1
     assert getTrace.name == trace_name
     assert len(getTrace.observations) == 1
-    assert getTrace.session_id == "test"
+    assert getTrace.session_id == "test-session-id"
 
     generation = getTrace.observations[0]
     assert generation.name == "generation"
@@ -604,14 +604,14 @@ def backwards_compatibility_sessionId():
     langfuse = Langfuse(debug=False)
     api = get_api()
 
-    trace = langfuse.trace(name="test", sessionId="test-session")
+    trace = langfuse.trace(name="test", sessionId="test-sessionId")
 
     langfuse.flush()
 
     trace = api.trace.get(trace.id)
 
     assert trace.name == "test"
-    assert trace.session_id == "test-session"
+    assert trace.session_id == "test-sessionId"
 
 
 def test_create_trace_with_manual_timestamp():

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -572,7 +572,9 @@ def test_create_trace_and_generation():
     trace_name = create_uuid()
     generationId = create_uuid()
 
-    trace = langfuse.trace(name=trace_name, input={"key": "value"}, sessionId="test")
+    trace = langfuse.trace(
+        name=trace_name, input={"key": "value"}, session_id="test-session"
+    )
     trace.generation(
         id=generationId,
         name="generation",
@@ -589,12 +591,27 @@ def test_create_trace_and_generation():
     assert len(dbTrace.observations) == 1
     assert getTrace.name == trace_name
     assert len(getTrace.observations) == 1
+    assert getTrace.session_id == "test"
 
     generation = getTrace.observations[0]
     assert generation.name == "generation"
     assert generation.trace_id == getTrace.id
     assert generation.start_time is not None
     assert getTrace.input == {"key": "value"}
+
+
+def backwards_compatibility_sessionId():
+    langfuse = Langfuse(debug=False)
+    api = get_api()
+
+    trace = langfuse.trace(name="test", sessionId="test-session")
+
+    langfuse.flush()
+
+    trace = api.trace.get(trace.id)
+
+    assert trace.name == "test"
+    assert trace.session_id == "test-session"
 
 
 def test_create_trace_with_manual_timestamp():


### PR DESCRIPTION
Non breaking, coalesce to sessionId if no session_id