### PR TITLE
fix(prompt): compile None value to empty string

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -106,7 +106,11 @@ class BasePromptClient(ABC):
 
             # Append the variable value
             if variable_name in kwargs:
-                result_list.append(str(kwargs[variable_name]))
+                result_list.append(
+                    str(kwargs[variable_name])
+                    if kwargs[variable_name] is not None
+                    else ""
+                )
             else:
                 result_list.append(content[var_start : var_end + len(closing)])
 

--- a/tests/test_prompt_compilation.py
+++ b/tests/test_prompt_compilation.py
@@ -50,6 +50,13 @@ def test_missing_variable():
     assert BasePromptClient._compile_template_string(template) == expected
 
 
+def test_none_variable():
+    template = "Hello, {{name}}!"
+    expected = "Hello, !"
+
+    assert BasePromptClient._compile_template_string(template, name=None) == expected
+
+
 def test_strip_whitespace():
     template = "Hello, {{    name }}!"
     expected = "Hello, John!"


### PR DESCRIPTION
Thanks to https://github.com/langfuse/langfuse-python/pull/543 I can now get rid of my own variable interpolation system that circumvented HTML escaping issues :partying_face:

However, one behavior that I think we should preserve is compiling `None` values to `""` instead of `"None"` (as chevron did).