### PR TITLE
fix(serializer): Fix None serialization without langchain installed

### DIFF
--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -78,7 +78,7 @@ class EventSerializer(JSONEncoder):
                 return str(obj)
 
             # if langchain is not available, the Serializable type is NoneType
-            if Serializable is not None and isinstance(obj, Serializable):
+            if Serializable is not type(None) and isinstance(obj, Serializable):
                 return obj.to_json()
 
             # 64-bit integers might overflow the JavaScript safe integer range.

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -5,7 +5,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from pydantic import BaseModel
 import json
+import pytest
 import threading
+import langfuse.serializer
 from langfuse.serializer import (
     EventSerializer,
 )
@@ -158,6 +160,12 @@ def test_exception():
 
 
 def test_none():
+    serializer = EventSerializer()
+    assert serializer.encode(None) == "null"
+
+
+def test_none_without_langchain(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(langfuse.serializer, "Serializable", type(None), raising=True)
     serializer = EventSerializer()
     assert serializer.encode(None) == "null"
 


### PR DESCRIPTION
This PR aims to fix the serialization of `None` to `"<not serializable object of type: NoneType>"` when langchain is not installed.
Related issue: https://github.com/langfuse/langfuse/issues/3570