### PR TITLE
fix(openai): pass parsed_n only if greater 1

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -351,8 +351,10 @@ def _get_langfuse_data_from_kwargs(
         "top_p": parsed_top_p,
         "frequency_penalty": parsed_frequency_penalty,
         "presence_penalty": parsed_presence_penalty,
-        "n": parsed_n,
     }
+    if parsed_n is not None and parsed_n > 1:
+        modelParameters["n"] = parsed_n
+
     if parsed_seed is not None:
         modelParameters["seed"] = parsed_seed
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `_get_langfuse_data_from_kwargs()` in `langfuse/openai.py` to only include `n` in `modelParameters` if greater than 1.
> 
>   - **Behavior**:
>     - In `langfuse/openai.py`, modify `_get_langfuse_data_from_kwargs()` to only include `n` in `modelParameters` if `parsed_n > 1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for d9aa5e679cb356dd36d1c5ae4d1ff02b643e03d5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->