### PR TITLE
fix(ci): lf server startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,10 @@ jobs:
           pnpm run db:migrate          
           pnpm run db:seed
           echo "::endgroup::"
+          rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false CLICKHOUSE_MIGRATION_URL=clickhouse://clickhouse:9000 LANGFUSE_ASYNC_INGESTION_PROCESSING=false LANGFUSE_ASYNC_CLICKHOUSE_INGESTION_PROCESSING=false docker compose -f docker-compose.v3preview.yml up -d
+          TELEMETRY_ENABLED=false CLICKHOUSE_CLUSTER_ENABLED=false LANGFUSE_ASYNC_INGESTION_PROCESSING=false LANGFUSE_ASYNC_CLICKHOUSE_INGESTION_PROCESSING=false LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false docker compose -f docker-compose.v3preview.yml up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -267,6 +267,8 @@ def test_linking_via_id_observation_arg_legacy():
 
         item.link(generation_id, run_name)
 
+    langfuse.flush()
+
     run = langfuse.get_dataset_run(dataset_name, run_name)
 
     assert run.name == run_name


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes Langfuse server startup in CI by adjusting environment variables and ensuring a clean environment, with a minor test adjustment for data flushing.
> 
>   - **CI Workflow**:
>     - In `.github/workflows/ci.yml`, added `CLICKHOUSE_CLUSTER_ENABLED=false`, `LANGFUSE_READ_FROM_POSTGRES_ONLY=true`, and `LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false` to the server startup command.
>     - Removed `.env` file after database seeding to ensure a clean environment.
>   - **Tests**:
>     - Added `langfuse.flush()` in `test_linking_via_id_observation_arg_legacy()` in `tests/test_datasets.py` to ensure data is flushed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 61b9316e5cbd1c8d21b1566ca3b97ca4edea555a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->