### PR TITLE
fix(media): retry requests upload errors

### DIFF
--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -285,7 +285,7 @@ class MediaManager:
                     raise e
             except requests.exceptions.RequestException as e:
                 if (
-                    e.response
+                    e.response is not None
                     and hasattr(e.response, "status_code")
                     and (e.response.status_code >= 500 or e.response.status_code == 429)
                 ):

--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -270,29 +270,29 @@ class MediaManager:
     def _request_with_backoff(
         self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
     ) -> T:
-        @backoff.on_exception(
-            backoff.expo, Exception, max_tries=self._max_retries, logger=None
-        )
-        def execute_task_with_backoff() -> T:
-            try:
-                return func(*args, **kwargs)
-            except ApiError as e:
-                if (
+        def _should_give_up(e: Exception) -> bool:
+            if isinstance(e, ApiError):
+                return (
                     e.status_code is not None
                     and 400 <= e.status_code < 500
-                    and (e.status_code) != 429
-                ):
-                    raise e
-            except requests.exceptions.RequestException as e:
-                if (
+                    and e.status_code != 429
+                )
+            if isinstance(e, requests.exceptions.RequestException):
+                return (
                     e.response is not None
-                    and hasattr(e.response, "status_code")
-                    and (e.response.status_code >= 500 or e.response.status_code == 429)
-                ):
-                    raise
+                    and e.response.status_code < 500
+                    and e.response.status_code != 429
+                )
+            return False
 
-                raise e  # break retries for all other status codes
-
-            raise Exception("Failed to execute task")
+        @backoff.on_exception(
+            backoff.expo,
+            Exception,
+            max_tries=self._max_retries,
+            giveup=_should_give_up,
+            logger=None,
+        )
+        def execute_task_with_backoff() -> T:
+            return func(*args, **kwargs)
 
         return execute_task_with_backoff()

--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -283,8 +283,15 @@ class MediaManager:
                     and (e.status_code) != 429
                 ):
                     raise e
-            except Exception as e:
-                raise e
+            except requests.exceptions.RequestException as e:
+                if (
+                    e.response
+                    and hasattr(e.response, "status_code")
+                    and (e.response.status_code >= 500 or e.response.status_code == 429)
+                ):
+                    raise
+
+                raise e  # break retries for all other status codes
 
             raise Exception("Failed to execute task")
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves media upload retry logic in `media_manager.py` by refining error handling to target server errors and rate limiting while avoiding retries for client errors.
> 
>   - **Error Handling**:
>     - Refined `_request_with_backoff` in `media_manager.py` to handle `requests.exceptions.RequestException`.
>     - Added retry logic for 5xx server errors and 429 rate limiting.
>     - Removed generic `Exception` catch to avoid retries on 4xx client errors (except 429).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for aeb5e61ea353ff72f164678ec24b331cd9b2cb26. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Improved error handling for media upload retries in the Python SDK, focusing on more precise retry logic for server errors and rate limiting.

- Modified `_request_with_backoff` in `langfuse/_task_manager/media_manager.py` to specifically handle `requests.exceptions.RequestException`
- Added targeted retry logic for 5xx server errors and 429 rate limiting responses
- Removed generic Exception catch to prevent unnecessary retries on client errors
- Improved error handling precision for media upload failures



<!-- /greptile_comment -->