### PR TITLE
fix llamaindex CompletionResponse serialize error

### DIFF
--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -36,8 +36,9 @@ class EventSerializer(JSONEncoder):
                 return f"{type(obj).__name__}: {str(obj)}"
 
             # LlamaIndex StreamingAgentChatResponse and StreamingResponse is not serializable by default as it is a generator
+            # LlamaIndex CompletionResponse is also not serializable by default
             # Attention: These LlamaIndex objects are a also a dataclasses, so check for it first
-            if "Streaming" in type(obj).__name__:
+            if "Streaming" in type(obj).__name__ or "CompletionResponse" == type(obj).__name__:
                 return str(obj)
 
             if isinstance(obj, enum.Enum):


### PR DESCRIPTION
While I use langfuse with llamaindex, I get an error output:
```
received error response: {'message': 'Invalid request data', 'errors': ['Expected object, received string']}
Received 400 error by Langfuse server, not retrying: {'message': 'Invalid request data', 'errors': ['Expected object, received string']}
```
Then I debug the task_manager file and find this code `data = json.dumps(kwargs, cls=EventSerializer)` .
In my case, the output object in body is type of `<class 'llama_index.core.base.llms.types.CompletionResponse'>`.
When it executes this line of  `default()` in EventSerializer, a TypeError will be thrown.
TypeError: `'MockValSer' object cannot be converted to 'SchemaSerializer'` (pydantic 2.8.2)
```
if isinstance(obj, BaseModel):
    return obj.dict()
```
-----------------------------------
I just realized that this issue is caused by the type from `llamaindex`.
Would there be any risks if I handle all of the CompletionResponse here?