### PR TITLE
feat: join task manager threads concurrently instead of serially (#734)

### DIFF
--- a/langfuse/task_manager.py
+++ b/langfuse/task_manager.py
@@ -285,8 +285,13 @@ class TaskManager(object):
         Blocks execution until finished
         """
         self._log.debug(f"joining {len(self._consumers)} consumer threads")
+
+        # pause all consumers before joining them so we don't have to wait for multiple
+        # flush intervals to join them all.
         for consumer in self._consumers:
             consumer.pause()
+
+        for consumer in self._consumers:
             try:
                 consumer.join()
             except RuntimeError:


### PR DESCRIPTION
Join task manager consumer threads concurrently instead of serially.