### PR TITLE
feat: use projectid when generating trace urls

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -314,6 +314,7 @@ class Langfuse(object):
         self.task_manager = TaskManager(**args)
 
         self.trace_id = None
+        self.project_id = None
 
         self.release = self._get_release_value(release)
 
@@ -333,7 +334,7 @@ class Langfuse(object):
 
     def get_trace_url(self) -> str:
         """Get the URL of the current trace to view it in the Langfuse UI."""
-        if not self.trace_id:
+        if not self.project_id:
             proj = self.client.projects.get()
             if not proj.data or not proj.data[0].id:
                 return f"{self.base_url}/trace/{self.trace_id}"

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -152,6 +152,9 @@ class Langfuse(object):
     host: str
     """Host of Langfuse API."""
 
+    project_id: Optional[str]
+    """Project ID of the Langfuse project associated with the API keys provided."""
+
     def __init__(
         self,
         public_key: Optional[str] = None,
@@ -330,7 +333,14 @@ class Langfuse(object):
 
     def get_trace_url(self) -> str:
         """Get the URL of the current trace to view it in the Langfuse UI."""
-        return f"{self.base_url}/trace/{self.trace_id}"
+        if not self.trace_id:
+            proj = self.client.projects.get()
+            if not proj.data or not proj.data[0].id:
+                return f"{self.base_url}/trace/{self.trace_id}"
+
+            self.project_id = proj.data[0].id
+
+        return f"{self.base_url}/{self.project_id}/traces/{self.trace_id}"
 
     def get_dataset(
         self, name: str, *, fetch_items_page_size: Optional[int] = 50

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -341,7 +341,7 @@ class Langfuse(object):
 
             self.project_id = proj.data[0].id
 
-        return f"{self.base_url}/{self.project_id}/traces/{self.trace_id}"
+        return f"{self.base_url}/project/{self.project_id}/traces/{self.trace_id}"
 
     def get_dataset(
         self, name: str, *, fetch_items_page_size: Optional[int] = 50

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -1536,3 +1536,17 @@ def test_mask_function():
     fetched_trace = api_wrapper.get_trace(trace.id)
     assert fetched_trace["input"] == "<fully masked due to failed mask function>"
     assert fetched_trace["output"] == "<fully masked due to failed mask function>"
+
+
+def test_generate_trace_id():
+    langfuse = Langfuse(debug=False)
+    trace_id = create_uuid()
+
+    trace = langfuse.trace(id=trace_id, name="test_trace")
+    langfuse.flush()
+
+    trace_url = langfuse.get_trace_url()
+    assert (
+        trace_url
+        == f"https://localhost:3000/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/traces/{trace_id}"
+    )

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -1548,5 +1548,5 @@ def test_generate_trace_id():
     trace_url = langfuse.get_trace_url()
     assert (
         trace_url
-        == f"http://localhost:3000/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/traces/{trace_id}"
+        == f"http://localhost:3000/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/traces/{trace_id}"
     )

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -1548,5 +1548,5 @@ def test_generate_trace_id():
     trace_url = langfuse.get_trace_url()
     assert (
         trace_url
-        == f"https://localhost:3000/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/traces/{trace_id}"
+        == f"http://localhost:3000/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/traces/{trace_id}"
     )

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -1542,7 +1542,7 @@ def test_generate_trace_id():
     langfuse = Langfuse(debug=False)
     trace_id = create_uuid()
 
-    trace = langfuse.trace(id=trace_id, name="test_trace")
+    langfuse.trace(id=trace_id, name="test_trace")
     langfuse.flush()
 
     trace_url = langfuse.get_trace_url()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> The PR updates the `Langfuse` class to include `project_id` in trace URLs and modifies tests to verify this behavior.
> 
>   - **Behavior**:
>     - Modify `get_trace_url()` in `Langfuse` class to include `project_id` in the URL if available.
>     - If `project_id` is not set, fetch `project_id` from the first project in `self.client.projects.get()`.
>   - **Attributes**:
>     - Add `project_id` attribute to `Langfuse` class to store the project ID associated with the API keys.
>   - **Tests**:
>     - Update `test_generate_trace_id()` in `test_core_sdk.py` to verify the trace URL includes `project_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for e255492df829e8d0a86ae0e2c42ef5416139327f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->