### PR TITLE
fix: Fixed an error when the event serializer encountered Exception

### DIFF
--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -32,7 +32,7 @@ class EventSerializer(JSONEncoder):
             return serialize_datetime(obj)
 
         if isinstance(obj, Exception):
-            return obj.message
+            return str(obj)
 
         # LlamaIndex StreamingAgentChatResponse and StreamingResponse is not serializable by default as it is a generator
         # Attention: These LlamaIndex objects are a also a dataclasses, so check for it first

--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -31,6 +31,9 @@ class EventSerializer(JSONEncoder):
             # Timezone-awareness check
             return serialize_datetime(obj)
 
+        if isinstance(obj, Exception):
+            return obj.message
+
         # LlamaIndex StreamingAgentChatResponse and StreamingResponse is not serializable by default as it is a generator
         # Attention: These LlamaIndex objects are a also a dataclasses, so check for it first
         if "Streaming" in type(obj).__name__:

--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -31,8 +31,8 @@ class EventSerializer(JSONEncoder):
             # Timezone-awareness check
             return serialize_datetime(obj)
 
-        if isinstance(obj, Exception):
-            return str(obj)
+        if isinstance(obj, (Exception, KeyboardInterrupt)):
+            return f"{type(obj).__name__}: {str(obj)}"
 
         # LlamaIndex StreamingAgentChatResponse and StreamingResponse is not serializable by default as it is a generator
         # Attention: These LlamaIndex objects are a also a dataclasses, so check for it first


### PR DESCRIPTION
When using langchain, an error was raised and generation could not be recorded

## The following is the duplicate code
```
def test_langfuse():
    from langfuse.callback import CallbackHandler

    langfuse_handler = CallbackHandler(
        public_key="pk-",
        secret_key="sk-",
        host="http://localhost:3000",
        tags=[-2],
        session_id=-2,
        trace_name=-2,
        user_id=-2,
        debug=True
    )

    def chat():
        from langchain_core.output_parsers import StrOutputParser
        from langchain_core.prompts import ChatPromptTemplate
        from langchain_openai import ChatOpenAI

        chat_messages = [
            ("system", "You are a helpful assistant"),
            ("human", "Question: {{question}}")
        ]

        prompt = ChatPromptTemplate.from_messages(
            chat_messages,
            template_format="mustache"
        )

        chain = prompt | ChatOpenAI(
            model_name="qwen-72b",
            openai_api_key="empty",
            openai_api_base="http://localhost:8888/v1",
            max_tokens=100000 # This is intentionally passed here because it will result in errors from the model service
        ) | StrOutputParser()

        content = chain.invoke({"question": "hello"}, config={"callbacks": [langfuse_handler]})
        return content
```
@hassiebp 
I don't know if my modification is in line with your style. If so, please mention it.