### PR TITLE
fix(serializer): NaN handling

### DIFF
--- a/langfuse/serializer.py
+++ b/langfuse/serializer.py
@@ -1,6 +1,7 @@
 """@private"""
 
 import enum
+import math
 from asyncio import Queue
 from collections.abc import Sequence
 from dataclasses import asdict, is_dataclass
@@ -53,6 +54,9 @@ class EventSerializer(JSONEncoder):
             # If so, convert it to a Python scalar using the item() method
             if np is not None and isinstance(obj, np.generic):
                 return obj.item()
+
+            if isinstance(obj, float) and math.isnan(obj):
+                return None
 
             if isinstance(obj, (Exception, KeyboardInterrupt)):
                 return f"{type(obj).__name__}: {str(obj)}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle NaN values in `EventSerializer.default` by returning `None`.
> 
>   - **Behavior**:
>     - In `EventSerializer.default`, handle `float` NaN values by returning `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 85bc08616e6c886ccc726514b7e23e118837c71e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Adds handling for NaN (Not a Number) float values in the EventSerializer class by converting them to None during JSON serialization, since NaN values are not valid in JSON.

- Added NaN handling in `langfuse/serializer.py` by converting NaN floats to None
- Missing test coverage for the new NaN handling functionality should be added to validate behavior
- Consider adding docstring or comment explaining the NaN to None conversion rationale



<!-- /greptile_comment -->