### PR TITLE
fix(decorators): stack trace on failed auth_check

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -1110,7 +1110,9 @@ class LangfuseDecorator:
         try:
             return self.client_instance.auth_check()
         except Exception as e:
-            self._log.error("No Langfuse object found in the current context", e)
+            self._log.error(
+                "No Langfuse object found in the current context", exc_info=e
+            )
 
             return False
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve error logging in `auth_check()` by including stack trace and add a test for `ChatBedrockConverse` model invocation.
> 
>   - **Logging**:
>     - Update `auth_check()` in `langfuse_decorator.py` to include stack trace in error logs using `exc_info`.
>   - **Testing**:
>     - Add `test_bedrock()` in `test_langchain.py` to test `ChatBedrockConverse` model invocation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 049e6b56f135dad7fabc456f848ef866e2cc5d48. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->