### PR TITLE
fix(prompts): Rename `meta` to `pagination` in `PromptMetaListResponse`

### DIFF
--- a/langfuse/api/resources/prompts/types/prompt_meta_list_response.py
+++ b/langfuse/api/resources/prompts/types/prompt_meta_list_response.py
@@ -11,7 +11,7 @@ from .prompt_meta import PromptMeta
 
 class PromptMetaListResponse(pydantic_v1.BaseModel):
     data: typing.List[PromptMeta]
-    meta: MetaResponse
+    pagination: MetaResponse
 
     def json(self, **kwargs: typing.Any) -> str:
         kwargs_with_defaults: typing.Any = {


### PR DESCRIPTION
## Problem
The `list` function of the prompts client returns a validation error.

```python
from langfuse import Langfuse

langfuse = Langfuse()
prompts = langfuse.client.prompts.list()
```

Output:
```shell
{ValidationError}ValidationError(model='ParsingModel[PromptMetaListResponse]', errors=[{'loc': ('__root__', 'meta'), 'msg': 'field required', 'type': 'value_error.missing'}])
```

## Proposed Solution
The validation error is caused by a mismatch between one of the keys of `_response` and the Pydantic model of `PromptMetaListResponse`.

**Renaming** the `meta` attribute into `pagination` solves the problem.