### PR TITLE
fix: add model support for langchain_aws

### DIFF
--- a/langfuse/extract_model.py
+++ b/langfuse/extract_model.py
@@ -31,6 +31,7 @@ def _extract_model_name(
         ("HuggingFacePipeline", ["invocation_params", "model_id"], "kwargs"),
         ("BedrockChat", ["kwargs", "model_id"], "serialized"),
         ("Bedrock", ["kwargs", "model_id"], "serialized"),
+        ("ChatBedrock", ["kwargs", "model_id"], "serialized"),
         ("LlamaCpp", ["invocation_params", "model_path"], "serialized"),
     ]
 

--- a/tests/test_extract_model.py
+++ b/tests/test_extract_model.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from langchain_anthropic import ChatAnthropic
 from langchain_google_vertexai import ChatVertexAI
 from langchain_groq import ChatGroq
+from langchain_aws import ChatBedrock
 import pytest
 from langfuse.callback import CallbackHandler
 
@@ -84,6 +85,14 @@ from tests.utils import get_api
             "amazon.titan-tg1-large",
             Bedrock(
                 model_id="amazon.titan-tg1-large",
+                region_name="us-east-1",
+                client=MagicMock(),
+            ),
+        ),
+        (
+            "anthropic.claude-3-sonnet-20240229-v1:0",
+            ChatBedrock(
+                model_id="anthropic.claude-3-sonnet-20240229-v1:0",
                 region_name="us-east-1",
                 client=MagicMock(),
             ),


### PR DESCRIPTION
This adds model parsing support for ChatBedrock from `langchain_aws`, since BedrockChat from has been deprecated.

```
 The class `BedrockChat` was deprecated in LangChain 0.0.34 and will be removed in 0.3. An updated version of the class exists in the langchain-aws package and should be used instead. To use it run `pip install -U langchain-aws` and import as `from langchain_aws import ChatBedrock`
```