### PR TITLE
fix(langchain): add run_id check on_llm_error

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -897,13 +897,14 @@ class LangchainCallbackHandler(
     ) -> Any:
         try:
             self._log_debug_event("on_llm_error", run_id, parent_run_id, error=error)
-            self.runs[run_id] = self.runs[run_id].end(
-                status_message=str(error),
-                level="ERROR",
-                version=self.version,
-                input=kwargs.get("inputs"),
-            )
-            self._update_trace_and_remove_state(run_id, parent_run_id, error)
+            if run_id in self.runs:
+                self.runs[run_id] = self.runs[run_id].end(
+                    status_message=str(error),
+                    level="ERROR",
+                    version=self.version,
+                    input=kwargs.get("inputs"),
+                )
+                self._update_trace_and_remove_state(run_id, parent_run_id, error)
 
         except Exception as e:
             self.log.exception(e)

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -1500,6 +1500,7 @@ def test_mask_function():
     langfuse = Langfuse(debug=True, mask=faulty_mask_func)
 
     trace = langfuse.trace(name="test_trace", input={"sensitive": "data"})
+    sleep(0.1)
     trace.update(output={"more": "sensitive"})
     langfuse.flush()
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -438,6 +438,7 @@ def test_llama_index_dataset():
     assert run.name == run_name
     assert len(run.dataset_run_items) == 1
     assert run.dataset_run_items[0].dataset_run_id == run.id
+    time.sleep(1)
 
     trace = get_api().trace.get(handler.get_trace_id())
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `run_id` existence check in `on_llm_error` and adjust sleep timing in tests for async operations.
> 
>   - **Behavior**:
>     - Add `run_id` existence check in `on_llm_error` in `langchain.py` to prevent errors when `run_id` is not found.
>   - **Tests**:
>     - Add `sleep(0.1)` in `test_core_sdk.py` and `sleep(1)` in `test_datasets.py` to ensure proper timing for asynchronous operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for f05dcecc02c7864921b980f909f75198f2882ac6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->