### PR TITLE
fix(decorators): handle generators as decorated function inputs

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -651,11 +651,16 @@ def test_disabled_io_capture():
     assert trace_data.observations[0].output == "manually set output"
 
 
-def test_decorated_instance_methods():
-    mock_name = "test_decorated_instance_methods"
+def test_decorated_class_and_instance_methods():
+    mock_name = "test_decorated_class_and_instance_methods"
     mock_trace_id = create_uuid()
 
     class TestClass:
+        @classmethod
+        @observe()
+        def class_method(cls, *args, **kwargs):
+            return "class_method"
+
         @observe(as_type="generation")
         def level_3_function(self):
             langfuse_context.update_current_observation(metadata=mock_metadata)
@@ -674,6 +679,8 @@ def test_decorated_instance_methods():
 
         @observe()
         def level_2_function(self):
+            TestClass.class_method()
+
             self.level_3_function()
             langfuse_context.update_current_observation(metadata=mock_metadata)
 
@@ -697,7 +704,7 @@ def test_decorated_instance_methods():
 
     trace_data = get_api().trace.get(mock_trace_id)
     assert (
-        len(trace_data.observations) == 2
+        len(trace_data.observations) == 3
     )  # Top-most function is trace, so it's not an observations
 
     assert trace_data.input == {"args": list(mock_args), "kwargs": mock_kwargs}
@@ -716,7 +723,11 @@ def test_decorated_instance_methods():
     assert len(adjacencies) == 2  # Only trace and one observation have children
 
     level_2_observation = adjacencies[mock_trace_id][0]
-    level_3_observation = adjacencies[level_2_observation.id][0]
+    level_3_observation = adjacencies[level_2_observation.id][1]
+    class_method_observation = adjacencies[level_2_observation.id][0]
+
+    assert class_method_observation.input == {"args": [], "kwargs": {}}
+    assert class_method_observation.output == "class_method"
 
     assert level_2_observation.metadata == mock_metadata
     assert level_3_observation.metadata == mock_deep_metadata


### PR DESCRIPTION
- Gracefully handle generators as function args / kwargs for an `@observe` decorated function to log the type name of the passed generator instead of serializing it.
- Fixes serialization of function outputs in decorator implementation