### PR TITLE
feat(prompts): add commit message to prompt creation

### DIFF
--- a/langfuse/api/reference.md
+++ b/langfuse/api/reference.md
@@ -2614,6 +2614,7 @@ client.prompts.create(
         config={"key": "value"},
         labels=["string"],
         tags=["string"],
+        commit_message="string",
     ),
 )
 

--- a/langfuse/api/resources/prompts/client.py
+++ b/langfuse/api/resources/prompts/client.py
@@ -267,6 +267,7 @@ class PromptsClient:
                 config={"key": "value"},
                 labels=["string"],
                 tags=["string"],
+                commit_message="string",
             ),
         )
         """
@@ -568,6 +569,7 @@ class AsyncPromptsClient:
                     config={"key": "value"},
                     labels=["string"],
                     tags=["string"],
+                    commit_message="string",
                 ),
             )
 

--- a/langfuse/api/resources/prompts/types/base_prompt.py
+++ b/langfuse/api/resources/prompts/types/base_prompt.py
@@ -21,6 +21,13 @@ class BasePrompt(pydantic_v1.BaseModel):
     List of tags. Used to filter via UI and API. The same across versions of a prompt.
     """
 
+    commit_message: typing.Optional[str] = pydantic_v1.Field(
+        alias="commitMessage", default=None
+    )
+    """
+    Commit message for this prompt version.
+    """
+
     def json(self, **kwargs: typing.Any) -> str:
         kwargs_with_defaults: typing.Any = {
             "by_alias": True,
@@ -49,5 +56,7 @@ class BasePrompt(pydantic_v1.BaseModel):
     class Config:
         frozen = True
         smart_union = True
+        allow_population_by_field_name = True
+        populate_by_name = True
         extra = pydantic_v1.Extra.allow
         json_encoders = {dt.datetime: serialize_datetime}

--- a/langfuse/api/resources/prompts/types/create_chat_prompt_request.py
+++ b/langfuse/api/resources/prompts/types/create_chat_prompt_request.py
@@ -22,6 +22,13 @@ class CreateChatPromptRequest(pydantic_v1.BaseModel):
     List of tags to apply to all versions of this prompt.
     """
 
+    commit_message: typing.Optional[str] = pydantic_v1.Field(
+        alias="commitMessage", default=None
+    )
+    """
+    Commit message for this prompt version.
+    """
+
     def json(self, **kwargs: typing.Any) -> str:
         kwargs_with_defaults: typing.Any = {
             "by_alias": True,
@@ -50,5 +57,7 @@ class CreateChatPromptRequest(pydantic_v1.BaseModel):
     class Config:
         frozen = True
         smart_union = True
+        allow_population_by_field_name = True
+        populate_by_name = True
         extra = pydantic_v1.Extra.allow
         json_encoders = {dt.datetime: serialize_datetime}

--- a/langfuse/api/resources/prompts/types/create_prompt_request.py
+++ b/langfuse/api/resources/prompts/types/create_prompt_request.py
@@ -16,6 +16,9 @@ class CreatePromptRequest_Chat(pydantic_v1.BaseModel):
     config: typing.Optional[typing.Any] = None
     labels: typing.Optional[typing.List[str]] = None
     tags: typing.Optional[typing.List[str]] = None
+    commit_message: typing.Optional[str] = pydantic_v1.Field(
+        alias="commitMessage", default=None
+    )
     type: typing.Literal["chat"] = "chat"
 
     def json(self, **kwargs: typing.Any) -> str:
@@ -46,6 +49,8 @@ class CreatePromptRequest_Chat(pydantic_v1.BaseModel):
     class Config:
         frozen = True
         smart_union = True
+        allow_population_by_field_name = True
+        populate_by_name = True
         extra = pydantic_v1.Extra.allow
         json_encoders = {dt.datetime: serialize_datetime}
 
@@ -56,6 +61,9 @@ class CreatePromptRequest_Text(pydantic_v1.BaseModel):
     config: typing.Optional[typing.Any] = None
     labels: typing.Optional[typing.List[str]] = None
     tags: typing.Optional[typing.List[str]] = None
+    commit_message: typing.Optional[str] = pydantic_v1.Field(
+        alias="commitMessage", default=None
+    )
     type: typing.Literal["text"] = "text"
 
     def json(self, **kwargs: typing.Any) -> str:
@@ -86,6 +94,8 @@ class CreatePromptRequest_Text(pydantic_v1.BaseModel):
     class Config:
         frozen = True
         smart_union = True
+        allow_population_by_field_name = True
+        populate_by_name = True
         extra = pydantic_v1.Extra.allow
         json_encoders = {dt.datetime: serialize_datetime}
 

--- a/langfuse/api/resources/prompts/types/create_text_prompt_request.py
+++ b/langfuse/api/resources/prompts/types/create_text_prompt_request.py
@@ -21,6 +21,13 @@ class CreateTextPromptRequest(pydantic_v1.BaseModel):
     List of tags to apply to all versions of this prompt.
     """
 
+    commit_message: typing.Optional[str] = pydantic_v1.Field(
+        alias="commitMessage", default=None
+    )
+    """
+    Commit message for this prompt version.
+    """
+
     def json(self, **kwargs: typing.Any) -> str:
         kwargs_with_defaults: typing.Any = {
             "by_alias": True,
@@ -49,5 +56,7 @@ class CreateTextPromptRequest(pydantic_v1.BaseModel):
     class Config:
         frozen = True
         smart_union = True
+        allow_population_by_field_name = True
+        populate_by_name = True
         extra = pydantic_v1.Extra.allow
         json_encoders = {dt.datetime: serialize_datetime}

--- a/langfuse/api/resources/prompts/types/prompt.py
+++ b/langfuse/api/resources/prompts/types/prompt.py
@@ -17,6 +17,9 @@ class Prompt_Chat(pydantic_v1.BaseModel):
     config: typing.Any
     labels: typing.List[str]
     tags: typing.List[str]
+    commit_message: typing.Optional[str] = pydantic_v1.Field(
+        alias="commitMessage", default=None
+    )
     type: typing.Literal["chat"] = "chat"
 
     def json(self, **kwargs: typing.Any) -> str:
@@ -47,6 +50,8 @@ class Prompt_Chat(pydantic_v1.BaseModel):
     class Config:
         frozen = True
         smart_union = True
+        allow_population_by_field_name = True
+        populate_by_name = True
         extra = pydantic_v1.Extra.allow
         json_encoders = {dt.datetime: serialize_datetime}
 
@@ -58,6 +63,9 @@ class Prompt_Text(pydantic_v1.BaseModel):
     config: typing.Any
     labels: typing.List[str]
     tags: typing.List[str]
+    commit_message: typing.Optional[str] = pydantic_v1.Field(
+        alias="commitMessage", default=None
+    )
     type: typing.Literal["text"] = "text"
 
     def json(self, **kwargs: typing.Any) -> str:
@@ -88,6 +96,8 @@ class Prompt_Text(pydantic_v1.BaseModel):
     class Config:
         frozen = True
         smart_union = True
+        allow_population_by_field_name = True
+        populate_by_name = True
         extra = pydantic_v1.Extra.allow
         json_encoders = {dt.datetime: serialize_datetime}
 

--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -1282,6 +1282,7 @@ class Langfuse(object):
         tags: Optional[List[str]] = None,
         type: Optional[Literal["chat"]],
         config: Optional[Any] = None,
+        commit_message: Optional[str] = None,
     ) -> ChatPromptClient: ...
 
     @overload
@@ -1295,6 +1296,7 @@ class Langfuse(object):
         tags: Optional[List[str]] = None,
         type: Optional[Literal["text"]] = "text",
         config: Optional[Any] = None,
+        commit_message: Optional[str] = None,
     ) -> TextPromptClient: ...
 
     def create_prompt(
@@ -1307,6 +1309,7 @@ class Langfuse(object):
         tags: Optional[List[str]] = None,
         type: Optional[Literal["chat", "text"]] = "text",
         config: Optional[Any] = None,
+        commit_message: Optional[str] = None,
     ) -> PromptClient:
         """Create a new prompt in Langfuse.
 
@@ -1318,6 +1321,7 @@ class Langfuse(object):
             tags: The tags of the prompt. Defaults to None. Will be applied to all versions of the prompt.
             config: Additional structured data to be saved with the prompt. Defaults to None.
             type: The type of the prompt to be created. "chat" vs. "text". Defaults to "text".
+            commit_message: Optional string describing the change.
 
         Returns:
             TextPromptClient: The prompt if type argument is 'text'.
@@ -1345,6 +1349,7 @@ class Langfuse(object):
                     labels=labels,
                     tags=tags,
                     config=config or {},
+                    commitMessage=commit_message,
                     type="chat",
                 )
                 server_prompt = self.client.prompts.create(request=request)
@@ -1360,6 +1365,7 @@ class Langfuse(object):
                 labels=labels,
                 tags=tags,
                 config=config or {},
+                commitMessage=commit_message,
                 type="text",
             )
 

--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -1,8 +1,8 @@
 """@private"""
 
-from abc import ABC, abstractmethod
-from typing import Optional, TypedDict, Any, Dict, Union, List, Tuple
 import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 from langfuse.api.resources.commons.types.dataset import (
     Dataset,  # noqa: F401
@@ -36,7 +36,7 @@ from langfuse.api.resources.dataset_run_items.types.create_dataset_run_item_requ
 from langfuse.api.resources.datasets.types.create_dataset_request import (  # noqa: F401
     CreateDatasetRequest,
 )
-from langfuse.api.resources.prompts import Prompt, ChatMessage, Prompt_Chat, Prompt_Text
+from langfuse.api.resources.prompts import ChatMessage, Prompt, Prompt_Chat, Prompt_Text
 
 
 class ModelUsage(TypedDict):
@@ -126,6 +126,7 @@ class BasePromptClient(ABC):
     config: Dict[str, Any]
     labels: List[str]
     tags: List[str]
+    commit_message: Optional[str]
 
     def __init__(self, prompt: Prompt, is_fallback: bool = False):
         self.name = prompt.name
@@ -133,6 +134,7 @@ class BasePromptClient(ABC):
         self.config = prompt.config
         self.labels = prompt.labels
         self.tags = prompt.tags
+        self.commit_message = prompt.commit_message
         self.is_fallback = is_fallback
 
     @abstractmethod

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,13 +1,14 @@
 from time import sleep
-import pytest
 from unittest.mock import Mock, patch
 
 import openai
+import pytest
+
+from langfuse.api.resources.prompts import Prompt_Chat, Prompt_Text
 from langfuse.client import Langfuse
-from langfuse.prompt_cache import PromptCacheItem, DEFAULT_PROMPT_CACHE_TTL_SECONDS
+from langfuse.model import ChatPromptClient, TextPromptClient
+from langfuse.prompt_cache import DEFAULT_PROMPT_CACHE_TTL_SECONDS, PromptCacheItem
 from tests.utils import create_uuid, get_api
-from langfuse.api.resources.prompts import Prompt_Text, Prompt_Chat
-from langfuse.model import TextPromptClient, ChatPromptClient
 
 
 def test_create_prompt():
@@ -17,6 +18,7 @@ def test_create_prompt():
         name=prompt_name,
         prompt="test prompt",
         labels=["production"],
+        commit_message="initial commit",
     )
 
     second_prompt_client = langfuse.get_prompt(prompt_name)
@@ -25,6 +27,7 @@ def test_create_prompt():
     assert prompt_client.version == second_prompt_client.version
     assert prompt_client.prompt == second_prompt_client.prompt
     assert prompt_client.config == second_prompt_client.config
+    assert prompt_client.commit_message == second_prompt_client.commit_message
     assert prompt_client.config == {}
 
 
@@ -79,6 +82,7 @@ def test_create_chat_prompt():
         labels=["production"],
         tags=["test"],
         type="chat",
+        commit_message="initial commit",
     )
 
     second_prompt_client = langfuse.get_prompt(prompt_name, type="chat")
@@ -97,6 +101,7 @@ def test_create_chat_prompt():
     assert prompt_client.config == second_prompt_client.config
     assert prompt_client.labels == ["production", "latest"]
     assert prompt_client.tags == second_prompt_client.tags
+    assert prompt_client.commit_message == second_prompt_client.commit_message
     assert prompt_client.config == {}
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `commit_message` parameter to prompt creation in Langfuse, updating models, client methods, and tests.
> 
>   - **Behavior**:
>     - Added `commit_message` parameter to prompt creation functions in `client.py` and `async_client.py`.
>     - Updated `create_prompt()` in `Langfuse` to accept `commit_message`.
>   - **Models**:
>     - Added `commit_message` field to `BasePrompt`, `CreateChatPromptRequest`, `CreatePromptRequest_Chat`, `CreatePromptRequest_Text`, `CreateTextPromptRequest`, `Prompt_Chat`, and `Prompt_Text`.
>   - **Tests**:
>     - Updated `test_prompt.py` to include tests for `commit_message` in prompt creation and retrieval.
>   - **Documentation**:
>     - Updated `reference.md` to reflect the new `commit_message` parameter in prompt creation examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 9c577ccfb34e2cb19b74bcbe1edc7e9649656d23. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR adds support for commit messages in prompt creation across the Langfuse Python SDK, enabling better version tracking and documentation of prompt changes.

- Added optional `commit_message` field (aliased as 'commitMessage') to all prompt-related classes in `/langfuse/api/resources/prompts/types/`
- Updated `BasePromptClient` in `model.py` to handle commit messages in prompt initialization
- Added proper Pydantic configuration with `allow_population_by_field_name` and `populate_by_name` for field aliasing support
- Added comprehensive test coverage in `test_prompt.py` for commit message functionality
- Maintained backward compatibility by making the commit message parameter optional throughout the implementation



<!-- /greptile_comment -->