### PR TITLE
fix handle_span_events exception

### DIFF
--- a/langfuse/llama_index/llama_index.py
+++ b/langfuse/llama_index/llama_index.py
@@ -546,7 +546,8 @@ class LlamaIndexCallbackHandler(
         ],
         trace_id: str,
     ) -> StatefulSpanClient:
-        start_event, end_event = self.event_map[event_id]
+        events = self.event_map[event_id]
+        start_event, end_event = events[0], events[-1]
 
         extracted_input = self._parse_input_from_event(start_event)
         extracted_output = self._parse_output_from_event(end_event)


### PR DESCRIPTION
When I was using LangFuse in LlamaIndex, I encountered an exceptional situation. 
When the llm generates a `CBEventType.EXCEPTION`, the `_handle_span_events` function is executed. 
The events, it is a single-element list, causes an exception during execution. 
So I made modifications according to the writing method in other functions

Error line:
```
start_event, end_event = self.event_map[event_id]
```
Exception information:
```
ValueError: not enough values to unpack (expected 2, got 1)
```

CBEventType.EXCEPTION events example:
```
[
  CallbackEvent(
    event_type=<CBEventType.EXCEPTION: 'exception'>, 
    payload={<EventPayload.EXCEPTION: 'exception'>: ResponseError('model "qwen2.5:72b" not found, try pulling it first')}, time=datetime.datetime(2024, 9, 23, 8, 34, 22, 529110, tzinfo=datetime.timezone.utc), id_='2084d724-0b9d-4409-827f-34964f7240c1'
  )
]

or

[
  CallbackEvent(
    event_type=<CBEventType.EXCEPTION: 'exception'>, 
    payload={<EventPayload.EXCEPTION: 'exception'>: 1 validation error for LLMChatStartEvent
      messages
        Input should be a valid list [type=list_type, input_value="#......", input_type=str]
          For further information visit https://errors.pydantic.dev/2.8/v/list_type}, time=datetime.datetime(2024, 9, 23, 8, 34, 23, 413709, tzinfo=datetime.timezone.utc), id_='5c62181c-40ef-4de2-adec-899edb27d8c5'
  )
]
```