### PR TITLE
Do another update call when we're updating an ended trace in update_current_trace

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -792,19 +792,21 @@ class LangfuseDecorator:
             if v is not None
         }
 
+        trace_already_ended = trace_id not in _observation_params_context.get()
         # metadata and tags are merged server side. Send separate update event to avoid merging them SDK side
         server_merged_attributes = ["metadata", "tags"]
-        if any(attribute in params_to_update for attribute in server_merged_attributes):
+        if trace_already_ended or any(attribute in params_to_update for attribute in server_merged_attributes):
             self.client_instance.trace(
                 id=trace_id,
                 **{
                     k: v
                     for k, v in params_to_update.items()
-                    if k in server_merged_attributes
+                    if k in server_merged_attributes or trace_already_ended
                 },
             )
 
-        _observation_params_context.get()[trace_id].update(params_to_update)
+        if not trace_already_ended:
+            _observation_params_context.get()[trace_id].update(params_to_update)
 
     def update_current_observation(
         self,


### PR DESCRIPTION

It's possible to have observations that 'outlive' their trace, for example when returning a StreamingResponse in FastAPI.

Currently, calling update_current_trace in such cases only worked for the server_merged_attributes. We can work around this by sending the metadata in .trace() instead of storing it in the context.

Failing use case:
```python
from fastapi import router, Response, StreamingResponse

@router.post("/test")
@observe()
async def test() -> Response:
    response_gen = test_inner()
    return StreamingResponse(response_gen, media_type="text/event-stream")

@observe()
async def test_inner() -> AsyncGenerator[str, None]:
    langfuse_context.update_current_trace(
        user_id="unauth"
    )
    yield "test"

```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `update_current_trace` to handle updates for ended traces by checking `trace_already_ended` and sending appropriate update events.
> 
>   - **Behavior**:
>     - In `update_current_trace`, handle cases where traces end before observations by checking `trace_already_ended`.
>     - If `trace_already_ended`, send an update event for all attributes, not just `server_merged_attributes`.
>     - Avoid updating `_observation_params_context` if `trace_already_ended`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for a8f972e3c9e0a18fdc49a3d0aab07a5a276d8465. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Modified the update_current_trace function to handle cases where observations outlive their traces, particularly in FastAPI StreamingResponse scenarios.

- Added check in `langfuse/decorators/langfuse_decorator.py` to detect if trace has already ended by checking observation params context
- Modified behavior to send all parameters directly to server instead of storing in context when trace has ended
- Fixed issue with metadata and tags not being properly updated for ended traces
- Added test coverage in `tests/test_decorators.py` to verify async streaming scenarios where observations continue after trace completion



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->