### PR TITLE
VertexAI usage metadata parsing

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -1131,7 +1131,7 @@ def _parse_usage(response: LLMResult):
         for generation in response.generations:
             for generation_chunk in generation:
                 if generation_chunk.generation_info and (
-                    "usage_metadata" in generation_chunk.generation_info
+                    generation_chunk.generation_info.get("usage_metadata", None)
                 ):
                     llm_usage = _parse_usage_model(
                         generation_chunk.generation_info["usage_metadata"]


### PR DESCRIPTION
Some ChatVertexAI responses contain empty `usage_metadata` in `generation_info`  while `message` contains valid one. Breaking here does not allow for processing of the valid one and results in returning None.

Added processing of tokens details for ChatVertexAI as they have different name and different format than the currently processed details.
Keeping the details unprocessed leads to Pydantic validation error further down the line -> https://github.com/langfuse/langfuse/issues/5468

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves `usage_metadata` parsing in ChatVertexAI responses by handling empty metadata and processing token details in `langfuse/callback/langchain.py`.
> 
>   - **Behavior**:
>     - Modified `_parse_usage` in `langfuse/callback/langchain.py` to use `.get('usage_metadata', None)` for safer access.
>     - Prevents early termination when `usage_metadata` is empty in ChatVertexAI responses.
>     - Processes valid metadata from `message` field when `generation_info` metadata is empty.
>   - **Token Details**:
>     - Updated `_parse_usage_model` to handle `prompt_tokens_details` and `candidates_tokens_details` for ChatVertexAI.
>     - Ensures correct parsing of token details to avoid Pydantic validation errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 10ceef6f7261071d3ebd20f8290b25967248bcc7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Enhanced ChatVertexAI usage metadata parsing to handle empty metadata cases and properly process token details in different formats.

- Modified `_parse_usage` in `langfuse/callback/langchain.py` to safely handle empty usage_metadata using `.get()` method
- Added support for extracting valid metadata from message field when generation_info metadata is empty
- Updated token details processing to handle ChatVertexAI-specific fields like `prompt_tokens_details` and `candidates_tokens_details`
- Improved Pydantic validation compatibility by properly formatting token details before validation



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->