### PR TITLE
Langchain prompt single braces

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -83,7 +83,20 @@ class BasePromptClient(ABC):
 
     @staticmethod
     def _get_langchain_prompt_string(content: str):
-        return re.sub(r"{{\s*(\w+)\s*}}", r"{\g<1>}", content)
+        # replace single `{` with the temporary replacement content
+        content = re.sub(r'(?<!{){(?!{)', '<LANGFUSE_REPLACE_OPEN>', content)
+        
+        # replace single `}` with the temporary replacement content
+        content = re.sub(r'(?<!})}(?!})', '<LANGFUSE_REPLACE_CLOSE>', content)
+        
+        # replace all double braces with single braces for langchain vars
+        content = re.sub(r"{{\s*(\w+)\s*}}", r"{\g<1>}", content)
+        
+        # replace temporary replacements with double braces
+        content = re.sub('<LANGFUSE_REPLACE_OPEN>', '{{', content)
+        content = re.sub('<LANGFUSE_REPLACE_CLOSE>', '}}', content)
+        
+        return content
 
     @staticmethod
     def _compile_template_string(content: str, data: Dict[str, Any] = {}) -> str:

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -1659,7 +1659,23 @@ def test_get_langchain_prompt_with_jinja2():
         langfuse_prompt.get_langchain_prompt()
         == 'this is a {template} template that should remain unchanged: {{ handle_text(payload["Name"], "Name is") }}'
     )
+    
+def test_get_langchain_prompt_with_braces():
+    langfuse = Langfuse()
 
+    prompt = 'This is a {{test}} with another {{test} that leads to {this}'
+    langfuse.create_prompt(
+        name="test_braces",
+        prompt=prompt,
+        labels=["production"],
+    )
+
+    langfuse_prompt = langfuse.get_prompt("test_braces")
+
+    assert (
+        langfuse_prompt.get_langchain_prompt()
+        == 'This is a {test} with another {{test}} that leads to {{this}}'
+    )
 
 def test_get_langchain_prompt():
     langfuse = Langfuse()


### PR DESCRIPTION
**Goal:** be able to use single braces in langfuse prompts later interacting with langchain

**Why?**
I am working a lot with generated latex which kind of revolves around { and }. Also, I am using langchain as a framework. Therefore I am not able to use { and } in my prompts on langfuse because then langchain expects them to hold variables inside them. To escape { and } for langchain, you would use {{ and }} but in langfuse {{ and }} circumenvent variables.

**My quick suggestion**
First replace all single { and } with temporary placeholders, then have the usual langfuse -> langchain prompt transformation and finally replace the temporary placeholders with double quotes.

I am a little unsure how this might impact the vast variety of prompts there is. Maybe some people use this as a feature to have variables in the prompt for langchain and not mark them variables for langfuse.