### PR TITLE
fix(langchain): parse tool calls in input

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -53,7 +53,7 @@ except ImportError:
 class LangchainCallbackHandler(
     LangchainBaseCallbackHandler, LangfuseBaseCallbackHandler
 ):
-    log = logging.getLogger("langfuse")
+    log = logging.getLogger(__name__)
     next_span_id: Optional[str] = None
 
     def __init__(
@@ -704,6 +704,10 @@ class LangchainCallbackHandler(
         **kwargs: Any,
     ):
         try:
+            tools = kwargs.get("invocation_params", {}).get("tools", None)
+            if tools and isinstance(tools, list):
+                prompts.extend([{"role": "tool", "content": tool} for tool in tools])
+
             self.__generate_trace_and_parent(
                 serialized,
                 inputs=prompts[0] if len(prompts) == 1 else prompts,

--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -53,7 +53,7 @@ except ImportError:
 class LangchainCallbackHandler(
     LangchainBaseCallbackHandler, LangfuseBaseCallbackHandler
 ):
-    log = logging.getLogger(__name__)
+    log = logging.getLogger("langfuse")
     next_span_id: Optional[str] = None
 
     def __init__(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances tool call parsing in `LangchainCallbackHandler` and updates logger initialization, with a new test added for verification.
> 
>   - **Behavior**:
>     - In `LangchainCallbackHandler.__on_llm_action`, tool calls are parsed from `kwargs['invocation_params']['tools']` and added to `prompts` if they exist and are a list.
>   - **Logging**:
>     - Changed logger initialization in `LangchainCallbackHandler` from `logging.getLogger('langfuse')` to `logging.getLogger(__name__)`.
>   - **Testing**:
>     - Added `test_callback_openai_functions_with_tools()` in `test_langchain.py` to verify tool call parsing functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 28cdb274aa226ed9d6d4b361db19f051b49baf76. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->