### PR TITLE
fix(openai): remove unused openai.resources import

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 from inspect import isclass
 from typing import Optional
 
-import openai.resources
 from openai._types import NotGiven
 from packaging.version import Version
 from pydantic import BaseModel


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused import `openai.resources` from `openai.py`.
> 
>   - **Code Cleanup**:
>     - Removed unused import `openai.resources` from `openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 737903c7f0139853812e1c88e1468fda93ab583a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Removed unused `openai.resources` import from `langfuse/openai.py`, cleaning up the codebase while maintaining full OpenAI integration functionality.

- Removed `import openai.resources` as it's not directly used - specific imports like `openai.resources.chat.completions` are used instead in `OPENAI_METHODS_V1`
- No functional changes as the OpenAI integration continues to work through explicit resource imports



<!-- /greptile_comment -->