### PR TITLE
chore(singleton): shutdown on reset

### DIFF
--- a/langfuse/utils/langfuse_singleton.py
+++ b/langfuse/utils/langfuse_singleton.py
@@ -72,6 +72,6 @@ class LangfuseSingleton:
     def reset(self) -> None:
         with self._lock:
             if self._langfuse:
-                self._langfuse.flush()
+                self._langfuse.shutdown()
 
             self._langfuse = None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `reset()` in `LangfuseSingleton` to call `shutdown()` instead of `flush()` on `_langfuse`.
> 
>   - **Behavior**:
>     - Change `reset()` method in `LangfuseSingleton` to call `shutdown()` instead of `flush()` on `_langfuse` instance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 9801902c1ca43c63aa8dcf1f391db7e6cd598a43. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->