### PR TITLE
fix: replace deprecated dict references

### DIFF
--- a/langfuse/task_manager.py
+++ b/langfuse/task_manager.py
@@ -223,7 +223,7 @@ class Consumer(threading.Thread):
             sdk_name=self._sdk_name,
             sdk_version=self._sdk_version,
             public_key=self._public_key,
-        ).dict()
+        ).model_dump()
 
         @backoff.on_exception(
             backoff.expo, Exception, max_tries=self._max_retries, logger=None

--- a/langfuse/utils/__init__.py
+++ b/langfuse/utils/__init__.py
@@ -49,7 +49,7 @@ def extract_by_priority(
 def _convert_usage_input(usage: typing.Union[pydantic.BaseModel, ModelUsage]):
     """Converts any usage input to a usage object"""
     if isinstance(usage, pydantic.BaseModel):
-        usage = usage.dict()
+        usage = usage.model_dump()
 
     # sometimes we do not match the pydantic usage object
     # in these cases, we convert to dict manually


### PR DESCRIPTION
Should close https://github.com/langfuse/langfuse/issues/2946

All other usages of .dict() appeared to be with a V1 pydantic model, so should not be changed until a v2 model is used.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace deprecated `dict()` with `model_dump()` in `task_manager.py` and `utils/__init__.py` for Pydantic v2 compatibility.
> 
>   - **Behavior**:
>     - Replace deprecated `dict()` with `model_dump()` in `task_manager.py` and `utils/__init__.py` for Pydantic v2 compatibility.
>     - Does not change other `dict()` usages with Pydantic v1 models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 1fb0f060be351efbc7b35f23790db6cec76414a8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->