### PR TITLE
chore(ci): unquarantine media download test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://0.0.0.0:9090 LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
+          TELEMETRY_ENABLED=false LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT=http://localhost:9090 LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://localhost:9090 LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
+          TELEMETRY_ENABLED=false LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://0.0.0.0:9090 LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -110,8 +110,7 @@ def test_nonexistent_file():
     assert media._content_type is None
 
 
-@pytest.mark.skip(reason="Docker networking issues. Enable once LFE-3159 is fixed.")
-def test_replace_media_reference_string_in_object(tmp_path):
+def test_replace_media_reference_string_in_object():
     # Create test audio file
     audio_file = "static/joke_prompt.wav"
     with open(audio_file, "rb") as f:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Unquarantine `test_replace_media_reference_string_in_object()` and update Docker networking in CI configuration.
> 
>   - **Tests**:
>     - Unquarantine `test_replace_media_reference_string_in_object()` in `tests/test_media.py` by removing `@pytest.mark.skip`.
>   - **CI Configuration**:
>     - Change `LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT` from `http://localhost:9090` to `http://0.0.0.0:9090` in `.github/workflows/ci.yml` to address Docker networking issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for f57e5aae666a49ed3d05b741cd26315d3500a265. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->