### PR TITLE
fix(client): link dataset item positional arg

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -3178,22 +3178,22 @@ class DatasetItemClient:
 
     def link(
         self,
+        trace_or_observation: typing.Union[StatefulClient, str, None],
         run_name: str,
         run_metadata: Optional[Any] = None,
         run_description: Optional[str] = None,
         trace_id: Optional[str] = None,
         observation_id: Optional[str] = None,
-        trace_or_observation: typing.Union[StatefulClient, str, None] = None,
     ):
         """Link the dataset item to observation within a specific dataset run. Creates a dataset run item.
 
         Args:
+            trace_or_observation (Union[StatefulClient, str, None]): The trace or observation object to link. Deprecated: can also be an observation ID.
             run_name (str): The name of the dataset run.
             run_metadata (Optional[Any]): Additional metadata to include in dataset run.
             run_description (Optional[str]): Description of the dataset run.
             trace_id (Optional[str]): The trace ID to link to the dataset item. Set trace_or_observation to None if trace_id is provided.
             observation_id (Optional[str]): The observation ID to link to the dataset item (optional). Set trace_or_observation to None if trace_id is provided.
-            trace_or_observation (Union[StatefulClient, str, None]): The trace or observation object to link. Deprecated: can also be an observation ID.
         """
         parsed_trace_id: str = None
         parsed_observation_id: str = None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder `trace_or_observation` parameter in `link()` in `langfuse/client.py` to be the first positional argument.
> 
>   - **Function Signature Change**:
>     - Reorder `trace_or_observation` parameter in `link()` in `langfuse/client.py` to be the first positional argument.
>     - Update docstring in `link()` to reflect the new parameter order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 5e5e46f878a0cd5311c3838734d2025e7684a20e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->