### PR TITLE
Add variable name extraction methods to prompt clients

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -1,7 +1,7 @@
 """@private"""
 
 from abc import ABC, abstractmethod
-from typing import Optional, TypedDict, Any, Dict, Union, List
+from typing import Optional, TypedDict, Any, Dict, Union, List, Tuple
 import re
 
 from langfuse.api.resources.commons.types.dataset import (
@@ -59,6 +59,69 @@ class ChatMessageVariables(TypedDict):
     variables: List[str]
 
 
+class TemplateParser:
+    OPENING = "{{"
+    CLOSING = "}}"
+
+    @staticmethod
+    def _parse_next_variable(
+        content: str, start_idx: int
+    ) -> Optional[Tuple[str, int, int]]:
+        """Returns (variable_name, start_pos, end_pos) or None if no variable found"""
+        var_start = content.find(TemplateParser.OPENING, start_idx)
+        if var_start == -1:
+            return None
+
+        var_end = content.find(TemplateParser.CLOSING, var_start)
+        if var_end == -1:
+            return None
+
+        variable_name = content[
+            var_start + len(TemplateParser.OPENING) : var_end
+        ].strip()
+        return (variable_name, var_start, var_end + len(TemplateParser.CLOSING))
+
+    @staticmethod
+    def find_variable_names(content: str) -> List[str]:
+        names = []
+        curr_idx = 0
+
+        while curr_idx < len(content):
+            result = TemplateParser._parse_next_variable(content, curr_idx)
+            if not result:
+                break
+            names.append(result[0])
+            curr_idx = result[2]
+
+        return names
+
+    @staticmethod
+    def compile_template(content: str, data: Dict[str, Any] = {}) -> str:
+        result_list = []
+        curr_idx = 0
+
+        while curr_idx < len(content):
+            result = TemplateParser._parse_next_variable(content, curr_idx)
+
+            if not result:
+                result_list.append(content[curr_idx:])
+                break
+
+            variable_name, var_start, var_end = result
+            result_list.append(content[curr_idx:var_start])
+
+            if variable_name in data:
+                result_list.append(
+                    str(data[variable_name]) if data[variable_name] is not None else ""
+                )
+            else:
+                result_list.append(content[var_start:var_end])
+
+            curr_idx = var_end
+
+        return "".join(result_list)
+
+
 class BasePromptClient(ABC):
     name: str
     version: int
@@ -79,6 +142,10 @@ class BasePromptClient(ABC):
         pass
 
     @abstractmethod
+    def variable_names(self, **kwargs) -> Union[List[str], List[ChatMessageVariables]]:
+        pass
+
+    @abstractmethod
     def __eq__(self, other):
         pass
 
@@ -90,69 +157,6 @@ class BasePromptClient(ABC):
     def _get_langchain_prompt_string(content: str):
         return re.sub(r"{{\s*(\w+)\s*}}", r"{\g<1>}", content)
 
-    @staticmethod
-    def _find_variable_names(content: str) -> List[str]:
-        opening = "{{"
-        closing = "}}"
-        curr_idx = 0
-        names = []
-
-        while curr_idx < len(content):
-            var_start = content.find(opening, curr_idx)
-            if var_start == -1:
-                break
-
-            var_end = content.find(closing, var_start)
-            if var_end == -1:
-                break
-
-            variable_name = content[var_start + len(opening) : var_end].strip()
-            names.append(variable_name)
-            curr_idx = var_end + len(closing)
-
-        return names
-
-    @staticmethod
-    def _compile_template_string(content: str, data: Dict[str, Any] = {}) -> str:
-        opening = "{{"
-        closing = "}}"
-
-        result_list = []
-        curr_idx = 0
-
-        while curr_idx < len(content):
-            # Find the next opening tag
-            var_start = content.find(opening, curr_idx)
-
-            if var_start == -1:
-                result_list.append(content[curr_idx:])
-                break
-
-            # Find the next closing tag
-            var_end = content.find(closing, var_start)
-
-            if var_end == -1:
-                result_list.append(content[curr_idx:])
-                break
-
-            # Append the content before the variable
-            result_list.append(content[curr_idx:var_start])
-
-            # Extract the variable name
-            variable_name = content[var_start + len(opening) : var_end].strip()
-
-            # Append the variable value
-            if variable_name in data:
-                result_list.append(
-                    str(data[variable_name]) if data[variable_name] is not None else ""
-                )
-            else:
-                result_list.append(content[var_start : var_end + len(closing)])
-
-            curr_idx = var_end + len(closing)
-
-        return "".join(result_list)
-
 
 class TextPromptClient(BasePromptClient):
     def __init__(self, prompt: Prompt_Text, is_fallback: bool = False):
@@ -160,7 +164,7 @@ class TextPromptClient(BasePromptClient):
         self.prompt = prompt.prompt
 
     def compile(self, **kwargs) -> str:
-        return self._compile_template_string(self.prompt, kwargs)
+        return TemplateParser.compile_template(self.prompt, kwargs)
 
     def variable_names(self) -> List[str]:
         """Find all the variable names in the prompt template
@@ -168,7 +172,7 @@ class TextPromptClient(BasePromptClient):
         Returns:
             List[str]: The list of variable names found in the prompt template
         """
-        return self._find_variable_names(self.prompt)
+        return TemplateParser.find_variable_names(self.prompt)
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):
@@ -195,7 +199,7 @@ class TextPromptClient(BasePromptClient):
             str: The string that can be plugged into Langchain's PromptTemplate.
         """
         prompt = (
-            self._compile_template_string(self.prompt, kwargs)
+            TemplateParser.compile_template(self.prompt, kwargs)
             if kwargs
             else self.prompt
         )
@@ -213,7 +217,9 @@ class ChatPromptClient(BasePromptClient):
     def compile(self, **kwargs) -> List[ChatMessageDict]:
         return [
             ChatMessageDict(
-                content=self._compile_template_string(chat_message["content"], kwargs),
+                content=TemplateParser.compile_template(
+                    chat_message["content"], kwargs
+                ),
                 role=chat_message["role"],
             )
             for chat_message in self.prompt
@@ -221,14 +227,13 @@ class ChatPromptClient(BasePromptClient):
 
     def variable_names(self) -> List[ChatMessageVariables]:
         """Find all the variable names in the chat prompt template per each chat message item
-
         Returns:
             List[ChatMessageVariables]: The list of variable names found in the prompt
                                         template coupled with the message role
         """
         return [
             ChatMessageVariables(
-                variables=self._find_variable_names(chat_message["content"]),
+                variables=TemplateParser.find_variable_names(chat_message["content"]),
                 role=chat_message["role"],
             )
             for chat_message in self.prompt
@@ -265,7 +270,7 @@ class ChatPromptClient(BasePromptClient):
             (
                 msg["role"],
                 self._get_langchain_prompt_string(
-                    self._compile_template_string(msg["content"], kwargs)
+                    TemplateParser.compile_template(msg["content"], kwargs)
                     if kwargs
                     else msg["content"]
                 ),

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -994,3 +994,106 @@ def test_do_not_link_observation_if_fallback():
 
     assert len(trace.observations) == 1
     assert trace.observations[0].prompt_id is None
+
+
+def test_variable_names_on_content_with_variable_names():
+    langfuse = Langfuse()
+
+    prompt_client = langfuse.create_prompt(
+        name="test_variable_names_1",
+        prompt="test prompt with var names {{ var1 }} {{ var2 }}",
+        is_active=True,
+        type="text",
+    )
+
+    second_prompt_client = langfuse.get_prompt("test_variable_names_1")
+
+    assert prompt_client.name == second_prompt_client.name
+    assert prompt_client.version == second_prompt_client.version
+    assert prompt_client.prompt == second_prompt_client.prompt
+    assert prompt_client.labels == ["production", "latest"]
+
+    var_names = second_prompt_client.variable_names()
+
+    assert var_names == ["var1", "var2"]
+
+
+def test_variable_names_on_content_with_no_variable_names():
+    langfuse = Langfuse()
+
+    prompt_client = langfuse.create_prompt(
+        name="test_variable_names_2",
+        prompt="test prompt with no var names",
+        is_active=True,
+        type="text",
+    )
+
+    second_prompt_client = langfuse.get_prompt("test_variable_names_2")
+
+    assert prompt_client.name == second_prompt_client.name
+    assert prompt_client.version == second_prompt_client.version
+    assert prompt_client.prompt == second_prompt_client.prompt
+    assert prompt_client.labels == ["production", "latest"]
+
+    var_names = second_prompt_client.variable_names()
+
+    assert var_names == []
+
+
+def test_variable_names_on_content_with_variable_names_chat_messages():
+    langfuse = Langfuse()
+
+    prompt_client = langfuse.create_prompt(
+        name="test_variable_names_3",
+        prompt=[
+            {
+                "role": "system",
+                "content": "test prompt with template vars {{ var1 }} {{ var2 }}",
+            },
+            {"role": "user", "content": "test prompt 2 with template vars {{ var3 }}"},
+        ],
+        is_active=True,
+        type="chat",
+    )
+
+    second_prompt_client = langfuse.get_prompt("test_variable_names_3")
+
+    assert prompt_client.name == second_prompt_client.name
+    assert prompt_client.version == second_prompt_client.version
+    assert prompt_client.prompt == second_prompt_client.prompt
+    assert prompt_client.labels == ["production", "latest"]
+
+    var_names = second_prompt_client.variable_names()
+
+    assert var_names == [
+        {"role": "system", "variables": ["var1", "var2"]},
+        {"role": "user", "variables": ["var3"]},
+    ]
+
+
+def test_variable_names_on_content_with_no_variable_names_chat_messages():
+    langfuse = Langfuse()
+
+    prompt_client = langfuse.create_prompt(
+        name="test_variable_names_4",
+        prompt=[
+            {"role": "system", "content": "test prompt with no template vars"},
+            {"role": "user", "content": "test prompt 2 with no template vars"},
+        ],
+        is_active=True,
+        type="chat",
+    )
+
+    second_prompt_client = langfuse.get_prompt("test_variable_names_4")
+
+    assert prompt_client.name == second_prompt_client.name
+    assert prompt_client.version == second_prompt_client.version
+    assert prompt_client.prompt == second_prompt_client.prompt
+    assert prompt_client.labels == ["production", "latest"]
+
+    var_names = second_prompt_client.variable_names()
+
+    assert var_names == [
+        {"role": "system", "variables": []},
+        {"role": "user", "variables": []},
+    ]

--- a/tests/test_prompt_compilation.py
+++ b/tests/test_prompt_compilation.py
@@ -1,16 +1,13 @@
 import pytest
 
-from langfuse.model import BasePromptClient
+from langfuse.model import TemplateParser
 
 
 def test_basic_replacement():
     template = "Hello, {{ name }}!"
     expected = "Hello, John!"
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"name": "John"})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"name": "John"}) == expected
 
 
 def test_multiple_replacements():
@@ -18,7 +15,7 @@ def test_multiple_replacements():
     expected = "Hello, John! Your balance is $100."
 
     assert (
-        BasePromptClient._compile_template_string(
+        TemplateParser.compile_template(
             template, {"greeting": "Hello", "name": "John", "balance": "$100"}
         )
         == expected
@@ -29,103 +26,77 @@ def test_no_replacements():
     template = "This is a test."
     expected = "This is a test."
 
-    assert BasePromptClient._compile_template_string(template) == expected
+    assert TemplateParser.compile_template(template) == expected
 
 
 def test_content_as_variable_name():
     template = "This is a {{content}}."
     expected = "This is a dog."
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"content": "dog"})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"content": "dog"}) == expected
 
 
 def test_unmatched_opening_tag():
     template = "Hello, {{name! Your balance is $100."
     expected = "Hello, {{name! Your balance is $100."
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"name": "John"})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"name": "John"}) == expected
 
 
 def test_unmatched_closing_tag():
     template = "Hello, {{name}}! Your balance is $100}}"
     expected = "Hello, John! Your balance is $100}}"
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"name": "John"})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"name": "John"}) == expected
 
 
 def test_missing_variable():
     template = "Hello, {{name}}!"
     expected = "Hello, {{name}}!"
 
-    assert BasePromptClient._compile_template_string(template) == expected
+    assert TemplateParser.compile_template(template) == expected
 
 
 def test_none_variable():
     template = "Hello, {{name}}!"
     expected = "Hello, !"
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"name": None}) == expected
-    )
+    assert TemplateParser.compile_template(template, {"name": None}) == expected
 
 
 def test_strip_whitespace():
     template = "Hello, {{    name }}!"
     expected = "Hello, John!"
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"name": "John"})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"name": "John"}) == expected
 
 
 def test_special_characters():
     template = "Symbols: {{symbol}}."
     expected = "Symbols: @$%^&*."
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"symbol": "@$%^&*"})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"symbol": "@$%^&*"}) == expected
 
 
 def test_multiple_templates_one_var():
     template = "{{a}} + {{a}} = {{b}}"
     expected = "1 + 1 = 2"
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"a": 1, "b": 2})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"a": 1, "b": 2}) == expected
 
 
 def test_unused_variable():
     template = "{{a}} + {{a}}"
     expected = "1 + 1"
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"a": 1, "b": 2})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"a": 1, "b": 2}) == expected
 
 
 def test_single_curly_braces():
     template = "{{a}} + {a} = {{b}"
     expected = "1 + {a} = {{b}"
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"a": 1, "b": 2})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"a": 1, "b": 2}) == expected
 
 
 def test_complex_json():
@@ -138,17 +109,14 @@ def test_complex_json():
     "key2": "val2",
     }}"""
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"a": 1, "b": 2})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"a": 1, "b": 2}) == expected
 
 
 def test_replacement_with_empty_string():
     template = "Hello, {{name}}!"
     expected = "Hello, !"
 
-    assert BasePromptClient._compile_template_string(template, {"name": ""}) == expected
+    assert TemplateParser.compile_template(template, {"name": ""}) == expected
 
 
 def test_variable_case_sensitivity():
@@ -156,9 +124,7 @@ def test_variable_case_sensitivity():
     expected = "John != john"
 
     assert (
-        BasePromptClient._compile_template_string(
-            template, {"Name": "John", "name": "john"}
-        )
+        TemplateParser.compile_template(template, {"Name": "John", "name": "john"})
         == expected
     )
 
@@ -167,10 +133,7 @@ def test_start_with_closing_braces():
     template = "}}"
     expected = "}}"
 
-    assert (
-        BasePromptClient._compile_template_string(template, {"name": "john"})
-        == expected
-    )
+    assert TemplateParser.compile_template(template, {"name": "john"}) == expected
 
 
 def test_unescaped_JSON_variable_value():
@@ -204,9 +167,7 @@ def test_unescaped_JSON_variable_value():
   }
 }"""
 
-    compiled = BasePromptClient._compile_template_string(
-        template, {"some_json": some_json}
-    )
+    compiled = TemplateParser.compile_template(template, {"some_json": some_json})
     assert compiled == some_json
 
 
@@ -219,4 +180,4 @@ def test_unescaped_JSON_variable_value():
     ],
 )
 def test_various_templates(template, data, expected):
-    assert BasePromptClient._compile_template_string(template, data) == expected
+    assert TemplateParser.compile_template(template, data) == expected


### PR DESCRIPTION
### Overview
PR introduces a `_find_variable_names` static method to extract variable names from content, similar to how [_compile_template_string static method.](https://github.com/langfuse/langfuse-python/blob/08298f6fb5b1c33905b5a786a4d1ab0de6cc2ce2/langfuse/model.py#L89) works.

### Usage

```python
text_prompt = TextPromptClient(
    name="example_text_prompt",
    version=1,
    prompt="{{ var1 }} {{ var2 }}",
)

text_variables = text_prompt.variable_names()
print(text_variables)
# > ['var1', 'var2']

chat_prompt = ChatPromptClient(
    name="example_chat_prompt",
    version=1,
    prompt=[
        {"role": "system", "content": "{{ system_var }}."},
        {"role": "user", "content": "{{ user_var }}."},
    ],
)

chat_variables = chat_prompt.variable_names()
print(chat_variables)
# > [{'role': 'system', 'variables': ['system_var']}, {'role': 'user', 'variables': ['user_var']}]
```
ref: https://github.com/orgs/langfuse/discussions/4414
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `_find_variable_names` method to extract variable names from prompt templates in `BasePromptClient`, with tests for text and chat prompts.
> 
>   - **Behavior**:
>     - Adds `_find_variable_names` static method in `BasePromptClient` to extract variable names from content.
>     - Implements `variable_names()` in `TextPromptClient` and `ChatPromptClient` to return variable names from prompts.
>   - **Tests**:
>     - Adds tests in `test_prompt.py` for `variable_names()` in both text and chat prompts, covering cases with and without variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 6cdbb708d4483d2c1dd6519f2a19931c96375e40. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->