### PR TITLE
fix: issue #599 where `meta` can be `None` (#598)

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -442,6 +442,9 @@ class LangchainCallbackHandler(
                 raise Exception("parent run not found")
             meta = self.__join_tags_and_metadata(tags, metadata)
 
+            if not meta:
+                meta = {}
+
             meta.update(
                 {key: value for key, value in kwargs.items() if value is not None}
             )


### PR DESCRIPTION
Bugfix: to fix issue #1775 where `meta` can be `None`

`meta` can be `None`, see https://github.com/langfuse/langfuse-python/blob/main/langfuse/callback/langchain.py#L722, but `meta.update()` at https://github.com/langfuse/langfuse-python/blob/main/langfuse/callback/langchain.py#L445 would fail on `None`