### PR TITLE
fix(langgraph): ignore control flow exceptions in LangChain callback (#1169)

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -13,7 +13,7 @@ except ImportError as e:
     log.error(
         f"Could not import langchain. The langchain integration will not work. {e}"
     )
-from typing import Any, Dict, List, Optional, Sequence, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, Set, Type, Union, cast
 from uuid import UUID, uuid4
 
 from langfuse.api.resources.ingestion.types.sdk_log_body import SdkLogBody
@@ -52,7 +52,13 @@ except ImportError:
     )
 
 LANGSMITH_TAG_HIDDEN: str = "langsmith:hidden"
+CONTROL_FLOW_EXCEPTION_TYPES: Set[Type[BaseException]] = set()
 
+try:
+    from langgraph.errors import GraphBubbleUp
+    CONTROL_FLOW_EXCEPTION_TYPES.add(GraphBubbleUp)
+except ImportError:
+    pass
 
 class LangchainCallbackHandler(
     LangchainBaseCallbackHandler, LangfuseBaseCallbackHandler
@@ -484,8 +490,13 @@ class LangchainCallbackHandler(
         try:
             self._log_debug_event("on_chain_error", run_id, parent_run_id, error=error)
             if run_id in self.runs:
+                if any(isinstance(error, t) for t in CONTROL_FLOW_EXCEPTION_TYPES):
+                    level = None
+                else:
+                    level = "ERROR"
+
                 self.runs[run_id] = self.runs[run_id].end(
-                    level="ERROR",
+                    level=level,
                     status_message=str(error),
                     version=self.version,
                     input=kwargs.get("inputs"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `LangchainCallbackHandler` now ignores `GraphBubbleUp` exceptions in `on_chain_error`, preventing them from being logged as errors.
> 
>   - **Behavior**:
>     - `on_chain_error` in `LangchainCallbackHandler` now ignores exceptions of type `GraphBubbleUp` from `langgraph.errors`, not logging them as errors.
>     - Introduces `CONTROL_FLOW_EXCEPTION_TYPES` set to store exception types to be ignored.
>   - **Imports**:
>     - Adds `Set` and `Type` to imports in `langchain.py`.
>     - Attempts to import `GraphBubbleUp` from `langgraph.errors` and adds it to `CONTROL_FLOW_EXCEPTION_TYPES` if available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for a43ebe741840142424d11adefc5b40357ec75342. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Enhanced LangChain callback handler to properly handle control flow exceptions from LangGraph, preventing GraphBubbleUp exceptions from being logged as errors in Langfuse.

- Added `CONTROL_FLOW_EXCEPTION_TYPES` set in `langfuse/callback/langchain.py` to track special exception types
- Added support for LangGraph's `GraphBubbleUp` exception in control flow handling
- Modified error handling logic to avoid marking control flow exceptions as errors
- Improved integration between LangGraph and Langfuse by allowing expected control flow exceptions



<!-- /greptile_comment -->