### PR TITLE
fix(client): pass timeout to FernLangfuse

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -284,6 +284,7 @@ class Langfuse(object):
             x_langfuse_sdk_version=version,
             x_langfuse_public_key=public_key,
             httpx_client=self.httpx_client,
+            timeout=timeout,
         )
 
         langfuse_client = LangfuseClient(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Passes `timeout` parameter to `FernLangfuse` in `langfuse/client.py` to handle API request timeouts.
> 
>   - **Behavior**:
>     - Passes `timeout` parameter to `FernLangfuse` in `langfuse/client.py` to handle API request timeouts.
>   - **Misc**:
>     - No other changes or refactoring were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 05d7da2157d2f5eceabd40c4b063c5d880fa8440. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->