### PR TITLE
feat: add optional seed in openai model parameters

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -318,6 +318,12 @@ def _get_langfuse_data_from_kwargs(
         else 0
     )
 
+    parsed_seed = (
+        kwargs.get("seed", None)
+        if not isinstance(kwargs.get("seed", None), NotGiven)
+        else None
+    )
+
     modelParameters = {
         "temperature": parsed_temperature,
         "max_tokens": parsed_max_tokens,  # casing?
@@ -325,6 +331,8 @@ def _get_langfuse_data_from_kwargs(
         "frequency_penalty": parsed_frequency_penalty,
         "presence_penalty": parsed_presence_penalty,
     }
+    if parsed_seed is not None:
+        modelParameters["seed"] = parsed_seed
 
     langfuse_prompt = kwargs.get("langfuse_prompt", None)
 

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -413,6 +413,33 @@ def test_openai_chat_completion_two_calls():
     assert generation_2.data[0].input == [{"content": "2 + 2 = ", "role": "user"}]
 
 
+def test_openai_chat_completion_with_seed():
+    api = get_api()
+    generation_name = create_uuid()
+    completion = chat_func(
+        name=generation_name,
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "1 + 1 = "}],
+        temperature=0,
+        seed=123,
+        metadata={"someKey": "someResponse"},
+    )
+
+    openai.flush_langfuse()
+
+    generation = api.observations.get_many(name=generation_name, type="GENERATION")
+
+    assert generation.data[0].model_parameters == {
+        "temperature": 0,
+        "top_p": 1,
+        "frequency_penalty": 0,
+        "max_tokens": "inf",
+        "presence_penalty": 0,
+        "seed": 123,
+    }
+    assert len(completion.choices) != 0
+
+
 def test_openai_completion():
     api = get_api()
     generation_name = create_uuid()


### PR DESCRIPTION
Hi

I added support to track the optional `seed` model parameter through the OpenAI integration.

![image](https://github.com/user-attachments/assets/f9fd6c33-9c3e-4751-8abd-b8ba03505c09)
_Screenshot from the trace generated by the unit test. You can also check the [public trace](https://cloud.langfuse.com/project/clqz1ivm90002q2hys8h23stv/traces/4a37f539-d7aa-41a1-a604-308e1edf7cd6?observation=93a6eb2c-1ea1-4850-85df-d1c61dc69f25)._