### PR TITLE
fix: correctly track falsy output values

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -452,7 +452,7 @@ class LangfuseDecorator:
                 # Objects are later serialized again so deserialization is necessary here to avoid unnecessary escaping of quotes.
                 json.loads(
                     json.dumps(
-                        result if result and capture_output else None,
+                        result if result is not None and capture_output else None,
                         cls=EventSerializer,
                     )
                 )


### PR DESCRIPTION
Fixes [issue 4439](https://github.com/langfuse/langfuse/issues/4439) where falsy (`False`, `0`, etc.) values get tracked as `null`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue in `langfuse_decorator.py` where falsy values were incorrectly tracked as `null`.
> 
>   - **Behavior**:
>     - Fixes issue where falsy values (`False`, `0`, etc.) were incorrectly tracked as `null` in `_handle_call_result()` in `langfuse_decorator.py`.
>     - Now checks `result is not None` instead of `result` to correctly handle falsy values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 685271adca003e1edbf5dc9b258e4ab5717f2337. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->