### PR TITLE
fix(langchain): invalid user_id / session_id in TraceBody

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -225,9 +225,13 @@ class LangchainCallbackHandler(
             if parent_run_id is None and (tags or metadata):
                 self.trace_updates[run_id].update(
                     {
-                        "tags": tags and [str(tag) for tag in tags],
-                        "session_id": metadata and metadata.get("langfuse_session_id"),
-                        "user_id": metadata and metadata.get("langfuse_user_id"),
+                        "tags": [str(tag) for tag in tags] if tags else None,
+                        "session_id": metadata.get("langfuse_session_id")
+                        if metadata
+                        else None,
+                        "user_id": metadata.get("langfuse_user_id")
+                        if metadata
+                        else None,
                     }
                 )
 

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -1960,8 +1960,6 @@ def test_link_langfuse_prompts_stream():
 def test_link_langfuse_prompts_batch():
     langfuse = Langfuse()
     trace_name = "test_link_langfuse_prompts_batch_" + create_uuid()[:8]
-    session_id = "session_" + create_uuid()[:8]
-    user_id = "user_" + create_uuid()[:8]
 
     # Create prompts
     joke_prompt_name = "joke_prompt_" + create_uuid()[:8]
@@ -2015,10 +2013,6 @@ def test_link_langfuse_prompts_batch():
             "callbacks": [langfuse_handler],
             "run_name": trace_name,
             "tags": ["langchain-tag"],
-            "metadata": {
-                "langfuse_session_id": session_id,
-                "langfuse_user_id": user_id,
-            },
         },
     )
 
@@ -2032,8 +2026,6 @@ def test_link_langfuse_prompts_batch():
         trace = get_api().trace.get(trace.id)
 
         assert trace.tags == ["langchain-tag"]
-        assert trace.session_id == session_id
-        assert trace.user_id == user_id
 
         observations = trace.observations
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of `session_id` and `user_id` in `on_chain_start` when `metadata` is `None` and update related test.
> 
>   - **Bug Fix**:
>     - Fix `on_chain_start` in `langfuse/callback/langchain.py` to correctly handle `session_id` and `user_id` when `metadata` is `None`.
>   - **Tests**:
>     - Remove `session_id` and `user_id` variables and assertions from `test_link_langfuse_prompts_batch()` in `test_langchain.py` as they are no longer needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 6cfc34cc547dee2a69a6e2649960a45a120449a5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->