### PR TITLE
feat: Add functionality to pass custom serializer

### DIFF
--- a/langfuse/decorators/langfuse_decorator.py
+++ b/langfuse/decorators/langfuse_decorator.py
@@ -40,7 +40,6 @@ from langfuse.client import (
     StatefulTraceClient,
     StateType,
 )
-from langfuse.serializer import EventSerializer
 from langfuse.types import ObservationParams, SpanLevel
 from langfuse.utils import _get_timestamp
 from langfuse.utils.error_logging import catch_and_log_errors
@@ -182,8 +181,8 @@ class LangfuseDecorator:
             )
 
         """
-        If the decorator is called without arguments, return the decorator function itself. 
-        This allows the decorator to be used with or without arguments. 
+        If the decorator is called without arguments, return the decorator function itself.
+        This allows the decorator to be used with or without arguments.
         Python calls the decorator function with the decorated function as an argument when the decorator is used without arguments.
         """
         if func is None:
@@ -401,7 +400,7 @@ class LangfuseDecorator:
 
         # Serialize and deserialize to ensure proper JSON serialization.
         # Objects are later serialized again so deserialization is necessary here to avoid unnecessary escaping of quotes.
-        return json.loads(json.dumps(raw_input, cls=EventSerializer))
+        return json.loads(json.dumps(raw_input, cls=self.client_instance._serializer))
 
     def _finalize_call(
         self,
@@ -457,7 +456,7 @@ class LangfuseDecorator:
                 json.loads(
                     json.dumps(
                         result if result is not None and capture_output else None,
-                        cls=EventSerializer,
+                        cls=self.client_instance._serializer,
                     )
                 )
             )

--- a/langfuse/request.py
+++ b/langfuse/request.py
@@ -7,7 +7,7 @@ from typing import Any, List, Union
 
 import httpx
 
-from langfuse.serializer import EventSerializer
+from langfuse.serializer import BaseEventSerializer
 
 
 class LangfuseClient:
@@ -17,6 +17,7 @@ class LangfuseClient:
     _version: str
     _timeout: int
     _session: httpx.Client
+    _serializer: BaseEventSerializer
 
     def __init__(
         self,
@@ -60,7 +61,7 @@ class LangfuseClient:
         """Post the `kwargs` to the API"""
         log = logging.getLogger("langfuse")
         url = self._remove_trailing_slash(self._base_url) + "/api/public/ingestion"
-        data = json.dumps(kwargs, cls=EventSerializer)
+        data = json.dumps(kwargs, cls=self._serializer)
         log.debug("making request: %s to %s", data, url)
         headers = self.generate_headers()
         res = self._session.post(

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
+import pandas as pd
 import pytest
 from pydantic import BaseModel
 
@@ -196,8 +197,6 @@ def test_numpy_float32():
 
 
 def test_custom_serializer():
-    import pandas as pd
-
     class CustomSerializer(BaseEventSerializer):
         def default(self, obj: Any) -> Any:
             if isinstance(obj, pd.DataFrame):


### PR DESCRIPTION
Introduce BaseEventSerializer as an abstract base class

This refactoring introduces a new BaseEventSerializer abstract base class that provides a common interface and shared functionality for JSON serialization. Key changes include:
- Creating an abstract base class with common serialization methods
- Moving shared serialization logic to the base class
- Adding an abstract default method for object serialization
- Implementing safe integer range checking
- Updating references in other files to use the new base class

- [ ] documentation with explanation
- [ ] JS SDK

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Introduces a new BaseEventSerializer abstract base class to standardize JSON serialization across the codebase, enabling custom serializer implementations while maintaining existing functionality.

- Missing initialization of `_serializer` field in `LangfuseClient.__init__` in `langfuse/request.py` needs to be added to prevent runtime errors
- `IngestionConsumer._serializer` defined as class variable could cause shared state issues with multiple instances
- No constructor parameter in `IngestionConsumer` to configure custom serializers without subclassing
- Added abstract `BaseEventSerializer` with required `default()` method in `langfuse/serializer.py`
- Test case for custom serializer extension needs pandas dependency added to test requirements



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->