### PR TITLE
langchain.callback supports ToolMessage, FunctionMessage

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -32,6 +32,8 @@ try:
         ChatMessage,
         HumanMessage,
         SystemMessage,
+        ToolMessage,
+        FunctionMessage
     )
 except ImportError:
     raise ModuleNotFoundError(
@@ -749,6 +751,10 @@ class LangchainCallbackHandler(
             message_dict = {"role": "assistant", "content": message.content}
         elif isinstance(message, SystemMessage):
             message_dict = {"role": "system", "content": message.content}
+        elif isinstance(message, ToolMessage):
+            message_dict = {"role": "tool", "content": message.content}
+        elif isinstance(message, FunctionMessage):
+            message_dict = {"role": "function", "content": message.content}
         elif isinstance(message, ChatMessage):
             message_dict = {"role": message.role, "content": message.content}
         else:


### PR DESCRIPTION
Correctly handle tool/function messages returned by Agent/Tool

Error example:
```
ERROR:langfuse:Got unknown type <class 'langchain_core.messages.tool.ToolMessage'>: content="..." additional_kwargs={'name': '...'} tool_call_id='call_b7LCGSeZNzcZZBoLJ6emDaio'

 Traceback (most recent call last):
   File "/opt/homebrew/Caskroom/miniconda/base/envs/py3.11/lib/python3.11/site-packages/langfuse/callback/langchain.py", line 369, in on_chat_model_start
     [self._create_message_dicts(m) for m in messages]
   File "/opt/homebrew/Caskroom/miniconda/base/envs/py3.11/lib/python3.11/site-packages/langfuse/callback/langchain.py", line 369, in <listcomp>
     [self._create_message_dicts(m) for m in messages]
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/homebrew/Caskroom/miniconda/base/envs/py3.11/lib/python3.11/site-packages/langfuse/callback/langchain.py", line 763, in _create_message_dicts
     return [self._convert_message_to_dict(m) for m in messages]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/homebrew/Caskroom/miniconda/base/envs/py3.11/lib/python3.11/site-packages/langfuse/callback/langchain.py", line 763, in <listcomp>
     return [self._convert_message_to_dict(m) for m in messages]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/homebrew/Caskroom/miniconda/base/envs/py3.11/lib/python3.11/site-packages/langfuse/callback/langchain.py", line 751, in _convert_message_to_dict
     raise ValueError(f"Got unknown type: {message}")
```
