### PR TITLE
fix(prompt): allow "content" prompt var again

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -76,7 +76,8 @@ class BasePromptClient(ABC):
         return re.sub(r"\{\{(.*?)\}\}", r"{\g<1>}", content)
 
     @staticmethod
-    def _compile_template_string(content: str, **kwargs) -> str:
+    def _compile_template_string(*args, **kwargs) -> str:
+        content = args[0]
         opening = "{{"
         closing = "}}"
 

--- a/tests/test_prompt_compilation.py
+++ b/tests/test_prompt_compilation.py
@@ -169,3 +169,13 @@ def test_unescaped_JSON_variable_value():
 )
 def test_various_templates(template, kwargs, expected):
     assert BasePromptClient._compile_template_string(template, **kwargs) == expected
+
+
+def test_content_var():
+    template = "Hello, {{content}}!"
+    expected = "Hello, Thomas!"
+
+    assert (
+        BasePromptClient._compile_template_string(template, content="Thomas")
+        == expected
+    )


### PR DESCRIPTION
One more issue after https://github.com/langfuse/langfuse-python/pull/543 is that having an existing `content` prompt var doesn't work anymore:
```
TypeError: BasePromptClient._compile_template_string() got multiple values for argument 'content'
```
Let's reallow it :pray: