### PR TITLE
fix: add project_id to urls returned by langfuse_context.get_current_trace_url

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -711,7 +711,12 @@ class LangfuseDecorator:
             if not trace_id:
                 raise ValueError("No trace found in the current context")
 
-            return f"{self.client_instance.client._client_wrapper._base_url}/trace/{trace_id}"
+            project_id = self.client_instance._get_project_id()
+
+            if not project_id:
+                return f"{self.client_instance.client._client_wrapper._base_url}/trace/{trace_id}"
+
+            return f"{self.client_instance.client._client_wrapper._base_url}/project/{project_id}/traces/{trace_id}"
 
         except Exception as e:
             self._log.error(f"Failed to get current trace URL: {e}")

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -1538,6 +1538,13 @@ def test_mask_function():
     assert fetched_trace["output"] == "<fully masked due to failed mask function>"
 
 
+def test_get_project_id():
+    langfuse = Langfuse(debug=False)
+    res = langfuse._get_project_id()
+    assert res is not None
+    assert res == "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a"
+
+
 def test_generate_trace_id():
     langfuse = Langfuse(debug=False)
     trace_id = create_uuid()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -608,6 +608,30 @@ def test_get_current_ids():
     )
 
 
+def test_get_current_trace_url():
+    mock_trace_id = create_uuid()
+
+    @observe()
+    def level_3_function():
+        return langfuse_context.get_current_trace_url()
+
+    @observe()
+    def level_2_function():
+        return level_3_function()
+
+    @observe()
+    def level_1_function(*args, **kwargs):
+        return level_2_function()
+
+    result = level_1_function(
+        *mock_args, **mock_kwargs, langfuse_observation_id=mock_trace_id
+    )
+    langfuse_context.flush()
+
+    expected_url = f"http://localhost:3000/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/traces/{mock_trace_id}"
+    assert result == expected_url
+
+
 def test_scoring_observations():
     mock_name = "test_scoring_observations"
     mock_trace_id = create_uuid()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `project_id` to trace URLs in `Langfuse` and `langfuse_context` to ensure correct project context in Langfuse UI.
> 
>   - **Behavior**:
>     - Add `project_id` to URLs in `Langfuse.get_trace_url()` and `langfuse_context.get_current_trace_url()`.
>     - Introduce `_get_project_id()` in `Langfuse` to fetch and cache project ID.
>   - **Tests**:
>     - Add `test_get_project_id()` in `test_core_sdk.py` to verify project ID retrieval.
>     - Add `test_get_current_trace_url()` in `test_decorators.py` to check URL format with project ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 0dae388d78e717ec09d1d484ac75d19aa717e88d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->