### PR TITLE
feat(core): adds httpx client and 'enabled'-switch for Langfuse

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -1,3 +1,4 @@
+import httpx
 import logging
 import typing
 
@@ -74,6 +75,8 @@ class LangchainCallbackHandler(
         flush_interval: Optional[int] = None,
         max_retries: Optional[int] = None,
         timeout: Optional[int] = None,
+        enabled: Optional[bool] = None,
+        httpx_client: Optional[httpx.Client] = None,
         sdk_integration: Optional[str] = None,
     ) -> None:
         LangfuseBaseCallbackHandler.__init__(
@@ -96,6 +99,8 @@ class LangchainCallbackHandler(
             flush_interval=flush_interval,
             max_retries=max_retries,
             timeout=timeout,
+            enabled=enabled,
+            httpx_client=httpx_client,
             sdk_integration=sdk_integration or "langchain",
         )
 
@@ -863,7 +868,7 @@ def _extract_raw_esponse(last_response):
     # We return the text of the response if not empty
     if last_response.text is not None and last_response.text.strip() != "":
         return last_response.text.strip()
-    elif hasattr(last_response, 'message'):
+    elif hasattr(last_response, "message"):
         # Additional kwargs contains the response in case of tool usage
         return last_response.message.additional_kwargs
     else:

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -106,6 +106,7 @@ class Langfuse(object):
         timeout: int = 20,  # seconds
         sdk_integration: Optional[str] = "default",
         httpx_client: Optional[httpx.Client] = None,
+        enabled: Optional[bool] = True,
     ):
         """Initialize the Langfuse client.
 
@@ -122,6 +123,7 @@ class Langfuse(object):
             timeout: Timeout of API requests in seconds.
             httpx_client: Pass your own httpx client for more customizability of requests.
             sdk_integration: Used by intgerations that wrap the Langfuse SDK to add context for debugging and support. Not to be used directly.
+            enabled: Enables or disables the Langfuse client. If disabled, all observability calls to the backend will be no-ops.
 
         Raises:
             ValueError: If public_key or secret_key are not set and not found in environment variables.
@@ -140,6 +142,11 @@ class Langfuse(object):
             langfuse = Langfuse()
             ```
         """
+        if not enabled:
+            self.log.warning(
+                "Langfuse client is disabled. No observability data will be sent."
+            )
+
         set_debug = debug if debug else (os.getenv("LANGFUSE_DEBUG", "False") == "True")
 
         if set_debug is True:
@@ -205,6 +212,7 @@ class Langfuse(object):
             "sdk_name": "python",
             "sdk_version": version,
             "sdk_integration": sdk_integration,
+            "enabled": enabled,
         }
 
         self.task_manager = TaskManager(**args)

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -154,13 +154,13 @@ class Langfuse(object):
         elif not public_key:
             self.enabled = False
             self.log.warning(
-                "Langfuse client is disabled since no public_key was provided as a parameter or environment variable 'LANGFUSE_PUBLIC_KEY'."
+                "Langfuse client is disabled since no public_key was provided as a parameter or environment variable 'LANGFUSE_PUBLIC_KEY'. See our docs: https://langfuse.com/docs/sdk/python/low-level-sdk#initialize-client"
             )
 
         elif not secret_key:
             self.enabled = False
             self.log.warning(
-                "Langfuse client is disabled since no secret_key was provided as a parameter or environment variable 'LANGFUSE_SECRET_KEY'."
+                "Langfuse client is disabled since no secret_key was provided as a parameter or environment variable 'LANGFUSE_SECRET_KEY'. See our docs: https://langfuse.com/docs/sdk/python/low-level-sdk#initialize-client"
             )
 
         set_debug = debug if debug else (os.getenv("LANGFUSE_DEBUG", "False") == "True")

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -143,6 +143,7 @@ class Langfuse(object):
             ```
         """
         if not enabled:
+            self.enabled = False
             self.log.warning(
                 "Langfuse client is disabled. No observability data will be sent."
             )
@@ -170,15 +171,15 @@ class Langfuse(object):
         )
 
         if not public_key:
-            self.log.warning("public_key is not set.")
-            raise ValueError(
-                "public_key is required, set as a parameter or environment variable 'LANGFUSE_PUBLIC_KEY'"
+            self.enabled = False
+            self.log.warning(
+                "Langfuse client is disabled since no public_key was provided as a parameter or environment variable 'LANGFUSE_PUBLIC_KEY'."
             )
 
         if not secret_key:
-            self.log.warning("secret_key is not set.")
-            raise ValueError(
-                "secret_key is required, set as parameter or environment variable 'LANGFUSE_SECRET_KEY'"
+            self.enabled = False
+            self.log.warning(
+                "Langfuse client is disabled since no secret_key was provided as a parameter or environment variable 'LANGFUSE_SECRET_KEY'."
             )
 
         self.httpx_client = httpx_client or httpx.Client(timeout=timeout)
@@ -212,7 +213,7 @@ class Langfuse(object):
             "sdk_name": "python",
             "sdk_version": version,
             "sdk_integration": sdk_integration,
-            "enabled": enabled,
+            "enabled": self.enabled,
         }
 
         self.task_manager = TaskManager(**args)

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -143,9 +143,24 @@ class Langfuse(object):
             ```
         """
         self.enabled = enabled
+        public_key = public_key or os.environ.get("LANGFUSE_PUBLIC_KEY")
+        secret_key = secret_key or os.environ.get("LANGFUSE_SECRET_KEY")
+
         if not self.enabled:
             self.log.warning(
                 "Langfuse client is disabled. No observability data will be sent."
+            )
+
+        elif not public_key:
+            self.enabled = False
+            self.log.warning(
+                "Langfuse client is disabled since no public_key was provided as a parameter or environment variable 'LANGFUSE_PUBLIC_KEY'."
+            )
+
+        elif not secret_key:
+            self.enabled = False
+            self.log.warning(
+                "Langfuse client is disabled since no secret_key was provided as a parameter or environment variable 'LANGFUSE_SECRET_KEY'."
             )
 
         set_debug = debug if debug else (os.getenv("LANGFUSE_DEBUG", "False") == "True")
@@ -162,25 +177,11 @@ class Langfuse(object):
             self.log.setLevel(logging.WARNING)
             clean_logger()
 
-        public_key = public_key or os.environ.get("LANGFUSE_PUBLIC_KEY")
-        secret_key = secret_key or os.environ.get("LANGFUSE_SECRET_KEY")
         self.base_url = (
             host
             if host
             else os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com")
         )
-
-        if not public_key:
-            self.enabled = False
-            self.log.warning(
-                "Langfuse client is disabled since no public_key was provided as a parameter or environment variable 'LANGFUSE_PUBLIC_KEY'."
-            )
-
-        if not secret_key:
-            self.enabled = False
-            self.log.warning(
-                "Langfuse client is disabled since no secret_key was provided as a parameter or environment variable 'LANGFUSE_SECRET_KEY'."
-            )
 
         self.httpx_client = httpx_client or httpx.Client(timeout=timeout)
 

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -142,8 +142,8 @@ class Langfuse(object):
             langfuse = Langfuse()
             ```
         """
-        if not enabled:
-            self.enabled = False
+        self.enabled = enabled
+        if not self.enabled:
             self.log.warning(
                 "Langfuse client is disabled. No observability data will be sent."
             )

--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from contextvars import ContextVar
 from datetime import datetime
 from functools import wraps
+import httpx
 import inspect
 import json
 import logging
@@ -898,6 +899,58 @@ class LangfuseDecorator:
             langfuse.flush()
         else:
             self._log.warn("No langfuse object found in the current context")
+
+    def configure(
+        self,
+        *,
+        public_key: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        host: Optional[str] = None,
+        release: Optional[str] = None,
+        debug: Optional[bool] = None,
+        threads: Optional[int] = None,
+        flush_at: Optional[int] = None,
+        flush_interval: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        timeout: Optional[int] = None,
+        httpx_client: Optional[httpx.Client] = None,
+        enabled: Optional[bool] = None,
+    ):
+        """Configure the Langfuse client.
+
+        If called, this method must be called before any other langfuse_context or observe decorated function to configure the Langfuse client with the necessary credentials and settings.
+
+        Args:
+            public_key: Public API key of Langfuse project. Can be set via `LANGFUSE_PUBLIC_KEY` environment variable.
+            secret_key: Secret API key of Langfuse project. Can be set via `LANGFUSE_SECRET_KEY` environment variable.
+            host: Host of Langfuse API. Can be set via `LANGFUSE_HOST` environment variable. Defaults to `https://cloud.langfuse.com`.
+            release: Release number/hash of the application to provide analytics grouped by release. Can be set via `LANGFUSE_RELEASE` environment variable.
+            debug: Enables debug mode for more verbose logging. Can be set via `LANGFUSE_DEBUG` environment variable.
+            threads: Number of consumer threads to execute network requests. Helps scaling the SDK for high load. Only increase this if you run into scaling issues.
+            flush_at: Max batch size that's sent to the API.
+            flush_interval: Max delay until a new batch is sent to the API.
+            max_retries: Max number of retries in case of API/network errors.
+            timeout: Timeout of API requests in seconds. Default is 20 seconds.
+            httpx_client: Pass your own httpx client for more customizability of requests.
+            enabled: Enables or disables the Langfuse client. Defaults to True. If disabled, no observability data will be sent to Langfuse. If data is requested while disabled, an error will be raised.
+        """
+        langfuse_singleton = LangfuseSingleton()
+        langfuse_singleton.reset()
+
+        langfuse_singleton.get(
+            public_key=public_key,
+            secret_key=secret_key,
+            host=host,
+            release=release,
+            debug=debug,
+            threads=threads,
+            flush_at=flush_at,
+            flush_interval=flush_interval,
+            max_retries=max_retries,
+            timeout=timeout,
+            httpx_client=httpx_client,
+            enabled=enabled,
+        )
 
     def _get_langfuse(self) -> Langfuse:
         return LangfuseSingleton().get()

--- a/langfuse/llama_index/llama_index.py
+++ b/langfuse/llama_index/llama_index.py
@@ -3,6 +3,7 @@ from contextvars import ContextVar
 from typing import Any, Dict, List, Optional, Union, Tuple, Callable, Generator
 from uuid import uuid4
 import logging
+import httpx
 
 from langfuse.client import (
     StatefulSpanClient,
@@ -81,6 +82,8 @@ class LlamaIndexCallbackHandler(
         event_starts_to_ignore: Optional[List[CBEventType]] = None,
         event_ends_to_ignore: Optional[List[CBEventType]] = None,
         tokenizer: Optional[Callable[[str], list]] = None,
+        enabled: Optional[bool] = None,
+        httpx_client: Optional[httpx.Client] = None,
         sdk_integration: Optional[str] = None,
     ) -> None:
         LlamaIndexBaseCallbackHandler.__init__(
@@ -106,6 +109,8 @@ class LlamaIndexCallbackHandler(
             flush_interval=flush_interval,
             max_retries=max_retries,
             timeout=timeout,
+            enabled=enabled,
+            httpx_client=httpx_client,
             sdk_integration=sdk_integration or "llama-index_callback",
         )
 

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -589,6 +589,7 @@ class OpenAILangfuse:
             secret_key=openai.langfuse_secret_key,
             host=openai.langfuse_host,
             debug=openai.langfuse_debug,
+            enabled=openai.langfuse_enabled,
             sdk_integration="openai",
         )
 
@@ -613,6 +614,7 @@ class OpenAILangfuse:
         setattr(openai, "langfuse_secret_key", None)
         setattr(openai, "langfuse_host", None)
         setattr(openai, "langfuse_debug", None)
+        setattr(openai, "langfuse_enabled", True)
         setattr(openai, "flush_langfuse", self.flush)
 
 

--- a/langfuse/task_manager.py
+++ b/langfuse/task_manager.py
@@ -190,6 +190,7 @@ class Consumer(threading.Thread):
 class TaskManager(object):
     _log = logging.getLogger("langfuse")
     _consumers: List[Consumer]
+    _enabled: bool
     _threads: int
     _max_task_queue_size: int
     _queue: Queue
@@ -213,6 +214,7 @@ class TaskManager(object):
         sdk_name: str,
         sdk_version: str,
         sdk_integration: str,
+        enabled: bool = True,
         max_task_queue_size: int = 100_000,
     ):
         self._max_task_queue_size = max_task_queue_size
@@ -227,6 +229,7 @@ class TaskManager(object):
         self._sdk_name = sdk_name
         self._sdk_version = sdk_version
         self._sdk_integration = sdk_integration
+        self._enabled = enabled
 
         self.init_resources()
 
@@ -251,6 +254,9 @@ class TaskManager(object):
             self._consumers.append(consumer)
 
     def add_task(self, event: dict):
+        if not self._enabled:
+            return
+
         try:
             json.dumps(event, cls=EventSerializer)
             event["timestamp"] = datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/langfuse/utils/base_callback_handler.py
+++ b/langfuse/utils/base_callback_handler.py
@@ -1,4 +1,5 @@
 from typing import Optional, Union, List, Any
+import httpx
 import logging
 import os
 
@@ -31,6 +32,8 @@ class LangfuseBaseCallbackHandler:
         flush_interval: Optional[int] = None,
         max_retries: Optional[int] = None,
         timeout: Optional[int] = None,
+        enabled: Optional[bool] = None,
+        httpx_client: Optional[httpx.Client] = None,
         sdk_integration: str,
     ) -> None:
         self.version = version
@@ -86,6 +89,10 @@ class LangfuseBaseCallbackHandler:
                 args["max_retries"] = max_retries
             if timeout is not None:
                 args["timeout"] = timeout
+            if enabled is not None:
+                args["enabled"] = enabled
+            if httpx_client is not None:
+                args["httpx_client"] = httpx_client
 
             args["sdk_integration"] = sdk_integration
 

--- a/langfuse/utils/base_callback_handler.py
+++ b/langfuse/utils/base_callback_handler.py
@@ -69,44 +69,35 @@ class LangfuseBaseCallbackHandler:
             )
             self._task_manager = stateful_client.task_manager
 
-        elif prio_public_key and prio_secret_key:
-            args = {
-                "public_key": prio_public_key,
-                "secret_key": prio_secret_key,
-                "host": prio_host,
-                "debug": debug,
-            }
+        args = {
+            "public_key": prio_public_key,
+            "secret_key": prio_secret_key,
+            "host": prio_host,
+            "debug": debug,
+        }
 
-            if release is not None:
-                args["release"] = release
-            if threads is not None:
-                args["threads"] = threads
-            if flush_at is not None:
-                args["flush_at"] = flush_at
-            if flush_interval is not None:
-                args["flush_interval"] = flush_interval
-            if max_retries is not None:
-                args["max_retries"] = max_retries
-            if timeout is not None:
-                args["timeout"] = timeout
-            if enabled is not None:
-                args["enabled"] = enabled
-            if httpx_client is not None:
-                args["httpx_client"] = httpx_client
+        if release is not None:
+            args["release"] = release
+        if threads is not None:
+            args["threads"] = threads
+        if flush_at is not None:
+            args["flush_at"] = flush_at
+        if flush_interval is not None:
+            args["flush_interval"] = flush_interval
+        if max_retries is not None:
+            args["max_retries"] = max_retries
+        if timeout is not None:
+            args["timeout"] = timeout
+        if enabled is not None:
+            args["enabled"] = enabled
+        if httpx_client is not None:
+            args["httpx_client"] = httpx_client
 
-            args["sdk_integration"] = sdk_integration
+        args["sdk_integration"] = sdk_integration
 
-            self.langfuse = Langfuse(**args)
-            self.trace: Optional[StatefulTraceClient] = None
-            self._task_manager = self.langfuse.task_manager
-
-        else:
-            self.log.error(
-                "Either provide a stateful langfuse object or both public_key and secret_key."
-            )
-            raise ValueError(
-                "Either provide a stateful langfuse object or both public_key and secret_key."
-            )
+        self.langfuse = Langfuse(**args)
+        self.trace: Optional[StatefulTraceClient] = None
+        self._task_manager = self.langfuse.task_manager
 
     def get_trace_id(self):
         """This method is deprecated and will be removed in a future version as it is not concurrency-safe.

--- a/langfuse/utils/base_callback_handler.py
+++ b/langfuse/utils/base_callback_handler.py
@@ -58,6 +58,8 @@ class LangfuseBaseCallbackHandler:
             self.trace = stateful_client
             self._task_manager = stateful_client.task_manager
 
+            return
+
         elif stateful_client and isinstance(stateful_client, StatefulSpanClient):
             self.root_span = stateful_client
             self.trace = StatefulTraceClient(
@@ -68,6 +70,8 @@ class LangfuseBaseCallbackHandler:
                 stateful_client.task_manager,
             )
             self._task_manager = stateful_client.task_manager
+
+            return
 
         args = {
             "public_key": prio_public_key,

--- a/langfuse/utils/langfuse_singleton.py
+++ b/langfuse/utils/langfuse_singleton.py
@@ -1,3 +1,4 @@
+import httpx
 import threading
 from typing import Optional
 
@@ -19,11 +20,20 @@ class LangfuseSingleton:
 
     def get(
         self,
+        *,
         public_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         host: Optional[str] = None,
-        debug: bool = False,
+        release: Optional[str] = None,
+        debug: Optional[bool] = None,
+        threads: Optional[int] = None,
+        flush_at: Optional[int] = None,
+        flush_interval: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        timeout: Optional[int] = None,
+        httpx_client: Optional[httpx.Client] = None,
         sdk_integration: Optional[str] = None,
+        enabled: Optional[bool] = None,
     ) -> Langfuse:
         if self._langfuse:
             return self._langfuse
@@ -32,16 +42,31 @@ class LangfuseSingleton:
             if self._langfuse:
                 return self._langfuse
 
+            langfuse_init_args = {
+                "public_key": public_key,
+                "secret_key": secret_key,
+                "host": host,
+                "release": release,
+                "debug": debug,
+                "threads": threads,
+                "flush_at": flush_at,
+                "flush_interval": flush_interval,
+                "max_retries": max_retries,
+                "timeout": timeout,
+                "httpx_client": httpx_client,
+                "sdk_integration": sdk_integration,
+                "enabled": enabled,
+            }
+
             self._langfuse = Langfuse(
-                public_key=public_key,
-                secret_key=secret_key,
-                host=host,
-                debug=debug,
-                sdk_integration=sdk_integration,
+                **{k: v for k, v in langfuse_init_args.items() if v is not None}
             )
 
             return self._langfuse
 
     def reset(self) -> None:
         with self._lock:
+            if self._langfuse:
+                self._langfuse.flush()
+
             self._langfuse = None

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -738,9 +738,11 @@ def test_decorated_class_and_instance_methods():
     assert len(adjacencies) == 2  # Only trace and one observation have children
 
     level_2_observation = adjacencies[mock_trace_id][0]
-    level_3_observation = adjacencies[level_2_observation.id][1]
     class_method_observation = [
         o for o in adjacencies[level_2_observation.id] if o.name == "class_method"
+    ][0]
+    level_3_observation = [
+        o for o in adjacencies[level_2_observation.id] if o.name != "class_method"
     ][0]
 
     assert class_method_observation.input == json.dumps({"args": [], "kwargs": {}})

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -1714,6 +1714,35 @@ def test_get_langchain_chat_prompt():
             )
 
 
+def test_disabled_langfuse():
+    api = get_api()
+
+    run_name_override = "This is a custom Run Name"
+    handler = CallbackHandler(enabled=False, debug=False)
+
+    prompt = ChatPromptTemplate.from_template("tell me a short joke about {topic}")
+    model = ChatOpenAI(temperature=0)
+
+    chain = prompt | model
+
+    chain.invoke(
+        {"topic": "ice cream"},
+        config={
+            "callbacks": [handler],
+            "run_name": run_name_override,
+        },
+    )
+
+    assert handler.langfuse.task_manager._queue.empty()
+
+    handler.flush()
+
+    trace_id = handler.get_trace_id()
+
+    with pytest.raises(Exception):
+        api.trace.get(trace_id)
+
+
 # def test_langchain_anthropic_package():
 #     langfuse_handler = CallbackHandler(debug=False)
 #     from langchain_anthropic import ChatAnthropic

--- a/tests/test_llama_index.py
+++ b/tests/test_llama_index.py
@@ -1,3 +1,4 @@
+import pytest
 from llama_index.core import (
     Settings,
     PromptTemplate,
@@ -528,3 +529,20 @@ def test_callback_with_custom_trace_metadata():
     assert trace_data.user_id == updated_user_id
     assert trace_data.session_id == updated_session_id
     assert trace_data.tags == updated_tags
+
+
+def test_disabled_langfuse():
+    callback = LlamaIndexCallbackHandler(enabled=False)
+    get_llama_index_index(callback, force_rebuild=True)
+
+    assert callback.trace is not None
+
+    trace_id = callback.trace.id
+    assert trace_id is not None
+
+    assert callback.langfuse.task_manager._queue.empty()
+
+    callback.flush()
+
+    with pytest.raises(Exception):
+        get_api().trace.get(trace_id)

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1068,3 +1068,26 @@ def test_openai_with_existing_trace_id():
     trace = api.trace.get(generation.data[0].trace_id)
     assert trace.output == "This is a standard output"
     assert trace.input == "My custom input"
+
+
+def test_disabled_langfuse():
+    openai.langfuse_enabled = False
+
+    api = get_api()
+    generation_name = create_uuid()
+    chat_func(
+        name=generation_name,
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "1 + 1 = "}],
+        temperature=0,
+        metadata={"someKey": "someResponse"},
+    )
+
+    openai.flush_langfuse()
+
+    generations = api.observations.get_many(name=generation_name, type="GENERATION")
+
+    assert len(generations.data) == 0
+
+    # Reset state
+    openai.langfuse_enabled = True

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1071,11 +1071,17 @@ def test_openai_with_existing_trace_id():
 
 
 def test_disabled_langfuse():
+    # Reimport to reset the state
+    from langfuse.openai import openai
+    from langfuse.utils.langfuse_singleton import LangfuseSingleton
+
+    LangfuseSingleton().reset()
+
     openai.langfuse_enabled = False
 
     api = get_api()
     generation_name = create_uuid()
-    chat_func(
+    openai.chat.completions.create(
         name=generation_name,
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": "1 + 1 = "}],
@@ -1089,5 +1095,5 @@ def test_disabled_langfuse():
 
     assert len(generations.data) == 0
 
-    # Reset state
-    openai.langfuse_enabled = True
+    # Reimport to reset the state
+    from langfuse.openai import openai

--- a/tests/test_sdk_setup.py
+++ b/tests/test_sdk_setup.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import os
 
 import httpx
@@ -50,7 +51,7 @@ def test_langfuse_release():
 
 
 # langfuse sdk
-def test_setup_without_any_keys():
+def test_setup_without_any_keys(caplog):
     public_key, secret_key, host = (
         os.environ["LANGFUSE_PUBLIC_KEY"],
         os.environ["LANGFUSE_SECRET_KEY"],
@@ -59,27 +60,34 @@ def test_setup_without_any_keys():
     os.environ.pop("LANGFUSE_PUBLIC_KEY")
     os.environ.pop("LANGFUSE_SECRET_KEY")
     os.environ.pop("LANGFUSE_HOST")
-    with pytest.raises(ValueError):
+
+    with caplog.at_level(logging.WARNING):
         Langfuse()
+
+    assert "Langfuse client is disabled" in caplog.text
 
     os.environ["LANGFUSE_PUBLIC_KEY"] = public_key
     os.environ["LANGFUSE_SECRET_KEY"] = secret_key
     os.environ["LANGFUSE_HOST"] = host
 
 
-def test_setup_without_pk():
+def test_setup_without_pk(caplog):
     public_key = os.environ["LANGFUSE_PUBLIC_KEY"]
     os.environ.pop("LANGFUSE_PUBLIC_KEY")
-    with pytest.raises(ValueError):
+    with caplog.at_level(logging.WARNING):
         Langfuse()
+
+    assert "Langfuse client is disabled" in caplog.text
     os.environ["LANGFUSE_PUBLIC_KEY"] = public_key
 
 
-def test_setup_without_sk():
+def test_setup_without_sk(caplog):
     secret_key = os.environ["LANGFUSE_SECRET_KEY"]
     os.environ.pop("LANGFUSE_SECRET_KEY")
-    with pytest.raises(ValueError):
+    with caplog.at_level(logging.WARNING):
         Langfuse()
+
+    assert "Langfuse client is disabled" in caplog.text
     os.environ["LANGFUSE_SECRET_KEY"] = secret_key
 
 
@@ -151,13 +159,16 @@ def test_sdk_custom_xhttp_client():
 
 
 # callback
-def test_callback_setup_without_keys():
+def test_callback_setup_without_keys(caplog):
     public_key, secret_key, host = get_env_variables()
     os.environ.pop("LANGFUSE_PUBLIC_KEY")
     os.environ.pop("LANGFUSE_SECRET_KEY")
     os.environ.pop("LANGFUSE_HOST")
-    with pytest.raises(ValueError):
+
+    with caplog.at_level(logging.WARNING):
         CallbackHandler()
+
+    assert "Langfuse client is disabled" in caplog.text
 
     os.environ["LANGFUSE_PUBLIC_KEY"] = public_key
     os.environ["LANGFUSE_SECRET_KEY"] = secret_key
@@ -186,19 +197,27 @@ def test_callback_setup():
     assert callback_handler.langfuse.client._client_wrapper._password == secret_key
 
 
-def test_callback_setup_without_pk():
+def test_callback_setup_without_pk(caplog):
     public_key = os.environ["LANGFUSE_PUBLIC_KEY"]
     os.environ.pop("LANGFUSE_PUBLIC_KEY")
-    with pytest.raises(ValueError):
+
+    with caplog.at_level(logging.WARNING):
         CallbackHandler()
+
+    assert "Langfuse client is disabled" in caplog.text
+
     os.environ["LANGFUSE_PUBLIC_KEY"] = public_key
 
 
-def test_callback_setup_without_sk():
+def test_callback_setup_without_sk(caplog):
     secret_key = os.environ["LANGFUSE_SECRET_KEY"]
     os.environ.pop("LANGFUSE_SECRET_KEY")
-    with pytest.raises(ValueError):
+
+    with caplog.at_level(logging.WARNING):
         CallbackHandler()
+
+    assert "Langfuse client is disabled" in caplog.text
+
     os.environ["LANGFUSE_SECRET_KEY"] = secret_key
 
 

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,0 +1,67 @@
+import pytest
+import threading
+from unittest.mock import patch
+from langfuse.utils.langfuse_singleton import LangfuseSingleton
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    LangfuseSingleton._instance = None
+    LangfuseSingleton._langfuse = None
+    yield
+    LangfuseSingleton._instance = None
+    LangfuseSingleton._langfuse = None
+
+
+def test_singleton_instance():
+    """Test that the LangfuseSingleton class truly implements singleton behavior."""
+    instance1 = LangfuseSingleton()
+    instance2 = LangfuseSingleton()
+
+    assert instance1 is instance2
+
+
+def test_singleton_thread_safety():
+    """Test the thread safety of the LangfuseSingleton class."""
+
+    def get_instance(results):
+        instance = LangfuseSingleton()
+        results.append(instance)
+
+    results = []
+    threads = [
+        threading.Thread(target=get_instance, args=(results,)) for _ in range(10)
+    ]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    for instance in results:
+        assert instance is results[0]
+
+
+@patch("langfuse.utils.langfuse_singleton.Langfuse")
+def test_langfuse_initialization(mock_langfuse):
+    instance = LangfuseSingleton()
+    created = instance.get(public_key="key123", secret_key="secret", debug=True)
+    mock_langfuse.assert_called_once_with(
+        public_key="key123",
+        secret_key="secret",
+        debug=True,
+    )
+
+    assert created is mock_langfuse.return_value
+
+
+@patch("langfuse.utils.langfuse_singleton.Langfuse")
+def test_reset_functionality(mock_langfuse):
+    """Test the reset functionality of the LangfuseSingleton."""
+    instance = LangfuseSingleton()
+    instance.get(public_key="key123")
+    instance.reset()
+
+    assert instance._langfuse is None
+
+    mock_langfuse.return_value.flush.assert_called_once()


### PR DESCRIPTION
- Adds `enabled` switch that decides whether to send observability events to Langfuse (langfuse.trace/generation/event/score/span)
- Adds passing a custom HTTPX client for `llama-index` and `langchain` integrations