### PR TITLE
fix(media): allow setting IO media via decorator update

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -446,13 +446,18 @@ class LangfuseDecorator:
             )
 
             end_time = observation_params["end_time"] or _get_timestamp()
-            raw_output = observation_params["output"] or (
-                result if result and capture_output else None
+
+            output = observation_params["output"] or (
+                # Serialize and deserialize to ensure proper JSON serialization.
+                # Objects are later serialized again so deserialization is necessary here to avoid unnecessary escaping of quotes.
+                json.loads(
+                    json.dumps(
+                        result if result and capture_output else None,
+                        cls=EventSerializer,
+                    )
+                )
             )
 
-            # Serialize and deserialize to ensure proper JSON serialization.
-            # Objects are later serialized again so deserialization is necessary here to avoid unnecessary escaping of quotes.
-            output = json.loads(json.dumps(raw_output, cls=EventSerializer))
             observation_params.update(end_time=end_time, output=output)
 
             if isinstance(observation, (StatefulSpanClient, StatefulGenerationClient)):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1473,6 +1473,16 @@ def test_media():
     @observe()
     def main():
         langfuse_context.update_current_trace(
+            input={
+                "context": {
+                    "nested": media,
+                },
+            },
+            output={
+                "context": {
+                    "nested": media,
+                },
+            },
             metadata={
                 "context": {
                     "nested": media,
@@ -1486,6 +1496,14 @@ def test_media():
 
     trace_data = get_api().trace.get(mock_trace_id)
 
+    assert (
+        "@@@langfuseMedia:type=application/pdf|id="
+        in trace_data.input["context"]["nested"]
+    )
+    assert (
+        "@@@langfuseMedia:type=application/pdf|id="
+        in trace_data.output["context"]["nested"]
+    )
     assert (
         "@@@langfuseMedia:type=application/pdf|id="
         in trace_data.metadata["context"]["nested"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes JSON serialization of output in `_handle_call_result` in `langfuse_decorator.py` and updates `test_media` in `test_decorators.py` to verify media handling.
> 
>   - **Behavior**:
>     - In `langfuse_decorator.py`, `_handle_call_result` now directly serializes `result` using `json.dumps` and `json.loads` with `EventSerializer` to ensure proper JSON serialization.
>   - **Tests**:
>     - In `test_decorators.py`, `test_media` is updated to check that media references in `input`, `output`, and `metadata` are correctly serialized and deserialized.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 1ad58c0d5e970ad25b6530d15d1284fa2b986f60. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->