### PR TITLE
chore: fix typo in function name

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -863,7 +863,7 @@ class LangchainCallbackHandler(
                 extracted_response = (
                     self._convert_message_to_dict(generation.message)
                     if isinstance(generation, ChatGeneration)
-                    else _extract_raw_esponse(generation)
+                    else _extract_raw_response(generation)
                 )
 
                 llm_usage = _parse_usage(response)
@@ -1029,7 +1029,7 @@ class LangchainCallbackHandler(
         )
 
 
-def _extract_raw_esponse(last_response):
+def _extract_raw_response(last_response):
     """Extract the response from the last response of the LLM call."""
     # We return the text of the response if not empty
     if last_response.text is not None and last_response.text.strip() != "":


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo by renaming `_extract_raw_esponse` to `_extract_raw_response` in `langfuse/callback/langchain.py`.
> 
>   - **Function Renames**:
>     - Rename `_extract_raw_esponse` to `_extract_raw_response` in `langfuse/callback/langchain.py`.
>   - **Function Usage**:
>     - Update usage of `_extract_raw_response` in `on_llm_end` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 77c9718b564c9a9ae0e3c560479b0f7b32d96d77. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixed a typo in the function name from '_extract_raw_esponse' to '_extract_raw_response' in the Langchain callback handler, ensuring consistent naming for the response extraction function.

- Renamed function in `langfuse/callback/langchain.py` from '_extract_raw_esponse' to '_extract_raw_response' for better code clarity
- Function is used within 'on_llm_end' method to extract text responses from LLM calls



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->