### PR TITLE
feat: join task manager threads concurrently instead of serially

### DIFF
--- a/langfuse/task_manager.py
+++ b/langfuse/task_manager.py
@@ -285,8 +285,13 @@ class TaskManager(object):
         Blocks execution until finished
         """
         self._log.debug(f"joining {len(self._consumers)} consumer threads")
+
+        # pause all consumers before joining them so we don't have to wait for multiple
+        # flush intervals to join them all.
         for consumer in self._consumers:
             consumer.pause()
+
+        for consumer in self._consumers:
             try:
                 consumer.join()
             except RuntimeError:


### PR DESCRIPTION
Calling Langfuse.shutdown() takes a long time if there are many threads. The problem is that TaskManager.join() pauses each consumer thread and joins it, before pausing and joining the next thread, etc.

The fix is to first pause all threads and then join them, so we end up waiting O(1) flush intervals instead of O(n) flush intervals to join all the threads.