### PR TITLE
feat(prompts): return stale prompt version and refresh prompt cache in background thread instead of waiting for the updated prompt

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -1013,11 +1013,11 @@ class Langfuse(object):
             max_retries, default_max_retries=2, max_retries_upper_bound=4
         )
 
-        self.log.warning(f"Getting prompt '{cache_key}'")
+        self.log.debug(f"Getting prompt '{cache_key}'")
         cached_prompt = self.prompt_cache.get(cache_key)
 
         if cached_prompt is None:
-            self.log.warning(f"Prompt '{cache_key}' not found in cache.")
+            self.log.debug(f"Prompt '{cache_key}' not found in cache.")
             try:
                 return self._fetch_prompt_and_update_cache(
                     name,
@@ -1058,7 +1058,7 @@ class Langfuse(object):
                 raise e
 
         if cached_prompt.is_expired():
-            self.log.warning(f"Stale prompt '{cache_key}' found in cache.")
+            self.log.debug(f"Stale prompt '{cache_key}' found in cache.")
             try:
                 # refresh prompt in background thread, refresh_prompt deduplicates tasks
                 self.log.debug(f"Refreshing prompt '{cache_key}' in background.")
@@ -1073,7 +1073,7 @@ class Langfuse(object):
                         fetch_timeout_seconds=fetch_timeout_seconds,
                     ),
                 )
-                self.log.warning(f"Returning stale prompt '{cache_key}' from cache.")
+                self.log.debug(f"Returning stale prompt '{cache_key}' from cache.")
                 # return stale prompt
                 return cached_prompt.value
 

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -1079,7 +1079,7 @@ class Langfuse(object):
 
             except Exception as e:
                 self.log.warning(
-                    f"Error when refreshing stale prompt '{cache_key}', returning stale prompt cache. Error: {e}"
+                    f"Error when refreshing cached prompt '{cache_key}', returning cached version. Error: {e}"
                 )
                 # creation of refresh prompt task failed, return stale prompt
                 return cached_prompt.value

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -1062,7 +1062,7 @@ class Langfuse(object):
             try:
                 # refresh prompt in background thread, refresh_prompt deduplicates tasks
                 self.log.debug(f"Refreshing prompt '{cache_key}' in background.")
-                self.prompt_cache.refresh_prompt(
+                self.prompt_cache.add_refresh_prompt_task(
                     cache_key,
                     lambda: self._fetch_prompt_and_update_cache(
                         name,

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -111,8 +111,9 @@ class PromptCacheTaskManager(object):
 
     def shutdown(self):
         self._log.debug(
-            f"Shutting down prompt cache refresh task manager, {len(self._consumers)} consumers..."
+            f"Shutting down prompt refresh task manager, {len(self._consumers)} consumers,..."
         )
+
         for consumer in self._consumers:
             consumer.pause()
 
@@ -123,7 +124,7 @@ class PromptCacheTaskManager(object):
                 # consumer thread has not started
                 pass
 
-        self._log.debug("Consumers joined.")
+        self._log.debug("Shutdown of prompt refresh task manager completed.")
 
 
 class PromptCache:
@@ -139,7 +140,6 @@ class PromptCache:
     ):
         self._cache = {}
         self._task_manager = PromptCacheTaskManager(threads=max_prompt_refresh_workers)
-        atexit.register(self._shutdown_task_manager)
         self._log.debug("Prompt cache initialized.")
 
     def get(self, key: str) -> Optional[PromptCacheItem]:
@@ -154,11 +154,6 @@ class PromptCache:
     def add_refresh_prompt_task(self, key: str, fetch_func):
         self._log.debug(f"Submitting refresh task for key: {key}")
         self._task_manager.add_task(key, fetch_func)
-
-    def _shutdown_task_manager(self):
-        self._log.debug("Shutting down prompt refresh task manager...")
-        self._task_manager.shutdown()
-        self._log.debug("Shutdown of prompt refresh task manager completed.")
 
     @staticmethod
     def generate_cache_key(

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -1,16 +1,18 @@
 """@private"""
 
 from datetime import datetime
-from typing import Optional, Dict
-import threading
-from concurrent.futures import ThreadPoolExecutor
+from typing import List, Optional, Dict, Set
+from threading import Thread, Event
 import atexit
 import logging
+from queue import Empty, Queue
 
 from langfuse.model import PromptClient
 
 
 DEFAULT_PROMPT_CACHE_TTL_SECONDS = 60
+
+DEFAULT_PROMPT_CACHE_REFRESH_WORKERS = 1
 
 
 class PromptCacheItem:
@@ -26,25 +28,110 @@ class PromptCacheItem:
         return int(datetime.now().timestamp())
 
 
+class PromptCacheConsumer(Thread):
+    _log = logging.getLogger("langfuse")
+    _queue: Queue
+    _identifier: int
+    running: bool = True
+
+    def __init__(self, queue: Queue, identifier: int):
+        super().__init__()
+        self.daemon = True
+        self._queue = queue
+        self._identifier = identifier
+
+    def run(self):
+        while self.running:
+            try:
+                task = self._queue.get(timeout=1)
+                self._log.debug(f"Consumer {self._identifier} processing task")
+                task()
+                self._queue.task_done()
+            except Empty:
+                pass
+
+    def pause(self):
+        """Pause the consumer."""
+        self.running = False
+
+
+class PromptCacheTaskManager(object):
+    _log = logging.getLogger("langfuse")
+    _consumers: List[PromptCacheConsumer]
+    _threads: int
+    _queue: Queue
+    _processing_keys: Set[str]
+
+    def __init__(self, threads: int = 1):
+        self._queue = Queue()
+        self._consumers = []
+        self._threads = threads
+        self._processing_keys = set()
+
+        for i in range(self._threads):
+            consumer = PromptCacheConsumer(self._queue, i)
+            consumer.start()
+            self._consumers.append(consumer)
+
+        atexit.register(self.shutdown)
+
+    def add_task(self, key: str, task):
+        if key not in self._processing_keys:
+            self._log.debug(f"Adding refresh task for key: {key}")
+            self._processing_keys.add(key)
+            wrapped_task = self._wrap_task(key, task)
+            self._queue.put((wrapped_task))
+        else:
+            self._log.debug(f"Refresh task already submitted for key: {key}")
+
+    def active_tasks(self) -> int:
+        return len(self._processing_keys)
+
+    def _wrap_task(self, key: str, task):
+        def wrapped():
+            self._log.debug(f"Refreshing prompt cache for key: {key}")
+            try:
+                task()
+            finally:
+                self._processing_keys.remove(key)
+                self._log.debug(f"Refreshed prompt cache for key: {key}")
+
+        return wrapped
+
+    def shutdown(self):
+        self._log.debug(
+            f"Shutting down prompt cache refresh task manager, {len(self._consumers)} consumers..."
+        )
+        for consumer in self._consumers:
+            consumer.pause()
+
+        for consumer in self._consumers:
+            try:
+                consumer.join()
+            except RuntimeError:
+                # consumer thread has not started
+                pass
+
+        self._log.debug("Consumers joined.")
+
+
 class PromptCache:
     _cache: Dict[str, PromptCacheItem]
 
-    _refreshing_keys: Dict[str, threading.Event]
+    _refreshing_keys: Dict[str, Event]
     """Keys that are currently being refreshed"""
 
-    _refresh_executor: ThreadPoolExecutor
-    """Executor for refreshing cache"""
+    _task_manager: PromptCacheTaskManager
+    """Task manager for refreshing cache"""
 
     _log = logging.getLogger("langfuse")
 
-    def __init__(self, max_prompt_refresh_workers: int = 1):
+    def __init__(
+        self, max_prompt_refresh_workers: int = DEFAULT_PROMPT_CACHE_REFRESH_WORKERS
+    ):
         self._cache = {}
-        self._refreshing_keys = {}
-        self._refresh_executor = ThreadPoolExecutor(
-            max_workers=max_prompt_refresh_workers,
-            thread_name_prefix="LangfusePromptCacheRefreshExecutor",
-        )
-        atexit.register(self._shutdown_refresh_executor)
+        self._task_manager = PromptCacheTaskManager(threads=max_prompt_refresh_workers)
+        atexit.register(self._shutdown_task_manager)
         self._log.debug(f"Prompt cache initialized.")
 
     def get(self, key: str) -> Optional[PromptCacheItem]:
@@ -57,26 +144,13 @@ class PromptCache:
         self._cache[key] = PromptCacheItem(value, ttl_seconds)
 
     def refresh_prompt(self, key: str, fetch_func):
-        if key not in self._refreshing_keys:
-            self._log.debug(f"Submitting refresh task for key: {key}")
-            self._refreshing_keys[key] = threading.Event()
-            self._refresh_executor.submit(self._refresh_task, key, fetch_func)
-        else:
-            self._log.debug(f"Refresh task already submitted for key: {key}")
+        self._log.debug(f"Submitting refresh task for key: {key}")
+        self._task_manager.add_task(key, fetch_func)
 
-    def _refresh_task(self, key: str, fetch_func):
-        """Run refresh task which updates cache itself, removes key from refreshing keys when done."""
-        try:
-            self._log.debug(f"Refreshing prompt cache for key: {key}")
-            fetch_func()
-            self._log.debug(f"Refreshed prompt cache for key: {key}")
-        finally:
-            self._refreshing_keys.pop(key, None)
-
-    def _shutdown_refresh_executor(self):
-        self._log.debug(f"Shutting down prompt refresh executor ...")
-        self._refresh_executor.shutdown(wait=False)
-        self._log.debug(f"Shutdown of prompt refresh executor completed.")
+    def _shutdown_task_manager(self):
+        self._log.debug(f"Shutting down prompt refresh task manager...")
+        self._task_manager.shutdown()
+        self._log.debug(f"Shutdown of prompt refresh task manager completed.")
 
     @staticmethod
     def generate_cache_key(

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -45,14 +45,14 @@ class PromptCacheRefreshConsumer(Thread):
             try:
                 task = self._queue.get(timeout=1)
                 self._log.debug(
-                    f"PromptCacheRefreshConsumer {self._identifier} processing task"
+                    f"PromptCacheRefreshConsumer processing task, {self._identifier}"
                 )
                 try:
                     task()
                 # Task failed, but we still consider it processed
                 except Exception as e:
                     self._log.exception(
-                        f"PromptCacheRefreshConsumer {self._identifier} encountered an error: {e}"
+                        f"PromptCacheRefreshConsumer encountered an error: {self._identifier}, {e}"
                     )
 
                 self._queue.task_done()

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from typing import List, Optional, Dict, Set
-from threading import Thread, Event
+from threading import Thread
 import atexit
 import logging
 from queue import Empty, Queue

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -2,11 +2,17 @@
 
 from datetime import datetime
 from typing import Optional, Dict
+import threading
+from concurrent.futures import ThreadPoolExecutor
+import atexit
+import logging
 
 from langfuse.model import PromptClient
 
 
 DEFAULT_PROMPT_CACHE_TTL_SECONDS = 60
+
+REFRESH_PROMPT_WORKER_THREADS = 1
 
 
 class PromptCacheItem:
@@ -25,8 +31,22 @@ class PromptCacheItem:
 class PromptCache:
     _cache: Dict[str, PromptCacheItem]
 
+    _refreshing_keys: Dict[str, threading.Event]
+    """Keys that are currently being refreshed"""
+
+    _refresh_executor: ThreadPoolExecutor
+    """Executor for refreshing cache"""
+
+    _log = logging.getLogger("langfuse")
+
     def __init__(self):
         self._cache = {}
+        self._refreshing_keys = {}
+        self._refresh_executor = ThreadPoolExecutor(
+            max_workers=REFRESH_PROMPT_WORKER_THREADS,
+            thread_name_prefix="LangfusePromptCacheRefreshExecutor",
+        )
+        atexit.register(self._shutdown_refresh_executor)
 
     def get(self, key: str) -> Optional[PromptCacheItem]:
         return self._cache.get(key, None)
@@ -36,6 +56,23 @@ class PromptCache:
             ttl_seconds = DEFAULT_PROMPT_CACHE_TTL_SECONDS
 
         self._cache[key] = PromptCacheItem(value, ttl_seconds)
+
+    def refresh_prompt(self, key: str, fetch_func):
+        if key not in self._refreshing_keys:
+            self._refreshing_keys[key] = threading.Event()
+            self._executor.submit(self._refresh_task, key, fetch_func)
+
+    def _refresh_task(self, key: str, fetch_func):
+        """Run refresh task which updates cache itself, removes key from refreshing keys when done."""
+        try:
+            fetch_func()
+        finally:
+            self._refreshing_keys.pop(key, None)
+
+    def _shutdown_refresh_executor(self):
+        self._log.debug(f"Shutting down prompt refresh executor ...")
+        self._refresh_executor.shutdown(wait=False, cancel_futures=True)
+        self._log.debug(f"Shutdown of prompt refresh executor completed.")
 
     @staticmethod
     def generate_cache_key(

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -129,9 +129,6 @@ class PromptCacheTaskManager(object):
 class PromptCache:
     _cache: Dict[str, PromptCacheItem]
 
-    _refreshing_keys: Dict[str, Event]
-    """Keys that are currently being refreshed"""
-
     _task_manager: PromptCacheTaskManager
     """Task manager for refreshing cache"""
 

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -12,8 +12,6 @@ from langfuse.model import PromptClient
 
 DEFAULT_PROMPT_CACHE_TTL_SECONDS = 60
 
-REFRESH_PROMPT_WORKER_THREADS = 1
-
 
 class PromptCacheItem:
     def __init__(self, prompt: PromptClient, ttl_seconds: int):
@@ -39,14 +37,15 @@ class PromptCache:
 
     _log = logging.getLogger("langfuse")
 
-    def __init__(self):
+    def __init__(self, max_prompt_refresh_workers: int = 1):
         self._cache = {}
         self._refreshing_keys = {}
         self._refresh_executor = ThreadPoolExecutor(
-            max_workers=REFRESH_PROMPT_WORKER_THREADS,
+            max_workers=max_prompt_refresh_workers,
             thread_name_prefix="LangfusePromptCacheRefreshExecutor",
         )
         atexit.register(self._shutdown_refresh_executor)
+        self._log.debug(f"Prompt cache initialized.")
 
     def get(self, key: str) -> Optional[PromptCacheItem]:
         return self._cache.get(key, None)
@@ -59,19 +58,24 @@ class PromptCache:
 
     def refresh_prompt(self, key: str, fetch_func):
         if key not in self._refreshing_keys:
+            self._log.debug(f"Submitting refresh task for key: {key}")
             self._refreshing_keys[key] = threading.Event()
-            self._executor.submit(self._refresh_task, key, fetch_func)
+            self._refresh_executor.submit(self._refresh_task, key, fetch_func)
+        else:
+            self._log.debug(f"Refresh task already submitted for key: {key}")
 
     def _refresh_task(self, key: str, fetch_func):
         """Run refresh task which updates cache itself, removes key from refreshing keys when done."""
         try:
+            self._log.debug(f"Refreshing prompt cache for key: {key}")
             fetch_func()
+            self._log.debug(f"Refreshed prompt cache for key: {key}")
         finally:
             self._refreshing_keys.pop(key, None)
 
     def _shutdown_refresh_executor(self):
         self._log.debug(f"Shutting down prompt refresh executor ...")
-        self._refresh_executor.shutdown(wait=False, cancel_futures=True)
+        self._refresh_executor.shutdown(wait=False)
         self._log.debug(f"Shutdown of prompt refresh executor completed.")
 
     @staticmethod

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -51,8 +51,8 @@ class PromptCacheRefreshConsumer(Thread):
                     task()
                 # Task failed, but we still consider it processed
                 except Exception as e:
-                    self._log.exception(
-                        f"PromptCacheRefreshConsumer encountered an error: {self._identifier}, {e}"
+                    self._log.warning(
+                        f"PromptCacheRefreshConsumer encountered an error, cache was not refreshed: {self._identifier}, {e}"
                     )
 
                 self._queue.task_done()

--- a/langfuse/prompt_cache.py
+++ b/langfuse/prompt_cache.py
@@ -143,7 +143,7 @@ class PromptCache:
         self._cache = {}
         self._task_manager = PromptCacheTaskManager(threads=max_prompt_refresh_workers)
         atexit.register(self._shutdown_task_manager)
-        self._log.debug(f"Prompt cache initialized.")
+        self._log.debug("Prompt cache initialized.")
 
     def get(self, key: str) -> Optional[PromptCacheItem]:
         return self._cache.get(key, None)
@@ -159,9 +159,9 @@ class PromptCache:
         self._task_manager.add_task(key, fetch_func)
 
     def _shutdown_task_manager(self):
-        self._log.debug(f"Shutting down prompt refresh task manager...")
+        self._log.debug("Shutting down prompt refresh task manager...")
         self._task_manager.shutdown()
-        self._log.debug(f"Shutdown of prompt refresh task manager completed.")
+        self._log.debug("Shutdown of prompt refresh task manager completed.")
 
     @staticmethod
     def generate_cache_key(

--- a/langfuse/version.py
+++ b/langfuse/version.py
@@ -1,3 +1,3 @@
 """@private"""
 
-__version__ = "2.45.2"
+__version__ = "2.45.3a0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langfuse"
-version = "2.45.2"
+version = "2.45.3a0"
 description = "A client library for accessing langfuse"
 authors = ["langfuse <developers@langfuse.com>"]
 license = "MIT"

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -676,6 +676,9 @@ def test_get_fresh_prompt_when_expired_cache_custom_ttl(mock_time, langfuse: Lan
 # Should return stale prompt immediately if cached one is expired according to default TTL and add to refresh promise map
 @patch.object(PromptCacheItem, "get_epoch_seconds")
 def test_get_stale_prompt_when_expired_cache_default_ttl(mock_time, langfuse: Langfuse):
+    import logging
+
+    logging.basicConfig(level=logging.DEBUG)
     mock_time.return_value = 0
 
     prompt_name = "test"

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -710,10 +710,10 @@ def test_get_stale_prompt_when_expired_cache_default_ttl(mock_time, langfuse):
 
     # Ensure that only one refresh is triggered despite multiple calls
     # Cannot check for value as the prompt might have already been updated
-    stale_result_2 = langfuse.get_prompt(prompt_name)
-    stale_result_3 = langfuse.get_prompt(prompt_name)
-    stale_result_4 = langfuse.get_prompt(prompt_name)
-    stale_result_5 = langfuse.get_prompt(prompt_name)
+    langfuse.get_prompt(prompt_name)
+    langfuse.get_prompt(prompt_name)
+    langfuse.get_prompt(prompt_name)
+    langfuse.get_prompt(prompt_name)
 
     assert mock_server_call.call_count == 2  # Only one new call to server
 

--- a/tests/test_prompt_atexit.py
+++ b/tests/test_prompt_atexit.py
@@ -1,11 +1,4 @@
 import pytest
-from unittest.mock import Mock, patch
-
-from langfuse.client import Langfuse
-from langfuse.prompt_cache import PromptCacheItem, DEFAULT_PROMPT_CACHE_TTL_SECONDS
-from tests.utils import create_uuid, get_api
-from langfuse.api.resources.prompts import Prompt_Text, Prompt_Chat
-from langfuse.model import TextPromptClient, ChatPromptClient
 import subprocess
 
 

--- a/tests/test_prompt_atexit.py
+++ b/tests/test_prompt_atexit.py
@@ -26,7 +26,7 @@ def wait_2_sec():
 
 # 8 times
 for i in range(8):
-    prompt_cache.refresh_prompt(f"key_wait_2_sec_i_{i}", lambda: wait_2_sec())
+    prompt_cache.add_refresh_prompt_task(f"key_wait_2_sec_i_{i}", lambda: wait_2_sec())
 """
 
     process = subprocess.Popen(
@@ -80,7 +80,7 @@ async def main():
         time.sleep(2)
 
     async def add_new_prompt_refresh(i: int):
-        prompt_cache.refresh_prompt(f"key_wait_2_sec_i_{i}", lambda: wait_2_sec())
+        prompt_cache.add_refresh_prompt_task(f"key_wait_2_sec_i_{i}", lambda: wait_2_sec())
     
     # 8 times
     tasks = [add_new_prompt_refresh(i) for i in range(8)]

--- a/tests/test_prompt_atexit.py
+++ b/tests/test_prompt_atexit.py
@@ -1,0 +1,124 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from langfuse.client import Langfuse
+from langfuse.prompt_cache import PromptCacheItem, DEFAULT_PROMPT_CACHE_TTL_SECONDS
+from tests.utils import create_uuid, get_api
+from langfuse.api.resources.prompts import Prompt_Text, Prompt_Chat
+from langfuse.model import TextPromptClient, ChatPromptClient
+import subprocess
+
+
+@pytest.mark.timeout(10)
+def test_prompts_atexit():
+    python_code = """
+import time
+import logging
+from langfuse.prompt_cache import PromptCache  # assuming task_manager is the module name
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.StreamHandler()
+    ]
+)
+
+print("Adding prompt cache", PromptCache)
+prompt_cache = PromptCache(max_prompt_refresh_workers=10)
+
+# example task that takes 2 seconds but we will force it to exit earlier
+def wait_2_sec():
+    time.sleep(2)
+
+# 8 times
+for i in range(8):
+    prompt_cache.refresh_prompt(f"key_wait_2_sec_i_{i}", lambda: wait_2_sec())
+"""
+
+    process = subprocess.Popen(
+        ["python", "-c", python_code], stderr=subprocess.PIPE, text=True
+    )
+
+    logs = ""
+
+    try:
+        for line in process.stderr:
+            logs += line.strip()
+            print(line.strip())
+    except subprocess.TimeoutExpired:
+        pytest.fail("The process took too long to execute")
+    process.communicate()
+
+    returncode = process.returncode
+    if returncode != 0:
+        pytest.fail("Process returned with error code")
+
+    print(process.stderr)
+
+    assert "Shutdown of prompt refresh executor completed." in logs
+
+
+@pytest.mark.timeout(10)
+def test_prompts_atexit_async():
+    python_code = """
+import time
+import asyncio
+import logging
+from langfuse.prompt_cache import PromptCache  # assuming task_manager is the module name
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.StreamHandler()
+    ]
+)
+
+async def main():
+    print("Adding prompt cache", PromptCache)
+    prompt_cache = PromptCache(max_prompt_refresh_workers=10)
+
+    # example task that takes 2 seconds but we will force it to exit earlier
+    def wait_2_sec():
+        time.sleep(2)
+
+    async def add_new_prompt_refresh(i: int):
+        prompt_cache.refresh_prompt(f"key_wait_2_sec_i_{i}", lambda: wait_2_sec())
+    
+    # 8 times
+    tasks = [add_new_prompt_refresh(i) for i in range(8)]
+    await asyncio.gather(*tasks)
+
+async def run_multiple_mains():
+    main_tasks = [main() for _ in range(3)]
+    await asyncio.gather(*main_tasks)
+
+if __name__ == "__main__":
+    asyncio.run(run_multiple_mains())
+"""
+
+    process = subprocess.Popen(
+        ["python", "-c", python_code], stderr=subprocess.PIPE, text=True
+    )
+
+    logs = ""
+
+    try:
+        for line in process.stderr:
+            logs += line.strip()
+            print(line.strip())
+    except subprocess.TimeoutExpired:
+        pytest.fail("The process took too long to execute")
+    process.communicate()
+
+    returncode = process.returncode
+    if returncode != 0:
+        pytest.fail("Process returned with error code")
+
+    print(process.stderr)
+
+    shutdown_count = logs.count("Shutdown of prompt refresh executor completed.")
+    assert (
+        shutdown_count == 3
+    ), f"Expected 3 shutdown messages, but found {shutdown_count}"

--- a/tests/test_prompt_atexit.py
+++ b/tests/test_prompt_atexit.py
@@ -49,7 +49,10 @@ for i in range(8):
 
     print(process.stderr)
 
-    assert "Shutdown of prompt refresh executor completed." in logs
+    shutdown_count = logs.count("Shutdown of prompt refresh task manager completed.")
+    assert (
+        shutdown_count == 1
+    ), f"Expected 1 shutdown messages, but found {shutdown_count}"
 
 
 @pytest.mark.timeout(10)
@@ -111,7 +114,7 @@ if __name__ == "__main__":
 
     print(process.stderr)
 
-    shutdown_count = logs.count("Shutdown of prompt refresh executor completed.")
+    shutdown_count = logs.count("Shutdown of prompt refresh task manager completed.")
     assert (
         shutdown_count == 3
     ), f"Expected 3 shutdown messages, but found {shutdown_count}"


### PR DESCRIPTION
uses threading logic similar to `task_manager`

Updated docs: https://github.com/langfuse/langfuse-docs/pull/787

In addition to tests, I also manually tested whether error handling prevents all sorts of errors to be captured, we have two layers of error handling to prevent any refresh exceptions causing issues in the main thread: (1) in get_prompt, (2) in PromptCacheRefreshConsumer.