### PR TITLE
[OpenAI - generation]: Support n parameter for multiple choices.

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -521,12 +521,21 @@ def _get_langfuse_data_from_default_response(resource: OpenAiDefinition, respons
     elif resource.type == "chat":
         choices = response.get("choices", [])
         if len(choices) > 0:
-            choice = choices[-1]
-            completion = (
-                _extract_chat_response(choice.message.__dict__)
-                if _is_openai_v1()
-                else choice.get("message", None)
-            )
+            # If multiple choices were generated, we'll show all of them in the UI as a list.
+            if len(choices) > 1:
+                completion = [
+                    _extract_chat_response(choice.message.__dict__)
+                    if _is_openai_v1()
+                    else choice.get("message", None)
+                    for choice in choices
+                ]
+            else:
+                choice = choices[0]
+                completion = (
+                    _extract_chat_response(choice.message.__dict__)
+                    if _is_openai_v1()
+                    else choice.get("message", None)
+                )
 
     usage = response.get("usage", None)
 

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -19,16 +19,16 @@ See docs for more details: https://langfuse.com/docs/integrations/openai
 
 import copy
 import logging
-from inspect import isclass
 import types
-
 from collections import defaultdict
 from dataclasses import dataclass
+from inspect import isclass
 from typing import List, Optional
 
 import openai.resources
 from openai._types import NotGiven
 from packaging.version import Version
+from pydantic import BaseModel
 from wrapt import wrap_function_wrapper
 
 from langfuse import Langfuse
@@ -36,7 +36,6 @@ from langfuse.client import StatefulGenerationClient
 from langfuse.decorators import langfuse_context
 from langfuse.utils import _get_timestamp
 from langfuse.utils.langfuse_singleton import LangfuseSingleton
-from pydantic import BaseModel
 
 try:
     import openai
@@ -344,12 +343,15 @@ def _get_langfuse_data_from_kwargs(
         else None
     )
 
+    parsed_n = kwargs.get("n", 1) if not isinstance(kwargs.get("n", 1), NotGiven) else 1
+
     modelParameters = {
         "temperature": parsed_temperature,
         "max_tokens": parsed_max_tokens,  # casing?
         "top_p": parsed_top_p,
         "frequency_penalty": parsed_frequency_penalty,
         "presence_penalty": parsed_presence_penalty,
+        "n": parsed_n,
     }
     if parsed_seed is not None:
         modelParameters["seed"] = parsed_seed


### PR DESCRIPTION
See issue here for discussion:

https://github.com/langfuse/langfuse/issues/4199
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `n` parameter in OpenAI generation to handle multiple choices in `openai.py`.
> 
>   - **Behavior**:
>     - Support for `n` parameter added in `_get_langfuse_data_from_kwargs()` to handle multiple choices.
>     - `_get_langfuse_data_from_default_response()` updated to process multiple choices and return them as a list if more than one choice is generated.
>   - **Misc**:
>     - Minor import reordering in `openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 6556d1e6ab46d4ef929ca48ff3dc08ff5e4b83db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->