### PR TITLE
Update LlamaCpp in extract_model.py

### DIFF
--- a/langfuse/extract_model.py
+++ b/langfuse/extract_model.py
@@ -31,7 +31,7 @@ def _extract_model_name(
         ("HuggingFacePipeline", ["invocation_params", "model_id"], "kwargs"),
         ("BedrockChat", ["kwargs", "model_id"], "serialized"),
         ("Bedrock", ["kwargs", "model_id"], "serialized"),
-        ("LlamaCpp", ["invocation_params", "model_path"], "serialized"),
+        ("LlamaCpp", ["invocation_params", "model_path"], "kwargs"),
     ]
 
     for model_name, keys, select_from in models_by_id:


### PR DESCRIPTION
update `select_from` for `LlamaCpp` in `models_by_id` list in `extract_models.py`

`["invocation_params", "model_path"]` are present in `kwargs` for `LlamaCpp` now the `current_obj` will succefully return the correct `model_path` for LlamaCpp