### PR TITLE
Fix Error: TypeError: Object of type object is not JSON serializable

### DIFF
--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -27,6 +27,10 @@ class EventSerializer(JSONEncoder):
         if type(obj).__name__ == "StreamingAgentChatResponse":
             return str(obj)
 
+        # In case the Object type is `object`
+        if isinstance(obj, object):
+            return str(obj)
+
         if is_dataclass(obj):
             return asdict(obj)
         if isinstance(obj, UUID):


### PR DESCRIPTION
Make json dump more robust. Support object type.
Fix the error like this, which occur in using langraph.
```
  File "/Users/huohuarong/.pyenv/versions/3.11.2/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           │           └ {'id': 'd4b690a2-78b9-4bc3-bda0-98e5e6c62366', 'type': 'span-update', 'body': {'output': <object object at 0x120809540>, 'id'...
           └ <_json.Encoder object at 0x1253fa080>
  File "/Users/huohuarong/llm/doctorgpt/.venv/lib/python3.11/site-packages/langfuse/serializer.py", line 55, in default
    return JSONEncoder.default(self, obj)
           │           │       │     └ <object object at 0x120809540>
           │           │       └ <langfuse.serializer.EventSerializer object at 0x1253b3050>
           │           └ <function JSONEncoder.default at 0x101e6d580>
           └ <class 'json.encoder.JSONEncoder'>
  File "/Users/huohuarong/.pyenv/versions/3.11.2/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '

TypeError: Object of type object is not JSON serializable
```