### PR TITLE
fix(openai): apply langfuse_mask

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -172,7 +172,9 @@ class OpenAiArgsExtractor:
         # If OpenAI model distillation is enabled, we need to add the metadata to the kwargs
         # https://platform.openai.com/docs/guides/distillation
         if self.kwargs.get("store", False):
-            self.kwargs["metadata"] = {} if self.args.get("metadata", None) is None else self.args["metadata"]
+            self.kwargs["metadata"] = (
+                {} if self.args.get("metadata", None) is None else self.args["metadata"]
+            )
 
             # OpenAI does not support non-string type values in metadata when using
             # model distillation feature
@@ -771,6 +773,7 @@ class OpenAILangfuse:
             enabled=openai.langfuse_enabled,
             sdk_integration="openai",
             sample_rate=openai.langfuse_sample_rate,
+            mask=openai.langfuse_mask,
         )
 
         return self._langfuse


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `langfuse_mask` configuration to `OpenAILangfuse.initialize()` in `openai.py`.
> 
>   - **Behavior**:
>     - Add `mask=openai.langfuse_mask` to `OpenAILangfuse.initialize()` in `openai.py` to support `langfuse_mask` configuration.
>   - **Misc**:
>     - Minor formatting change in `get_openai_args()` in `openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 5248943ccd4863ef88ea76a794679a2a016aace6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added support for the `langfuse_mask` parameter in the OpenAI integration, allowing sensitive data masking when using the Langfuse drop-in replacement for OpenAI.

- Added `mask=openai.langfuse_mask` parameter to `LangfuseSingleton().get()` in `langfuse/openai.py` to properly pass masking configuration
- Improved code formatting in `get_openai_args()` method for better readability
- Ensures consistent masking behavior between direct Langfuse SDK usage and the OpenAI integration
- Maintains backward compatibility with existing code using the OpenAI integration



<!-- /greptile_comment -->