### PR TITLE
fix(serializer): remove unnecessary log statement

### DIFF
--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -149,7 +149,6 @@ class EventSerializer(JSONEncoder):
                 return f"<{type(obj).__name__}>"
 
         except Exception as e:
-            print(obj.__dict__)
             logger.debug(
                 f"Serialization failed for object of type {type(obj).__name__}",
                 exc_info=e,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unnecessary `print` statement from `default()` method in `EventSerializer` class in `serializer.py`.
> 
>   - **Code Cleanup**:
>     - Removed unnecessary `print(obj.__dict__)` statement from `default()` method in `EventSerializer` class in `serializer.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 81a857d120cbef5927fb4a45b13ff7fb04f31004. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->