### PR TITLE
fix(langchain): cached token usage

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -1106,7 +1106,7 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]):
                 usage_model[f"output_{key}"] = value
 
                 if "output" in usage_model:
-                    usage_model["output"] -= value
+                    usage_model["output"] = max(0, usage_model["output"] - value)
 
     return usage_model if usage_model else None
 

--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -1096,11 +1096,17 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]):
             for key, value in input_token_details.items():
                 usage_model[f"input_{key}"] = value
 
+                if "input" in usage_model:
+                    usage_model["input"] -= value
+
         if "output_token_details" in usage_model:
             output_token_details = usage_model.pop("output_token_details", {})
 
             for key, value in output_token_details.items():
                 usage_model[f"output_{key}"] = value
+
+                if "output" in usage_model:
+                    usage_model["output"] -= value
 
     return usage_model if usage_model else None
 

--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -1097,7 +1097,7 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]):
                 usage_model[f"input_{key}"] = value
 
                 if "input" in usage_model:
-                    usage_model["input"] -= value
+                    usage_model["input"] = max(0, usage_model["input"] - value)
 
         if "output_token_details" in usage_model:
             output_token_details = usage_model.pop("output_token_details", {})

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -2336,7 +2336,7 @@ def test_cached_token_usage():
     chat = ChatOpenAI(model="gpt-4o-mini")
     chain = prompt | chat
     handler = CallbackHandler()
-    config = {"callbacks": [handler]} if handler else {}
+    config = {"callbacks": [handler]}
 
     chain.invoke({"test_param": "in a funny way"}, config)
 

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -2318,3 +2318,49 @@ def test_langgraph():
             assert observation.level == "DEFAULT"
 
     assert hidden_count > 0
+
+
+def test_cached_token_usage():
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                (
+                    "This is a test prompt to reproduce the issue. "
+                    "The prompt needs 1024 tokens to enable cache." * 100
+                ),
+            ),
+            ("user", "Reply to this message {test_param}."),
+        ]
+    )
+    chat = ChatOpenAI(model="gpt-4o-mini")
+    chain = prompt | chat
+    handler = CallbackHandler()
+    config = {"callbacks": [handler]} if handler else {}
+
+    chain.invoke({"test_param": "in a funny way"}, config)
+
+    # invoke again to force cached token usage
+    chain.invoke({"test_param": "in a funny way"}, config)
+
+    handler.flush()
+
+    trace = get_api().trace.get(handler.get_trace_id())
+
+    generation = next((o for o in trace.observations if o.type == "GENERATION"))
+
+    assert generation.usage_details["input_cache_read"] > 0
+    assert (
+        generation.usage_details["input"]
+        + generation.usage_details["input_cache_read"]
+        + generation.usage_details["output"]
+        == generation.usage_details["total"]
+    )
+
+    assert generation.cost_details["input_cache_read"] > 0
+    assert (
+        generation.cost_details["input"]
+        + generation.cost_details["input_cache_read"]
+        + generation.cost_details["output"]
+        == generation.cost_details["total"]
+    )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes token usage calculation in `langchain.py` and adds a test for cached token usage handling.
> 
>   - **Behavior**:
>     - Fixes token usage calculation in `_parse_usage_model()` in `langchain.py` by adjusting `input` and `output` values when `input_token_details` and `output_token_details` are present.
>     - Adds a test `test_cached_token_usage()` in `test_langchain.py` to verify correct handling of cached token usage.
>   - **Misc**:
>     - No changes to constants or logging.
>     - No renames or typo fixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 331cc4392d39bd8726ad9de299cb14ab560c1c9f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR fixes token usage calculations in the Langchain integration by correctly handling cached tokens and preventing double-counting when detailed token breakdowns are present.

- Modified `langfuse/callback/langchain.py` to subtract input/output token details from totals in `_parse_usage_model` function to prevent double-counting
- Added comprehensive test case in `tests/test_langchain.py` to verify token usage accuracy with caching enabled
- Ensures proper tracking of `input_cache_read` values and accurate cost calculations when using cached tokens



<!-- /greptile_comment -->