### PR TITLE
fix(openai): handle NoneType responses gracefully

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -495,6 +495,9 @@ def _extract_streamed_openai_response(resource, chunks):
 
 
 def _get_langfuse_data_from_default_response(resource: OpenAiDefinition, response):
+    if response is None:
+        return None, "<NoneType response returned from OpenAI>", None
+
     model = response.get("model", None) or None
 
     completion = None
@@ -558,7 +561,9 @@ def _wrap(open_ai_resource: OpenAiDefinition, initialize, wrapped, args, kwargs)
         else:
             model, completion, usage = _get_langfuse_data_from_default_response(
                 open_ai_resource,
-                openai_response.__dict__ if _is_openai_v1() else openai_response,
+                (openai_response and openai_response.__dict__)
+                if _is_openai_v1()
+                else openai_response,
             )
             generation.update(
                 model=model, output=completion, end_time=_get_timestamp(), usage=usage
@@ -609,7 +614,9 @@ async def _wrap_async(
         else:
             model, completion, usage = _get_langfuse_data_from_default_response(
                 open_ai_resource,
-                openai_response.__dict__ if _is_openai_v1() else openai_response,
+                (openai_response and openai_response.__dict__)
+                if _is_openai_v1()
+                else openai_response,
             )
             generation.update(
                 model=model,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle `NoneType` responses from OpenAI gracefully in `langfuse/openai.py` by updating response handling functions.
> 
>   - **Behavior**:
>     - Handle `NoneType` responses in `_get_langfuse_data_from_default_response()` by returning a specific message.
>     - Update `_wrap()` and `_wrap_async()` to check for `NoneType` before accessing `__dict__` of `openai_response`.
>   - **Functions**:
>     - Modify `_get_langfuse_data_from_default_response()` to handle `NoneType` responses.
>     - Update `_wrap()` and `_wrap_async()` to handle `NoneType` responses gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for f219fc687b7b5802593170be84431b91e8a8146f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->