### PR TITLE
fix(openai): structured output parsing with openai >= 1.50

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -19,6 +19,7 @@ See docs for more details: https://langfuse.com/docs/integrations/openai
 
 import copy
 import logging
+from inspect import isclass
 import types
 
 from collections import defaultdict
@@ -152,7 +153,8 @@ class OpenAiArgsExtractor:
             else {
                 **(metadata or {}),
                 "response_format": kwargs["response_format"].model_json_schema()
-                if issubclass(kwargs["response_format"], BaseModel)
+                if isclass(kwargs["response_format"])
+                and issubclass(kwargs["response_format"], BaseModel)
                 else kwargs["response_format"],
             }
         )

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1482,6 +1482,7 @@ def test_structured_output_response_format_kwarg():
 
 def test_structured_output_beta_completions_parse():
     from typing import List
+    from packaging.version import Version
 
     class CalendarEvent(BaseModel):
         name: str
@@ -1491,51 +1492,58 @@ def test_structured_output_beta_completions_parse():
     generation_name = create_uuid()
     api = get_api()
 
-    openai.beta.chat.completions.parse(
-        model="gpt-4o-2024-08-06",
-        messages=[
+    params = {
+        "model": "gpt-4o-2024-08-06",
+        "messages": [
             {"role": "system", "content": "Extract the event information."},
             {
                 "role": "user",
                 "content": "Alice and Bob are going to a science fair on Friday.",
             },
         ],
-        response_format=CalendarEvent,
-        name=generation_name,
-    )
+        "response_format": CalendarEvent,
+        "name": generation_name,
+    }
+
+    # The beta API is only wrapped for this version range. prior to that, implicitly another wrapped method was called
+    if Version(openai.__version__) < Version("1.50.0"):
+        params.pop("name")
+
+    openai.beta.chat.completions.parse(**params)
 
     openai.flush_langfuse()
 
-    # Check the trace and observation properties
-    generation = api.observations.get_many(name=generation_name, type="GENERATION")
+    if Version(openai.__version__) >= Version("1.50.0"):
+        # Check the trace and observation properties
+        generation = api.observations.get_many(name=generation_name, type="GENERATION")
 
-    assert len(generation.data) == 1
-    assert generation.data[0].name == generation_name
-    assert generation.data[0].type == "GENERATION"
-    assert generation.data[0].model == "gpt-4o-2024-08-06"
-    assert generation.data[0].start_time is not None
-    assert generation.data[0].end_time is not None
-    assert generation.data[0].start_time < generation.data[0].end_time
+        assert len(generation.data) == 1
+        assert generation.data[0].name == generation_name
+        assert generation.data[0].type == "GENERATION"
+        assert generation.data[0].model == "gpt-4o-2024-08-06"
+        assert generation.data[0].start_time is not None
+        assert generation.data[0].end_time is not None
+        assert generation.data[0].start_time < generation.data[0].end_time
 
-    # Check input and output
-    assert len(generation.data[0].input) == 2
-    assert generation.data[0].input[0]["role"] == "system"
-    assert generation.data[0].input[1]["role"] == "user"
-    assert isinstance(generation.data[0].output, dict)
-    assert "name" in generation.data[0].output["content"]
-    assert "date" in generation.data[0].output["content"]
-    assert "participants" in generation.data[0].output["content"]
+        # Check input and output
+        assert len(generation.data[0].input) == 2
+        assert generation.data[0].input[0]["role"] == "system"
+        assert generation.data[0].input[1]["role"] == "user"
+        assert isinstance(generation.data[0].output, dict)
+        assert "name" in generation.data[0].output["content"]
+        assert "date" in generation.data[0].output["content"]
+        assert "participants" in generation.data[0].output["content"]
 
-    # Check usage
-    assert generation.data[0].usage.input is not None
-    assert generation.data[0].usage.output is not None
-    assert generation.data[0].usage.total is not None
+        # Check usage
+        assert generation.data[0].usage.input is not None
+        assert generation.data[0].usage.output is not None
+        assert generation.data[0].usage.total is not None
 
-    # Check trace
-    trace = api.trace.get(generation.data[0].trace_id)
+        # Check trace
+        trace = api.trace.get(generation.data[0].trace_id)
 
-    assert trace.input is not None
-    assert trace.output is not None
+        assert trace.input is not None
+        assert trace.output is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `langfuse/openai.py` to support structured output parsing for OpenAI versions >= 1.50.0 with new methods and version checks.
> 
>   - **Behavior**:
>     - Adds `parse` method to `OpenAiDefinition` for `Completions` and `AsyncCompletions` in `openai.resources.beta.chat.completions` with `min_version` 1.50.0.
>     - Skips wrapping functions if OpenAI version is below `min_version` in `register_tracing()`.
>   - **Classes**:
>     - Converts `OpenAiDefinition` to use `@dataclass`.
>   - **Functions**:
>     - Updates `OpenAiArgsExtractor.__init__()` to handle `response_format` using `model_json_schema()` if it is a subclass of `BaseModel`.
>   - **Tests**:
>     - Adds tests for structured output parsing in `tests/test_openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 204ce087d3898e49436deba4fd2e101f53062edf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->