### PR TITLE
chore: bump jinja2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1819,13 +1819,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
-    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This appears to be a dependency update PR to bump the Jinja2 package version in the langfuse-python repository.

- Without access to the specific changes in requirements files or dependency specifications, I cannot provide detailed comments about version changes or potential impacts

Note: For dependency updates, it would be helpful to see the actual version changes and any related modifications to provide a more meaningful review.



<!-- /greptile_comment -->