### PR TITLE
docs(llama-index): deprecate CallbackHandler and promote Instrumentor

### DIFF
--- a/langfuse/llama_index/_instrumentor.py
+++ b/langfuse/llama_index/_instrumentor.py
@@ -24,7 +24,7 @@ logger = getLogger(__name__)
 
 
 class LlamaIndexInstrumentor:
-    """[BETA] Instrumentor for exporting LlamaIndex instrumentation module spans to Langfuse.
+    """Instrumentor for exporting LlamaIndex instrumentation module spans to Langfuse.
 
     This beta integration is currently under active development and subject to change.
     Please provide feedback to the Langfuse team: https://github.com/langfuse/langfuse/issues/1931

--- a/langfuse/llama_index/llama_index.py
+++ b/langfuse/llama_index/llama_index.py
@@ -57,7 +57,7 @@ context_trace_metadata: ContextVar[TraceMetadata] = ContextVar(
 class LlamaIndexCallbackHandler(
     LlamaIndexBaseCallbackHandler, LangfuseBaseCallbackHandler
 ):
-    """LlamaIndex callback handler for Langfuse. This version is in alpha and may change in the future."""
+    """[Deprecated] LlamaIndex callback handler for Langfuse. Deprecated, please use the LlamaIndexInstrumentor instead."""
 
     log = logging.getLogger("langfuse")
 
@@ -88,6 +88,9 @@ class LlamaIndexCallbackHandler(
         sdk_integration: Optional[str] = None,
         sample_rate: Optional[float] = None,
     ) -> None:
+        self.log.warning(
+            "LlamaIndexCallbackHandler is deprecated, please use the LlamaIndexInstrumentor instead."
+        )
         LlamaIndexBaseCallbackHandler.__init__(
             self,
             event_starts_to_ignore=event_starts_to_ignore or [],

--- a/langfuse/llama_index/llama_index.py
+++ b/langfuse/llama_index/llama_index.py
@@ -88,9 +88,6 @@ class LlamaIndexCallbackHandler(
         sdk_integration: Optional[str] = None,
         sample_rate: Optional[float] = None,
     ) -> None:
-        self.log.warning(
-            "LlamaIndexCallbackHandler is deprecated, please use the LlamaIndexInstrumentor instead."
-        )
         LlamaIndexBaseCallbackHandler.__init__(
             self,
             event_starts_to_ignore=event_starts_to_ignore or [],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Deprecates `LlamaIndexCallbackHandler` and promotes `LlamaIndexInstrumentor` for tracing and logging in `llama_index.py` and `_instrumentor.py`.
> 
>   - **Deprecation**:
>     - `LlamaIndexCallbackHandler` marked as deprecated in `llama_index.py`.
>     - Warning log added in `__init__()` of `LlamaIndexCallbackHandler` to notify users of deprecation.
>   - **Promotion**:
>     - `LlamaIndexInstrumentor` is now the recommended tool for tracing and logging, as indicated by updated docstring in `_instrumentor.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for c4a71c2d208e0b825baa7decd946cfe02691aae0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->