### PR TITLE
fix(dataset+decorator): item observer with top-level generation

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -364,7 +364,9 @@ class LangfuseDecorator:
                 # Create wrapper trace if generation is top-level
                 # Do not add wrapper trace to stack, as it does not have a corresponding end that will pop it off again
                 trace = self.client_instance.trace(
-                    id=id, name=name, start_time=start_time
+                    id=_root_trace_id_context.get() or id,
+                    name=name,
+                    start_time=start_time,
                 )
                 self._set_root_trace_id(trace.id)
 

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,6 +1,8 @@
-import pytest
 import threading
 from unittest.mock import patch
+
+import pytest
+
 from langfuse.utils.langfuse_singleton import LangfuseSingleton
 
 
@@ -64,4 +66,4 @@ def test_reset_functionality(mock_langfuse):
 
     assert instance._langfuse is None
 
-    mock_langfuse.return_value.flush.assert_called_once()
+    mock_langfuse.return_value.shutdown.assert_called_once()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes trace ID assignment for top-level generations in `langfuse_decorator.py` and updates a test in `test_singleton.py`.
> 
>   - **Behavior**:
>     - Fixes trace ID assignment in `_prepare_call()` in `langfuse_decorator.py` to use `_root_trace_id_context.get()` or `id` for top-level generations.
>   - **Tests**:
>     - Update `test_reset_functionality()` in `test_singleton.py` to assert `shutdown` is called instead of `flush`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 07b0870a7f12a3f8cfcc9f7db460924a97d98813. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->