### PR TITLE
fix(langchain): mitigate missing run_id on_chain_error

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -481,16 +481,21 @@ class LangchainCallbackHandler(
     ) -> None:
         try:
             self._log_debug_event("on_chain_error", run_id, parent_run_id, error=error)
-            self.runs[run_id] = self.runs[run_id].end(
-                level="ERROR",
-                status_message=str(error),
-                version=self.version,
-                input=kwargs.get("inputs"),
-            )
+            if run_id in self.runs:
+                self.runs[run_id] = self.runs[run_id].end(
+                    level="ERROR",
+                    status_message=str(error),
+                    version=self.version,
+                    input=kwargs.get("inputs"),
+                )
 
-            self._update_trace_and_remove_state(
-                run_id, parent_run_id, error, input=kwargs.get("inputs")
-            )
+                self._update_trace_and_remove_state(
+                    run_id, parent_run_id, error, input=kwargs.get("inputs")
+                )
+            else:
+                self.log.warning(
+                    f"Run ID {run_id} already popped from run map. Could not update run with error message"
+                )
 
         except Exception as e:
             self.log.exception(e)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a check in `on_chain_error()` in `langchain.py` to log a warning if `run_id` is missing, preventing errors from accessing non-existent runs.
> 
>   - **Behavior**:
>     - In `on_chain_error()` in `langchain.py`, added check for `run_id` existence in `self.runs` before ending run and updating trace.
>     - Logs a warning if `run_id` is not found, instead of raising an exception.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 1f1478430d460d0d3a7c4126b2cbc51ad415722d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->