### PR TITLE
fix(openai): pass metadata when model distillation feat is used

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -170,6 +170,11 @@ class OpenAiArgsExtractor:
         return {**self.args, **self.kwargs}
 
     def get_openai_args(self):
+        # If OpenAI model distillation is enabled, we need to add the metadata to the kwargs
+        # https://platform.openai.com/docs/guides/distillation
+        if self.kwargs.get("store", False):
+            self.kwargs["metadata"] = self.args.get("metadata", {})
+
         return self.kwargs
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add metadata to kwargs in `get_openai_args()` if `store` is True to support OpenAI model distillation.
> 
>   - **Behavior**:
>     - In `get_openai_args()` in `langfuse/openai.py`, add `metadata` to `kwargs` if `store` is `True`.
>     - This change supports OpenAI model distillation by including metadata when `store` is enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 258d18373d09f4a2c61b75497c7bdff326bb47dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->