### PR TITLE
fix(media): add timeout to reference resolution

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -49,6 +49,7 @@ from langfuse.api.resources.trace.types.traces import Traces
 from langfuse.api.resources.utils.resources.pagination.types.meta_response import (
     MetaResponse,
 )
+from langfuse.api.resources.media import GetMediaResponse
 from langfuse.model import (
     ChatMessageDict,
     ChatPromptClient,
@@ -109,6 +110,13 @@ class FetchObservationResponse:
     """Response object for fetch_observation method."""
 
     data: Observation
+
+
+@dataclass
+class FetchMediaResponse:
+    """Response object for fetch_media method."""
+
+    data: GetMediaResponse
 
 
 @dataclass
@@ -885,19 +893,23 @@ class Langfuse(object):
             handle_fern_exception(e)
             raise e
 
-    def fetch_media(self, id: str):
+    def fetch_media(self, id: str) -> FetchMediaResponse:
         """Get media content by ID.
 
         Args:
             id: The identifier of the media content to fetch.
 
         Returns:
-            Media object
+            FetchMediaResponse: The media data of the given id on `data`.
 
         Raises:
-            Exception: If the media content could not be found or if an error occurred during the request.
+            Exception: If the media content with the given id could not be found within the authenticated project or if an error occurred during the request.
         """
-        return self.client.media.get(id)
+        try:
+            return FetchMediaResponse(data=self.client.media.get(id))
+        except Exception as e:
+            handle_fern_exception(e)
+            raise e
 
     def get_observation(
         self,

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -145,8 +145,8 @@ def test_replace_media_reference_string_in_object(tmp_path):
     )
 
     # Resolve media references back to base64
-    resolved_trace = LangfuseMedia.resolve_media_references(
-        obj=fetched_trace, langfuse_client=langfuse, resolve_with="base64_data_uri"
+    resolved_trace = langfuse.resolve_media_references(
+        obj=fetched_trace, resolve_with="base64_data_uri"
     )
 
     # Verify resolved base64 matches original


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add timeout to `resolve_media_references()` in `media.py` and improve error handling in `fetch_media()` in `client.py`.
> 
>   - **Behavior**:
>     - Add `content_fetch_timeout_seconds` parameter to `resolve_media_references()` in `media.py` for media content fetching timeout.
>     - Update `fetch_media()` in `client.py` to handle exceptions using `handle_fern_exception()`.
>   - **Classes**:
>     - Add `FetchMediaResponse` dataclass in `client.py` for `fetch_media()` method response.
>   - **Logging**:
>     - Change logging from `logging.warning` to `LangfuseMedia._log.warning` in `media.py` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for d1ad3c8b8dcc33a1c1e6b44294ad13766ed42446. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->