### PR TITLE
fix(decorator): improve stack access safety

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -595,7 +595,8 @@ class LangfuseDecorator:
 
             return None
 
-        observation = _observation_stack_context.get()[-1]
+        stack = _observation_stack_context.get()
+        observation = stack[-1] if stack else None
 
         if observation is None:
             self._log.warning("No observation found in the current context")
@@ -629,7 +630,8 @@ class LangfuseDecorator:
             - This method should be called within the context of a trace (i.e., within a function wrapped by @observe) to ensure that an observation context exists.
             - If no observation is found in the current context (e.g., if called outside of a trace or if the observation stack is empty), the method logs a warning and returns None.
         """
-        observation = _observation_stack_context.get()[-1]
+        stack = _observation_stack_context.get()
+        observation = stack[-1] if stack else None
 
         if observation is None:
             self._log.warning("No observation found in the current context")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve stack access safety in `get_current_llama_index_handler()` and `get_current_langchain_handler()` by checking for empty stack before accessing elements.
> 
>   - **Safety Improvements**:
>     - In `get_current_llama_index_handler()` and `get_current_langchain_handler()`, check if `_observation_stack_context` is empty before accessing the last element to prevent errors.
>     - Log a warning and return `None` if no observation is found in the current context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 5af31a9a1e186e48a05badb3879b7fee0c1c32ec. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->