### PR TITLE
fix: allow 'content' as prompt var

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -106,7 +106,11 @@ class BasePromptClient(ABC):
 
             # Append the variable value
             if variable_name in kwargs:
-                result_list.append(str(kwargs[variable_name]))
+                result_list.append(
+                    str(kwargs[variable_name])
+                    if kwargs[variable_name] is not None
+                    else ""
+                )
             else:
                 result_list.append(content[var_start : var_end + len(closing)])
 

--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -76,7 +76,7 @@ class BasePromptClient(ABC):
         return re.sub(r"\{\{(.*?)\}\}", r"{\g<1>}", content)
 
     @staticmethod
-    def _compile_template_string(content: str, **kwargs) -> str:
+    def _compile_template_string(content: str, data: Dict[str, Any] = {}) -> str:
         opening = "{{"
         closing = "}}"
 
@@ -105,11 +105,9 @@ class BasePromptClient(ABC):
             variable_name = content[var_start + len(opening) : var_end].strip()
 
             # Append the variable value
-            if variable_name in kwargs:
+            if variable_name in data:
                 result_list.append(
-                    str(kwargs[variable_name])
-                    if kwargs[variable_name] is not None
-                    else ""
+                    str(data[variable_name]) if data[variable_name] is not None else ""
                 )
             else:
                 result_list.append(content[var_start : var_end + len(closing)])
@@ -125,7 +123,7 @@ class TextPromptClient(BasePromptClient):
         self.prompt = prompt.prompt
 
     def compile(self, **kwargs) -> str:
-        return self._compile_template_string(self.prompt, **kwargs)
+        return self._compile_template_string(self.prompt, kwargs)
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):
@@ -158,9 +156,7 @@ class ChatPromptClient(BasePromptClient):
     def compile(self, **kwargs) -> List[ChatMessage]:
         return [
             ChatMessage(
-                content=self._compile_template_string(
-                    chat_message["content"], **kwargs
-                ),
+                content=self._compile_template_string(chat_message["content"], kwargs),
                 role=chat_message["role"],
             )
             for chat_message in self.prompt

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -133,6 +133,27 @@ def test_compiling_prompt_without_character_escaping():
     assert compiled == 'Hello, {"key": "value"}'
 
 
+def test_compiling_prompt_with_content_as_variable_name():
+    langfuse = Langfuse()
+
+    prompt_client = langfuse.create_prompt(
+        name="test",
+        prompt="Hello, {{ content }}!",
+        is_active=True,
+    )
+
+    second_prompt_client = langfuse.get_prompt("test")
+
+    assert prompt_client.name == second_prompt_client.name
+    assert prompt_client.version == second_prompt_client.version
+    assert prompt_client.prompt == second_prompt_client.prompt
+
+    compiled = second_prompt_client.compile(content="Jane")
+    print(compiled)
+
+    assert compiled == "Hello, Jane!"
+
+
 def test_create_prompt_with_null_config():
     langfuse = Langfuse(debug=False)
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -54,7 +54,6 @@ def test_create_chat_prompt():
     assert prompt_client.version == second_prompt_client.version
     assert prompt_client.prompt == second_prompt_client.prompt
     assert prompt_client.config == second_prompt_client.config
-    print(prompt_client.config, second_prompt_client.config)
     assert prompt_client.config == {}
 
 
@@ -149,7 +148,6 @@ def test_compiling_prompt_with_content_as_variable_name():
     assert prompt_client.prompt == second_prompt_client.prompt
 
     compiled = second_prompt_client.compile(content="Jane")
-    print(compiled)
 
     assert compiled == "Hello, Jane!"
 

--- a/tests/test_prompt_compilation.py
+++ b/tests/test_prompt_compilation.py
@@ -7,7 +7,10 @@ def test_basic_replacement():
     template = "Hello, {{ name }}!"
     expected = "Hello, John!"
 
-    assert BasePromptClient._compile_template_string(template, name="John") == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"name": "John"})
+        == expected
+    )
 
 
 def test_multiple_replacements():
@@ -16,7 +19,7 @@ def test_multiple_replacements():
 
     assert (
         BasePromptClient._compile_template_string(
-            template, greeting="Hello", name="John", balance="$100"
+            template, {"greeting": "Hello", "name": "John", "balance": "$100"}
         )
         == expected
     )
@@ -29,18 +32,34 @@ def test_no_replacements():
     assert BasePromptClient._compile_template_string(template) == expected
 
 
+def test_content_as_variable_name():
+    template = "This is a {{content}}."
+    expected = "This is a dog."
+
+    assert (
+        BasePromptClient._compile_template_string(template, {"content": "dog"})
+        == expected
+    )
+
+
 def test_unmatched_opening_tag():
     template = "Hello, {{name! Your balance is $100."
     expected = "Hello, {{name! Your balance is $100."
 
-    assert BasePromptClient._compile_template_string(template, name="John") == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"name": "John"})
+        == expected
+    )
 
 
 def test_unmatched_closing_tag():
     template = "Hello, {{name}}! Your balance is $100}}"
     expected = "Hello, John! Your balance is $100}}"
 
-    assert BasePromptClient._compile_template_string(template, name="John") == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"name": "John"})
+        == expected
+    )
 
 
 def test_missing_variable():
@@ -54,14 +73,19 @@ def test_none_variable():
     template = "Hello, {{name}}!"
     expected = "Hello, !"
 
-    assert BasePromptClient._compile_template_string(template, name=None) == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"name": None}) == expected
+    )
 
 
 def test_strip_whitespace():
     template = "Hello, {{    name }}!"
     expected = "Hello, John!"
 
-    assert BasePromptClient._compile_template_string(template, name="John") == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"name": "John"})
+        == expected
+    )
 
 
 def test_special_characters():
@@ -69,7 +93,8 @@ def test_special_characters():
     expected = "Symbols: @$%^&*."
 
     assert (
-        BasePromptClient._compile_template_string(template, symbol="@$%^&*") == expected
+        BasePromptClient._compile_template_string(template, {"symbol": "@$%^&*"})
+        == expected
     )
 
 
@@ -77,21 +102,30 @@ def test_multiple_templates_one_var():
     template = "{{a}} + {{a}} = {{b}}"
     expected = "1 + 1 = 2"
 
-    assert BasePromptClient._compile_template_string(template, a=1, b=2) == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"a": 1, "b": 2})
+        == expected
+    )
 
 
 def test_unused_variable():
     template = "{{a}} + {{a}}"
     expected = "1 + 1"
 
-    assert BasePromptClient._compile_template_string(template, a=1, b=2) == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"a": 1, "b": 2})
+        == expected
+    )
 
 
 def test_single_curly_braces():
     template = "{{a}} + {a} = {{b}"
     expected = "1 + {a} = {{b}"
 
-    assert BasePromptClient._compile_template_string(template, a=1, b=2) == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"a": 1, "b": 2})
+        == expected
+    )
 
 
 def test_complex_json():
@@ -104,14 +138,17 @@ def test_complex_json():
     "key2": "val2",
     }}"""
 
-    assert BasePromptClient._compile_template_string(template, a=1, b=2) == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"a": 1, "b": 2})
+        == expected
+    )
 
 
 def test_replacement_with_empty_string():
     template = "Hello, {{name}}!"
     expected = "Hello, !"
 
-    assert BasePromptClient._compile_template_string(template, name="") == expected
+    assert BasePromptClient._compile_template_string(template, {"name": ""}) == expected
 
 
 def test_variable_case_sensitivity():
@@ -119,7 +156,9 @@ def test_variable_case_sensitivity():
     expected = "John != john"
 
     assert (
-        BasePromptClient._compile_template_string(template, Name="John", name="john")
+        BasePromptClient._compile_template_string(
+            template, {"Name": "John", "name": "john"}
+        )
         == expected
     )
 
@@ -128,7 +167,10 @@ def test_start_with_closing_braces():
     template = "}}"
     expected = "}}"
 
-    assert BasePromptClient._compile_template_string(template, name="john") == expected
+    assert (
+        BasePromptClient._compile_template_string(template, {"name": "john"})
+        == expected
+    )
 
 
 def test_unescaped_JSON_variable_value():
@@ -162,17 +204,19 @@ def test_unescaped_JSON_variable_value():
   }
 }"""
 
-    compiled = BasePromptClient._compile_template_string(template, some_json=some_json)
+    compiled = BasePromptClient._compile_template_string(
+        template, {"some_json": some_json}
+    )
     assert compiled == some_json
 
 
 @pytest.mark.parametrize(
-    "template,kwargs,expected",
+    "template,data,expected",
     [
         ("{{a}} + {{b}} = {{result}}", {"a": 1, "b": 2, "result": 3}, "1 + 2 = 3"),
         ("{{x}}, {{y}}", {"x": "X", "y": "Y"}, "X, Y"),
         ("No variables", {}, "No variables"),
     ],
 )
-def test_various_templates(template, kwargs, expected):
-    assert BasePromptClient._compile_template_string(template, **kwargs) == expected
+def test_various_templates(template, data, expected):
+    assert BasePromptClient._compile_template_string(template, data) == expected

--- a/tests/test_prompt_compilation.py
+++ b/tests/test_prompt_compilation.py
@@ -50,6 +50,13 @@ def test_missing_variable():
     assert BasePromptClient._compile_template_string(template) == expected
 
 
+def test_none_variable():
+    template = "Hello, {{name}}!"
+    expected = "Hello, !"
+
+    assert BasePromptClient._compile_template_string(template, name=None) == expected
+
+
 def test_strip_whitespace():
     template = "Hello, {{    name }}!"
     expected = "Hello, John!"


### PR DESCRIPTION
- Allow `content` as prompt var again
- If variable is set to `None` replace with empty string "" instead of "None"