### PR TITLE
Return Iterator instead of Iterable for OpenAI Streaming

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -558,13 +558,13 @@ async def _wrap_async(
         openai_response = await wrapped(**arg_extractor.get_openai_args())
 
         if _is_streaming_response(openai_response):
-            return LangfuseResponseGeneratorAsync(
+            return aiter(LangfuseResponseGeneratorAsync(
                 resource=open_ai_resource,
                 response=openai_response,
                 generation=generation,
                 langfuse=new_langfuse,
                 is_nested_trace=is_nested_trace,
-            )
+            ))
 
         else:
             model, completion, usage = _get_langfuse_data_from_default_response(

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -711,6 +711,8 @@ async def test_async_chat_stream():
         stream=True,
     )
 
+    # Make sure that stream is consumed through iterator protocol: __anext__() and __aiter__()
+    await anext(completion)
     async for c in completion:
         print(c)
 


### PR DESCRIPTION
- Changes: Modified return type to Iterator to match OpenAI's implementation
- Testing: Verified `anext()` is now callable on the returned object
- Notes: Improves semantic consistency with original OpenAI Streaming

```py
first_chunk = anext(stream)
if isinstance(first_chunk.choices[0].delta.content, str):  # for mypy
    ...
elif isinstance(first_chunk.choices[0].delta.tool_calls, list):
    ...
```
