### PR TITLE
feat(client): add async api client

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -71,7 +71,7 @@ except ImportError:
     import pydantic  # type: ignore
 
 from langfuse._task_manager.task_manager import TaskManager
-from langfuse.api.client import FernLangfuse
+from langfuse.api.client import AsyncFernLangfuse, FernLangfuse
 from langfuse.environment import get_common_release_envs
 from langfuse.logging import clean_logger
 from langfuse.media import LangfuseMedia
@@ -299,9 +299,19 @@ class Langfuse(object):
             httpx_client=self.httpx_client,
             timeout=timeout,
         )
+        async_public_api_client = AsyncFernLangfuse(
+            base_url=self.base_url,
+            username=public_key,
+            password=secret_key,
+            x_langfuse_sdk_name="python",
+            x_langfuse_sdk_version=version,
+            x_langfuse_public_key=public_key,
+            timeout=timeout,
+        )
 
         self.api = public_api_client
         self.client = public_api_client  # legacy, to be removed in next major release
+        self.async_api = async_public_api_client
 
         langfuse_client = LangfuseClient(
             public_key=public_key,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add asynchronous API client `AsyncFernLangfuse` to `Langfuse` class for non-blocking operations.
> 
>   - **Behavior**:
>     - Add `AsyncFernLangfuse` to `Langfuse` class in `client.py` for asynchronous API operations.
>     - Initialize `async_public_api_client` in `Langfuse.__init__()` and assign to `self.async_api`.
>   - **Imports**:
>     - Import `AsyncFernLangfuse` from `langfuse.api.client`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for a1f7f1479a4f65f1450bc6f271ba1614492452da. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added asynchronous API client capabilities to the Langfuse Python SDK while maintaining backward compatibility with the existing synchronous client.

- Added `AsyncFernLangfuse` client in `/langfuse/client.py` for non-blocking API calls
- Preserved existing synchronous client as `self.api` and legacy `self.client` for backward compatibility
- Added `self.async_api` property to access new async client functionality
- Maintained consistent timeout and authentication handling between sync/async clients



<!-- /greptile_comment -->