### PR TITLE
fix(model): update start_date type to datetime and make unit optional

### DIFF
--- a/langfuse/api/resources/commons/types/model.py
+++ b/langfuse/api/resources/commons/types/model.py
@@ -24,14 +24,14 @@ class Model(pydantic_v1.BaseModel):
     Regex pattern which matches this model definition to generation.model. Useful in case of fine-tuned models. If you want to exact match, use `(?i)^modelname$`
     """
 
-    start_date: typing.Optional[dt.date] = pydantic_v1.Field(
+    start_date: typing.Optional[dt.datetime] = pydantic_v1.Field(
         alias="startDate", default=None
     )
     """
     Apply only to generations which are newer than this ISO date.
     """
 
-    unit: ModelUsageUnit = pydantic_v1.Field()
+    unit: typing.Optional[ModelUsageUnit] = pydantic_v1.Field(default=None)
     """
     Unit used by this model.
     """


### PR DESCRIPTION
Fixes langfuse/langfuse#4973


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `start_date` to `datetime` and make `unit` optional in `Model` class.
> 
>   - **Model Class Updates**:
>     - Change `start_date` type from `date` to `datetime` in `Model` class.
>     - Make `unit` field optional in `Model` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 6c6cee3f423d6fb7ce799a6150d73320725e0ac9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->