### PR TITLE
fix(serializer): reduce log level to debug on failed serialization

### DIFF
--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -138,7 +138,7 @@ class EventSerializer(JSONEncoder):
 
         except Exception as e:
             print(obj.__dict__)
-            logger.warning(
+            logger.debug(
                 f"Serialization failed for object of type {type(obj).__name__}",
                 exc_info=e,
             )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce log level from warning to debug for failed serialization in `default()` method of `EventSerializer` class in `serializer.py`.
> 
>   - **Logging**:
>     - Change log level from `warning` to `debug` for failed serialization in `default()` method of `EventSerializer` class in `serializer.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 25dd070e2ddb809b868385af6c482eff0926739d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->