### PR TITLE
feat(client): allow more params.(like langfuse_version, etc)

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -253,16 +253,17 @@ class LangchainCallbackHandler(
             # Update trace-level information if this is a root-level chain (no parent)
             # and if tags or metadata are provided
             if parent_run_id is None and (tags or metadata):
+                update_dict = {
+                    "tags": [str(tag) for tag in tags] if tags else None,
+                    "session_id": None,
+                    "user_id": None,
+                }
+                if metadata:
+                    for key, value in metadata.items():
+                        if key.startswith("langfuse_"):
+                            update_dict[key[len("langfuse_"):]] = value
                 self.trace_updates[run_id].update(
-                    {
-                        "tags": [str(tag) for tag in tags] if tags else None,
-                        "session_id": metadata.get("langfuse_session_id")
-                        if metadata
-                        else None,
-                        "user_id": metadata.get("langfuse_user_id")
-                        if metadata
-                        else None,
-                    }
+                    update_dict
                 )
 
             content = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `on_chain_start` in `langchain.py` to dynamically update trace-level parameters using metadata prefixed with `langfuse_`.
> 
>   - **Behavior**:
>     - In `on_chain_start` in `langchain.py`, trace-level information is updated with metadata keys prefixed by `langfuse_`.
>     - This allows dynamic updates to parameters like `session_id` and `user_id` based on metadata.
>   - **Misc**:
>     - Refactored code to use a dictionary `update_dict` for updating trace information.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 0b4f495ae1c9144f0d249718c819b146c08cb5a2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added support for dynamic trace parameter updates through metadata prefixing in the langchain callback handler, but introduced a bug that breaks existing functionality.

- Fixed bug in `on_chain_start` where `session_id` and `user_id` are incorrectly set to None instead of using metadata values
- Added support for dynamic parameter updates via `langfuse_` prefixed metadata keys
- Improved code organization by collecting updates in a dictionary before applying to trace
- Maintained backward compatibility for existing metadata parameter handling

The main issue is that the current implementation always sets `session_id` and `user_id` to None in the `update_dict`, overriding any values that may have been set in metadata. This needs to be fixed to preserve the existing functionality while adding support for the new dynamic parameters.



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->