### PR TITLE
Fix runnable name determination in LangChain integration

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -150,23 +150,35 @@ class LangchainCallbackHandler(
             self.updated_completion_start_time_memo.add(run_id)
 
     def get_langchain_run_name(self, serialized: Dict[str, Any], **kwargs: Any) -> str:
-        """Retrieves the 'run_name' for an entity based on Langchain convention, prioritizing the 'name'
-        key in 'kwargs' or falling back to the 'name' or 'id' in 'serialized'. Defaults to "<unknown>"
-        if none are available.
+        """Retrieve the name of a serialized LangChain runnable.
+
+        The prioritization for the determination of the run name is as follows:
+        - The value assigned to the "name" key in `kwargs`.
+        - The value assigned to the "name" key in `serialized`.
+        - The last entry of the value assigned to the "id" key in `serialized`.
+        - "<unknown>".
 
         Args:
-            serialized (Dict[str, Any]): A dictionary containing the entity's serialized data.
+            serialized (Dict[str, Any]): A dictionary containing the runnable's serialized data.
             **kwargs (Any): Additional keyword arguments, potentially including the 'name' override.
 
         Returns:
-            str: The determined Langchain run name for the entity.
+            str: The determined name of the Langchain runnable.
         """
-        # Check if 'name' is in kwargs and not None, otherwise use default fallback logic
         if "name" in kwargs and kwargs["name"] is not None:
             return kwargs["name"]
 
-        # Fallback to serialized 'name', 'id', or "<unknown>"
-        return serialized.get("name", serialized.get("id", ["<unknown>"])[-1])
+        try:
+            return serialized["name"]
+        except (KeyError, TypeError):
+            pass
+
+        try:
+            return serialized["id"][-1]
+        except (KeyError, TypeError):
+            pass
+
+        return "<unknown>"
 
     def on_retriever_error(
         self,

--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -149,7 +149,7 @@ class LangchainCallbackHandler(
 
             self.updated_completion_start_time_memo.add(run_id)
 
-    def get_langchain_run_name(self, serialized: Dict[str, Any], **kwargs: Any) -> str:
+    def get_langchain_run_name(self, serialized: Optional[Dict[str, Any]], **kwargs: Any) -> str:
         """Retrieve the name of a serialized LangChain runnable.
 
         The prioritization for the determination of the run name is as follows:
@@ -159,7 +159,7 @@ class LangchainCallbackHandler(
         - "<unknown>".
 
         Args:
-            serialized (Dict[str, Any]): A dictionary containing the runnable's serialized data.
+            serialized (Optional[Dict[str, Any]]): A dictionary containing the runnable's serialized data.
             **kwargs (Any): Additional keyword arguments, potentially including the 'name' override.
 
         Returns:
@@ -208,7 +208,7 @@ class LangchainCallbackHandler(
 
     def on_chain_start(
         self,
-        serialized: Dict[str, Any],
+        serialized: Optional[Dict[str, Any]],
         inputs: Dict[str, Any],
         *,
         run_id: UUID,
@@ -301,7 +301,7 @@ class LangchainCallbackHandler(
 
     def __generate_trace_and_parent(
         self,
-        serialized: Dict[str, Any],
+        serialized: Optional[Dict[str, Any]],
         inputs: Union[Dict[str, Any], List[str], str, None],
         *,
         run_id: UUID,
@@ -491,7 +491,7 @@ class LangchainCallbackHandler(
 
     def on_chat_model_start(
         self,
-        serialized: Dict[str, Any],
+        serialized: Optional[Dict[str, Any]],
         messages: List[List[BaseMessage]],
         *,
         run_id: UUID,
@@ -520,7 +520,7 @@ class LangchainCallbackHandler(
 
     def on_llm_start(
         self,
-        serialized: Dict[str, Any],
+        serialized: Optional[Dict[str, Any]],
         prompts: List[str],
         *,
         run_id: UUID,
@@ -547,7 +547,7 @@ class LangchainCallbackHandler(
 
     def on_tool_start(
         self,
-        serialized: Dict[str, Any],
+        serialized: Optional[Dict[str, Any]],
         input_str: str,
         *,
         run_id: UUID,
@@ -585,7 +585,7 @@ class LangchainCallbackHandler(
 
     def on_retriever_start(
         self,
-        serialized: Dict[str, Any],
+        serialized: Optional[Dict[str, Any]],
         query: str,
         *,
         run_id: UUID,
@@ -710,7 +710,7 @@ class LangchainCallbackHandler(
 
     def __on_llm_action(
         self,
-        serialized: Dict[str, Any],
+        serialized: Optional[Dict[str, Any]],
         run_id: UUID,
         prompts: List[str],
         parent_run_id: Optional[UUID] = None,

--- a/langfuse/extract_model.py
+++ b/langfuse/extract_model.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 
 def _extract_model_name(
-    serialized: Dict[str, Any],
+    serialized: Optional[Dict[str, Any]],
     **kwargs: Any,
 ):
     """Extracts the model name from the serialized or kwargs object. This is used to get the model names for Langfuse."""
@@ -106,12 +106,17 @@ def _extract_model_name(
 
 
 def _extract_model_from_repr_by_pattern(
-    id: str, serialized: dict, pattern: str, default: Optional[str] = None
+    id: str, serialized: Optional[Dict[str, Any]], pattern: str, default: Optional[str] = None
 ):
+    if serialized is None:
+        return None
+
     if serialized.get("id")[-1] == id:
         if serialized.get("repr"):
             extracted = _extract_model_with_regex(pattern, serialized.get("repr"))
             return extracted if extracted else default if default else None
+
+    return None
 
 
 def _extract_model_with_regex(pattern: str, text: str):
@@ -123,21 +128,27 @@ def _extract_model_with_regex(pattern: str, text: str):
 
 def _extract_model_by_path_for_id(
     id: str,
-    serialized: dict,
+    serialized: Optional[Dict[str, Any]],
     kwargs: dict,
     keys: List[str],
-    select_from: str = Literal["serialized", "kwargs"],
+    select_from: Literal["serialized", "kwargs"],
 ):
+    if serialized is None and select_from == "serialized":
+        return None
+
     if serialized.get("id")[-1] == id:
         return _extract_model_by_path(serialized, kwargs, keys, select_from)
 
 
 def _extract_model_by_path(
-    serialized: dict,
+    serialized: Optional[Dict[str, Any]],
     kwargs: dict,
     keys: List[str],
-    select_from: str = Literal["serialized", "kwargs"],
+    select_from: Literal["serialized", "kwargs"],
 ):
+    if serialized is None and select_from == "serialized":
+        return None
+
     current_obj = kwargs if select_from == "kwargs" else serialized
 
     for key in keys:


### PR DESCRIPTION
[Issue #3578](https://github.com/langfuse/langfuse/issues/3578):
LangChain made the `serialized` parameter of some callback handler methods optional. The case where `serialized` is `None` has to be considered in the determination of the name of a LangChain runnable.

Changes:
- The implementation of `langfuse.callback.langchain.LangchainCallbackHandler.get_langchain_run_name` is fixed.
- The docstring of `langfuse.callback.langchain.LangchainCallbackHandler.get_langchain_run_name` is slightly changed and adapted.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `get_langchain_run_name` in `langfuse/callback/langchain.py` to handle `None` for `serialized` and update docstring.
> 
>   - **Behavior**:
>     - Fix `get_langchain_run_name` in `langfuse/callback/langchain.py` to handle `None` for `serialized` parameter.
>     - Prioritizes `name` in `kwargs`, then `serialized`, and defaults to `"<unknown>"`.
>   - **Documentation**:
>     - Update docstring for `get_langchain_run_name` to reflect new prioritization logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 137bc0da697b66d8607df7571808d4e50eb26af1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->