### PR TITLE
Replacing root logging calls with langfuse logger

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -2234,6 +2234,8 @@ class DatasetItemClient:
             run_name (str): The name of the dataset run.
         """
         observation_id = None
+        
+        log = logging.getLogger("langfuse")
 
         if isinstance(observation, StatefulClient):
             # flush the queue before creating the dataset run item
@@ -2248,7 +2250,7 @@ class DatasetItemClient:
                 "observation parameter must be either a StatefulClient or a string"
             )
 
-        logging.debug(
+        log.debug(
             f"Creating dataset run item: {run_name} {self.id} {observation_id}"
         )
         self.langfuse.client.dataset_run_items.create(

--- a/langfuse/request.py
+++ b/langfuse/request.py
@@ -50,8 +50,8 @@ class LangfuseClient:
 
     def batch_post(self, **kwargs) -> httpx.Response:
         """Post the `kwargs` to the batch API endpoint for events"""
-
-        logging.debug("uploading data: %s", kwargs)
+        log = logging.getLogger("langfuse")
+        log.debug("uploading data: %s", kwargs)
         res = self.post(**kwargs)
         return self._process_response(
             res, success_message="data uploaded successfully", return_json=False


### PR DESCRIPTION
I found two instances where the root logger from logging was being called, hence making impossible to disable logging from Langfuse externally (ie. in a script using the langfuse package).