### PR TITLE
Removed URL encoding of dataset_name

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -434,7 +434,7 @@ class Langfuse(object):
         try:
             self.log.debug("Getting dataset runs")
             return self.client.datasets.get_runs(
-                dataset_name=self._url_encode(dataset_name), page=page, limit=limit
+                dataset_name=dataset_name, page=page, limit=limit
             )
         except Exception as e:
             handle_fern_exception(e)
@@ -459,8 +459,8 @@ class Langfuse(object):
                 f"Getting dataset runs for dataset {dataset_name} and run {dataset_run_name}"
             )
             return self.client.datasets.get_run(
-                dataset_name=self._url_encode(dataset_name),
-                run_name=self._url_encode(dataset_run_name),
+                dataset_name=dataset_name,
+                run_name=dataset_run_name,
             )
         except Exception as e:
             handle_fern_exception(e)
@@ -1122,7 +1122,7 @@ class Langfuse(object):
             )
             def fetch_prompts():
                 return self.client.prompts.get(
-                    self._url_encode(name),
+                    name,
                     version=version,
                     label=label,
                     request_options={

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -364,7 +364,7 @@ class Langfuse(object):
             page = 1
             while True:
                 new_items = self.client.dataset_items.list(
-                    dataset_name=self._url_encode(name),
+                    dataset_name=name,
                     page=page,
                     limit=fetch_items_page_size,
                 )


### PR DESCRIPTION
I removed some encoding logic, so there will be no problem of Chinese error reporting. The following issue is that it uses other packages to call the API. The original SDK should be correct...

[Issues with querying Chinese datasets](https://github.com/langfuse/langfuse/issues/3714)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed URL encoding for `dataset_name` and `dataset_run_name` in `langfuse/client.py` to fix issues with non-ASCII characters.
> 
>   - **Behavior**:
>     - Removed URL encoding for `dataset_name` in `get_dataset()`, `get_dataset_runs()`, and `get_dataset_run()`.
>     - Removed URL encoding for `run_name` in `get_dataset_run()`.
>     - Removed URL encoding for `name` in `_fetch_prompt_and_update_cache()`.
>   - **Functions**:
>     - `_url_encode()` is no longer used in the above functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for b1afc368cd8146d9627df1a3a5ccc35ab9c5ceba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->