### PR TITLE
refactor(llama-index): send generation updates directly from event handler

### DIFF
--- a/langfuse/llama_index/_instrumentor.py
+++ b/langfuse/llama_index/_instrumentor.py
@@ -99,14 +99,8 @@ class LlamaIndexInstrumentor:
             sdk_integration="llama-index_instrumentation",
         )
         self._observation_updates = {}
-        self._span_handler = LlamaIndexSpanHandler(
-            langfuse_client=self._langfuse,
-            observation_updates=self._observation_updates,
-        )
-        self._event_handler = LlamaIndexEventHandler(
-            langfuse_client=self._langfuse,
-            observation_updates=self._observation_updates,
-        )
+        self._span_handler = LlamaIndexSpanHandler(langfuse_client=self._langfuse)
+        self._event_handler = LlamaIndexEventHandler(langfuse_client=self._langfuse)
         self._context = InstrumentorContext()
 
     def start(self):

--- a/langfuse/llama_index/_instrumentor.py
+++ b/langfuse/llama_index/_instrumentor.py
@@ -98,7 +98,6 @@ class LlamaIndexInstrumentor:
             mask=mask,
             sdk_integration="llama-index_instrumentation",
         )
-        self._observation_updates = {}
         self._span_handler = LlamaIndexSpanHandler(langfuse_client=self._langfuse)
         self._event_handler = LlamaIndexEventHandler(langfuse_client=self._langfuse)
         self._context = InstrumentorContext()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `LlamaIndexEventHandler` and `LlamaIndexSpanHandler` to remove `observation_updates` and directly update generation clients, handling missing trace IDs by generating new UUIDs.
> 
>   - **Refactor**:
>     - Remove `observation_updates` from `LlamaIndexEventHandler` and `LlamaIndexSpanHandler`.
>     - Directly update generation client in `update_generation_from_start_event()` and `update_generation_from_end_event()` in `_event_handler.py`.
>     - Handle missing trace ID by generating a new UUID and logging a warning in `_get_generation_client()` in `_event_handler.py` and `_span_handler.py`.
>   - **Initialization**:
>     - Remove `observation_updates` parameter from `LlamaIndexEventHandler` and `LlamaIndexSpanHandler` constructors.
>     - Update `LlamaIndexInstrumentor` to reflect changes in handler initialization.
>   - **Misc**:
>     - Minor import cleanup in `_event_handler.py` and `_span_handler.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 13930678301b0bf07e4bbf122ed01ab9c3213d83. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->