### PR TITLE
chore(ci): update to v3 docker compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false LANGFUSE_CI_SYNC_PROCESSING_ENABELD=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
+          TELEMETRY_ENABLED=false LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false LANGFUSE_CI_SYNC_PROCESSING_ENABELD=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_RETURN_FROM_CLICKHOUSE=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
+          TELEMETRY_ENABLED=false LANGFUSE_CI_SYNC_PROCESSING_ENABELD=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,11 @@ jobs:
           cd ./langfuse-server
 
           echo "::group::Run langfuse server"
-          TELEMETRY_ENABLED=false docker compose -f docker-compose.v3preview.yml up -d postgres
+          TELEMETRY_ENABLED=false docker compose up -d postgres
           echo "::endgroup::"
 
           echo "::group::Logs from langfuse server"
-          TELEMETRY_ENABLED=false docker compose -f docker-compose.v3preview.yml logs
+          TELEMETRY_ENABLED=false docker compose logs
           echo "::endgroup::"
 
           echo "::group::Install dependencies (necessary to run seeder)"
@@ -90,7 +90,7 @@ jobs:
           rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false CLICKHOUSE_CLUSTER_ENABLED=false LANGFUSE_ASYNC_INGESTION_PROCESSING=false LANGFUSE_ASYNC_CLICKHOUSE_INGESTION_PROCESSING=false LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose -f docker-compose.v3preview.yml up -d
+          TELEMETRY_ENABLED=false LANGFUSE_CI_SYNC_PROCESSING_ENABELD=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_RETURN_FROM_CLICKHOUSE=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update CI workflow in `ci.yml` to use default Docker Compose file, removing version-specific flag.
> 
>   - **CI Workflow**:
>     - Update `ci.yml` to use default Docker Compose file, removing `-f docker-compose.v3preview.yml` flag.
>     - Affects `Run langfuse server`, `Logs from langfuse server`, and `Run server` steps by removing the flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 594d8091b3d01a019df7fe6db2d4feee85c54bdb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->