### PR TITLE
perf(decorator): remove get_caller_module

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -676,25 +676,11 @@ class LangfuseDecorator:
             return context_trace_id
 
         stack = _observation_stack_context.get()
-        should_log_warning = self._get_caller_module_name() != "langfuse.openai"
 
         if not stack:
-            if should_log_warning:
-                self._log.warning("No trace found in the current context")
-
             return None
 
         return stack[0].id
-
-    def _get_caller_module_name(self):
-        try:
-            caller_module = inspect.getmodule(inspect.stack()[2][0])
-        except Exception as e:
-            self._log.warning(f"Failed to get caller module: {e}")
-
-            return None
-
-        return caller_module.__name__ if caller_module else None
 
     def get_current_trace_url(self) -> Optional[str]:
         """Retrieve the URL of the current trace in context.
@@ -738,12 +724,8 @@ class LangfuseDecorator:
             - If called at the top level of a trace, it will return the trace ID.
         """
         stack = _observation_stack_context.get()
-        should_log_warning = self._get_caller_module_name() != "langfuse.openai"
 
         if not stack:
-            if should_log_warning:
-                self._log.warning("No observation found in the current context")
-
             return None
 
         return stack[-1].id


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `get_caller_module_name()` and related warning logs from `LangfuseDecorator` to simplify code.
> 
>   - **Behavior**:
>     - Removed `get_caller_module_name()` method from `LangfuseDecorator` class.
>     - Removed warning logs in `get_current_trace_id()` and `get_current_observation_id()` when no trace or observation is found.
>   - **Code Simplification**:
>     - Eliminated unnecessary module inspection and exception handling related to caller module identification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 275e2c304346602ddd7eb1cad7a9791a2e5df90e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->