### PR TITLE
fix(openai): implement aclose on async stream responses

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -977,3 +977,10 @@ class LangfuseResponseGeneratorAsync:
         Automatically called if the response body is read to completion.
         """
         await self.response.close()
+
+    async def aclose(self) -> None:
+        """Close the response and release the connection.
+
+        Automatically called if the response body is read to completion.
+        """
+        await self.response.aclose()


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added `aclose` method to `LangfuseResponseGeneratorAsync` class to properly handle cleanup of async streaming responses from OpenAI.

- Added `aclose` method in `/langfuse/openai.py` to mirror existing `close` functionality for async streams
- Method delegates to underlying response's `aclose` method to ensure proper resource cleanup
- Maintains compatibility with OpenAI's async streaming API patterns
- Addresses potential resource leaks when using async streaming responses



<!-- /greptile_comment -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `aclose()` method to `LangfuseResponseGeneratorAsync` in `langfuse/openai.py` for closing async stream responses.
> 
>   - **Behavior**:
>     - Adds `aclose()` method to `LangfuseResponseGeneratorAsync` in `langfuse/openai.py` to close async stream responses.
>     - Ensures connection release when response body is read to completion in async contexts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for beb1d98f34302b3f229f9588b17ed82f967ed911. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->