### PR TITLE
Fix: Force a flush from the internal queue to the server at exit

### DIFF
--- a/langfuse/_task_manager/task_manager.py
+++ b/langfuse/_task_manager/task_manager.py
@@ -81,7 +81,7 @@ class TaskManager(object):
         self.init_resources()
 
         # cleans up when the python interpreter closes
-        atexit.register(self.join)
+        atexit.register(self.shutdown)
 
     def init_resources(self):
         for i in range(self._threads):


### PR DESCRIPTION
Force a flush from the internal queue to the server at exit.

This is necessary for properly sending events to langfuse when requests are happening in ephemeral / distributed processes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `atexit.register(self.join)` with `atexit.register(self.shutdown)` in `TaskManager` to ensure queue flush at exit.
> 
>   - **Behavior**:
>     - Replaces `atexit.register(self.join)` with `atexit.register(self.shutdown)` in `TaskManager.__init__()` to ensure a flush of the internal queue to the server at exit.
>   - **Functions**:
>     - `shutdown()` now handles both flushing and joining of consumer threads, ensuring clean shutdown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 22ec71750ef489c3012ccc235043b05a88c29a0d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->