### PR TITLE
ci: check availability of packages

### DIFF
--- a/.github/workflows/availability-partner-packages.yml
+++ b/.github/workflows/availability-partner-packages.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 4.0]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/availability-partner-packages.yml
+++ b/.github/workflows/availability-partner-packages.yml
@@ -15,7 +15,6 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/availability-partner-packages.yml
+++ b/.github/workflows/availability-partner-packages.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 * * * *"
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/availability-partner-packages.yml
+++ b/.github/workflows/availability-partner-packages.yml
@@ -1,0 +1,24 @@
+name: Availability/compatibility of partner packages
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 4.0]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies using pip
+        run: |
+          pip install llama-index-callbacks-langfuse langfuse

--- a/.github/workflows/package-availability-check.yml
+++ b/.github/workflows/package-availability-check.yml
@@ -2,7 +2,7 @@ name: Check availability of packages
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "*/30 * * * *"
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/package-availability-check.yml
+++ b/.github/workflows/package-availability-check.yml
@@ -1,4 +1,4 @@
-name: Availability/compatibility of partner packages
+name: Check availability of packages
 
 on:
   schedule:


### PR DESCRIPTION
Adding ci workflow to test availability of packages, especially as partners might change how they deploy our integrations