### PR TITLE
fix(api-models): usage unit to optional

### DIFF
--- a/langfuse/api/resources/commons/types/model.py
+++ b/langfuse/api/resources/commons/types/model.py
@@ -31,7 +31,7 @@ class Model(pydantic_v1.BaseModel):
     Apply only to generations which are newer than this ISO date.
     """
 
-    unit: ModelUsageUnit = pydantic_v1.Field()
+    unit: typing.Optional[ModelUsageUnit] = pydantic_v1.Field(default=None)
     """
     Unit used by this model.
     """


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `unit` field optional in `Model` class in `model.py`.
> 
>   - **Models**:
>     - In `model.py`, changed `unit` field in `Model` class to be optional with a default of `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 9ebeaf10fb4b2039d2b18d12877c85bbe8b6724e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->