### PR TITLE
feat(api): mask data from traces logged to langfuse

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -317,6 +317,7 @@ class Langfuse(object):
             "sdk_integration": sdk_integration,
             "enabled": self.enabled,
             "sample_rate": sample_rate,
+            "mask": mask,
         }
 
         self.task_manager = TaskManager(**args)

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -11,6 +11,7 @@ import time
 import tracemalloc
 from typing import (
     Any,
+    Callable,
     Dict,
     Optional,
     Literal,
@@ -179,6 +180,7 @@ class Langfuse(object):
         httpx_client: Optional[httpx.Client] = None,
         enabled: Optional[bool] = True,
         sample_rate: Optional[float] = None,
+        mask: Optional[Callable[[Any], Any]] = None,
     ):
         """Initialize the Langfuse client.
 
@@ -197,6 +199,7 @@ class Langfuse(object):
             sdk_integration: Used by intgerations that wrap the Langfuse SDK to add context for debugging and support. Not to be used directly.
             enabled: Enables or disables the Langfuse client. If disabled, all observability calls to the backend will be no-ops.
             sample_rate: Sampling rate for tracing. If set to 0.2, only 20% of the data will be sent to the backend. Can be set via `LANGFUSE_SAMPLE_RATE` environment variable.
+            mask (Callable): Function that masks sensitive information from input and output in log messages.
 
         Raises:
             ValueError: If public_key or secret_key are not set and not found in environment variables.
@@ -291,6 +294,8 @@ class Langfuse(object):
             httpx_client=self.httpx_client,
         )
 
+        self.mask = mask
+
         langfuse_client = LangfuseClient(
             public_key=public_key,
             secret_key=secret_key,
@@ -321,6 +326,11 @@ class Langfuse(object):
         self.release = self._get_release_value(release)
 
         self.prompt_cache = PromptCache()
+
+    def _apply_mask(self, data: Any) -> Any:
+        if self.mask:
+            return self.mask(data)
+        return data
 
     def _get_release_value(self, release: Optional[str] = None) -> Optional[str]:
         if release:
@@ -1317,8 +1327,8 @@ class Langfuse(object):
                 "release": self.release,
                 "version": version,
                 "metadata": metadata,
-                "input": input,
-                "output": output,
+                "input": self._apply_mask(input),
+                "output": self._apply_mask(output),
                 "tags": tags,
                 "timestamp": timestamp or _get_timestamp(),
                 "public": public,
@@ -1584,8 +1594,8 @@ class Langfuse(object):
                 "name": name,
                 "start_time": start_time or _get_timestamp(),
                 "metadata": metadata,
-                "input": input,
-                "output": output,
+                "input": self._apply_mask(input),
+                "output": self._apply_mask(output),
                 "level": level,
                 "status_message": status_message,
                 "parent_observation_id": parent_observation_id,
@@ -1686,8 +1696,8 @@ class Langfuse(object):
                 "name": name,
                 "start_time": start_time or _get_timestamp(),
                 "metadata": metadata,
-                "input": input,
-                "output": output,
+                "input": self._apply_mask(input),
+                "output": self._apply_mask(output),
                 "level": level,
                 "status_message": status_message,
                 "parent_observation_id": parent_observation_id,
@@ -1802,8 +1812,8 @@ class Langfuse(object):
                 "name": name,
                 "start_time": start_time or _get_timestamp(),
                 "metadata": metadata,
-                "input": input,
-                "output": output,
+                "input": self._apply_mask(input),
+                "output": self._apply_mask(output),
                 "level": level,
                 "status_message": status_message,
                 "parent_observation_id": parent_observation_id,

--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -1040,6 +1040,7 @@ class LangfuseDecorator:
         timeout: Optional[int] = None,
         httpx_client: Optional[httpx.Client] = None,
         enabled: Optional[bool] = None,
+        mask: Optional[Callable] = None,
     ):
         """Configure the Langfuse client.
 
@@ -1058,6 +1059,8 @@ class LangfuseDecorator:
             timeout: Timeout of API requests in seconds. Default is 20 seconds.
             httpx_client: Pass your own httpx client for more customizability of requests.
             enabled: Enables or disables the Langfuse client. Defaults to True. If disabled, no observability data will be sent to Langfuse. If data is requested while disabled, an error will be raised.
+            mask (Callable): Function that masks sensitive information from input and output in log messages.
+
         """
         langfuse_singleton = LangfuseSingleton()
         langfuse_singleton.reset()
@@ -1075,6 +1078,7 @@ class LangfuseDecorator:
             timeout=timeout,
             httpx_client=httpx_client,
             enabled=enabled,
+            mask=mask,
         )
 
     @property

--- a/langfuse/utils/langfuse_singleton.py
+++ b/langfuse/utils/langfuse_singleton.py
@@ -1,6 +1,6 @@
 import httpx
 import threading
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 
 from langfuse import Langfuse

--- a/langfuse/utils/langfuse_singleton.py
+++ b/langfuse/utils/langfuse_singleton.py
@@ -1,6 +1,6 @@
 import httpx
 import threading
-from typing import Optional
+from typing import Any, Callable, Optional
 
 
 from langfuse import Langfuse
@@ -35,6 +35,7 @@ class LangfuseSingleton:
         sdk_integration: Optional[str] = None,
         enabled: Optional[bool] = None,
         sample_rate: Optional[float] = None,
+        mask: Optional[Callable] = None,
     ) -> Langfuse:
         if self._langfuse:
             return self._langfuse
@@ -58,6 +59,7 @@ class LangfuseSingleton:
                 "sdk_integration": sdk_integration,
                 "enabled": enabled,
                 "sample_rate": sample_rate,
+                "mask": mask,
             }
 
             self._langfuse = Langfuse(

--- a/tests/test_core_sdk_unit.py
+++ b/tests/test_core_sdk_unit.py
@@ -1,6 +1,4 @@
 from unittest.mock import Mock
-from typing import Any, Callable
-
 from langfuse.api.client import FernLangfuse
 from langfuse.client import (
     StatefulClient,
@@ -84,25 +82,3 @@ def test_stateful_client_returning_if_taskmanager_fails(
     mock_task_manager.assert_called()
 
     assert isinstance(result, expected_client)
-
-
-@pytest.mark.parametrize("method", ["trace", "span", "event", "generation"])
-def test_mask_input(langfuse, method: str):
-    def mask(data: Any) -> Any:
-        return {**data, "key": "masked"} if isinstance(data, dict) else data
-
-    langfuse.mask = mask
-
-    mock_task_manager = langfuse.task_manager.add_task
-
-    method_to_call: Callable = getattr(langfuse, method)
-    method_to_call(
-        user_id="test",
-        input={"key": "value"},
-        output={"key": "pii-data"},
-        tags=["tag1", "tag2"],
-        public=True,
-    )
-
-    assert mock_task_manager.call_args[0][0]["body"]["input"] == {"key": "masked"}
-    assert mock_task_manager.call_args[0][0]["body"]["output"] == {"key": "masked"}


### PR DESCRIPTION
Supports https://github.com/langfuse/langfuse/issues/3518

## Developer Experience

```Python
from langfuse.decorators import observe, langfuse_context

langfuse_context.configure(
  # example lambda to replace "home_address" from input and output
  mask=lambda data: {**data, "home_address": "masked"} if isinstance(data, dict) else data
)

@observe()
def process_pii(home_address: str):
    print("Hello, from the process_pii function!")
 
process_pii("777 this road")

langfuse_context.flush()
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add data masking functionality to Langfuse client to protect sensitive information in logs.
> 
>   - **Behavior**:
>     - Add `mask` parameter to `Langfuse` class in `client.py` to mask sensitive data in logs.
>     - Apply `mask` function to `input` and `output` in `trace()`, `span()`, `event()`, and `generation()` methods in `client.py`.
>   - **Configuration**:
>     - Add `mask` parameter to `configure()` in `langfuse_decorator.py` and `get()` in `langfuse_singleton.py`.
>   - **Testing**:
>     - Add `test_mask_input` in `test_core_sdk_unit.py` to verify masking of `input` and `output` data.
>   - **Misc**:
>     - Update docstrings in `client.py` to include `mask` parameter description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 7e6bcb6c1573b35b9ad6f3c5f92f68927a438066. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->