### PR TITLE
Resolve runtime error with openai extension when metadata is missing

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -172,7 +172,7 @@ class OpenAiArgsExtractor:
         # If OpenAI model distillation is enabled, we need to add the metadata to the kwargs
         # https://platform.openai.com/docs/guides/distillation
         if self.kwargs.get("store", False):
-            self.kwargs["metadata"] = self.args.get("metadata", {})
+            self.kwargs["metadata"] = {} if self.args.get("metadata") is None else self.args["metadata"]
 
             # OpenAI does not support non-string type values in metadata when using
             # model distillation feature

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -172,7 +172,7 @@ class OpenAiArgsExtractor:
         # If OpenAI model distillation is enabled, we need to add the metadata to the kwargs
         # https://platform.openai.com/docs/guides/distillation
         if self.kwargs.get("store", False):
-            self.kwargs["metadata"] = {} if self.args.get("metadata") is None else self.args["metadata"]
+            self.kwargs["metadata"] = {} if self.args.get("metadata", None) is None else self.args["metadata"]
 
             # OpenAI does not support non-string type values in metadata when using
             # model distillation feature


### PR DESCRIPTION
When store=True is passed to the chat.completions.create API, the metadata parameter is optional. In this case, the updated line of code fails to set an empty dictionary to self.kwargs["metadata"]. More specifically, `self.args["metadata"]` is `None` in the scenario. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes runtime error in `get_openai_args()` in `openai.py` by setting `metadata` to `{}` when `None` and `store=True`.
> 
>   - **Behavior**:
>     - Fixes runtime error in `get_openai_args()` in `openai.py` when `metadata` is `None` and `store=True` is passed to `chat.completions.create` API.
>     - Sets `self.kwargs["metadata"]` to `{}` if `self.args["metadata"]` is `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 3ec9248f9df68c6b5c37578df0320a32c4030e4d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixed a runtime error in the OpenAI extension where missing metadata caused failures when using the chat.completions.create API with store=True.

- Modified `langfuse/openai.py` to handle None metadata by defaulting to empty dictionary
- Ensures compatibility with OpenAI's model distillation feature which requires metadata to be a dictionary
- Prevents runtime errors when optional metadata parameter is not provided
- Maintains proper tracing functionality for OpenAI API calls



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->