### PR TITLE
feat(openai): parse usage if stream_options has include_usage

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -170,6 +170,17 @@ class OpenAiArgsExtractor:
         return {**self.args, **self.kwargs}
 
     def get_openai_args(self):
+        # OpenAI returns streaming usage not by default but only if stream_options has include_usage set
+        if self.kwargs.get("stream") and "stream_options" not in self.kwargs:
+            self.kwargs["stream_options"] = {"include_usage": True}
+
+        if (
+            self.kwargs.get("stream")
+            and "stream_options" in self.kwargs
+            and "include_usage" not in self.kwargs["stream_options"]
+        ):
+            self.kwargs["stream_options"]["include_usage"] = True
+
         return self.kwargs
 
 

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -119,7 +119,8 @@ def test_openai_chat_completion_stream():
 
     chat_content = ""
     for i in completion:
-        chat_content += i.choices[0].delta.content or ""
+        print("\n", i)
+        chat_content += (i.choices[0].delta.content or "") if i.choices else ""
 
     assert len(chat_content) > 0
 
@@ -180,7 +181,7 @@ def test_openai_chat_completion_stream_with_next_iteration():
     while True:
         try:
             c = next(completion)
-            chat_content += c.choices[0].delta.content or ""
+            chat_content += (c.choices[0].delta.content or "") if c.choices else ""
 
         except StopIteration:
             break
@@ -562,7 +563,7 @@ def test_openai_completion_stream():
     assert iter(completion)
     content = ""
     for i in completion:
-        content += i.choices[0].text
+        content += (i.choices[0].text or "") if i.choices else ""
 
     openai.flush_langfuse()
 
@@ -854,7 +855,7 @@ async def test_async_chat_stream_with_anext():
         try:
             c = await completion.__anext__()
 
-            result += c.choices[0].delta.content or ""
+            result += (c.choices[0].delta.content or "") if c.choices else ""
 
         except StopAsyncIteration:
             break


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add functionality to parse and include usage data in Langfuse updates when `stream_options` has `include_usage`.
> 
>   - **Behavior**:
>     - Parse and include `usage` data in Langfuse updates if `stream_options` has `include_usage`.
>     - Update `usage` in `_create_langfuse_update()` and `_extract_streamed_openai_response()`.
>   - **Functions**:
>     - Modify `_create_langfuse_update()` to accept and update `usage`.
>     - Update `_extract_streamed_openai_response()` to extract `usage` from chunks.
>     - Adjust `_get_langfuse_data_from_default_response()` to handle `usage`.
>   - **Classes**:
>     - Update `_finalize()` in `LangfuseResponseGeneratorSync` and `LangfuseResponseGeneratorAsync` to include `usage` in updates.
>   - **Tests**:
>     - Update tests in `test_openai.py` to handle cases where `choices` might be empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 82aea3c16c7aa88604e16e3cf352555f0d4a5e91. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->