### PR TITLE
fix: add default value in deprecated argument

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -3170,22 +3170,22 @@ class DatasetItemClient:
 
     def link(
         self,
-        trace_or_observation: typing.Union[StatefulClient, str, None],
         run_name: str,
         run_metadata: Optional[Any] = None,
         run_description: Optional[str] = None,
         trace_id: Optional[str] = None,
         observation_id: Optional[str] = None,
+        trace_or_observation: typing.Union[StatefulClient, str, None] = None,
     ):
         """Link the dataset item to observation within a specific dataset run. Creates a dataset run item.
 
         Args:
-            trace_or_observation (Union[StatefulClient, str, None]): The trace or observation object to link. Deprecated: can also be an observation ID.
             run_name (str): The name of the dataset run.
             run_metadata (Optional[Any]): Additional metadata to include in dataset run.
             run_description (Optional[str]): Description of the dataset run.
             trace_id (Optional[str]): The trace ID to link to the dataset item. Set trace_or_observation to None if trace_id is provided.
             observation_id (Optional[str]): The observation ID to link to the dataset item (optional). Set trace_or_observation to None if trace_id is provided.
+            trace_or_observation (Union[StatefulClient, str, None]): The trace or observation object to link. Deprecated: can also be an observation ID.
         """
         parsed_trace_id: str = None
         parsed_observation_id: str = None


### PR DESCRIPTION
Added a default value of None to the `trace_or_observation` for optional usage.
It prevents potential confusion for users by clearly indicating the optional and deprecated parameter.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added default value `None` to `trace_or_observation` parameter in `link()` function in `client.py` to indicate it is optional and deprecated.
> 
>   - **Function Signature**:
>     - In `link()` function in `client.py`, added default value `None` to `trace_or_observation` parameter.
>     - This change clarifies that `trace_or_observation` is optional and deprecated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 391d2840201adbfe6a9ed9c272a51c65ee33fa91. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->