### PR TITLE
Updated deprecated logging warning in langfuse_decorator.py

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -785,7 +785,7 @@ class LangfuseDecorator:
         observation = stack[-1] if stack else None
 
         if not observation:
-            self._log.warn("No observation found in the current context")
+            self._log.warning("No observation found in the current context")
 
             return
 


### PR DESCRIPTION
Updated deprecated logging warning

langfuse_decorator.py:788: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
  self._log.warn("No observation found in the current context")