### PR TITLE
fix(environments): correctly propagate client attribute

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -297,6 +297,7 @@ class Langfuse:
                         input=input,
                         output=output,
                         metadata=metadata,
+                        environment=self._environment,
                     )
 
         otel_span = self._otel_tracer.start_span(name=name, attributes=attributes)
@@ -307,6 +308,7 @@ class Langfuse:
             input=input,
             output=output,
             metadata=metadata,
+            environment=self._environment,
         )
 
     def start_as_current_span(
@@ -697,6 +699,7 @@ class Langfuse:
                     input=input,
                     output=output,
                     metadata=metadata,
+                    environment=self._environment,
                 )
                 if as_type == "span"
                 else LangfuseGeneration(
@@ -705,6 +708,7 @@ class Langfuse:
                     input=input,
                     output=output,
                     metadata=metadata,
+                    environment=self._environment,
                 )
             )
 
@@ -849,7 +853,11 @@ class Langfuse:
         current_otel_span = self._get_current_otel_span()
 
         if current_otel_span is not None:
-            span = LangfuseSpan(otel_span=current_otel_span, langfuse_client=self)
+            span = LangfuseSpan(
+                otel_span=current_otel_span,
+                langfuse_client=self,
+                environment=self._environment,
+            )
 
             span.update(
                 input=input,
@@ -919,7 +927,11 @@ class Langfuse:
         current_otel_span = self._get_current_otel_span()
 
         if current_otel_span is not None:
-            span = LangfuseSpan(otel_span=current_otel_span, langfuse_client=self)
+            span = LangfuseSpan(
+                otel_span=current_otel_span,
+                langfuse_client=self,
+                environment=self._environment,
+            )
 
             span.update_trace(
                 name=name,

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -68,6 +68,7 @@ class LangfuseSpanWrapper(ABC):
         input: Optional[Any] = None,
         output: Optional[Any] = None,
         metadata: Optional[Any] = None,
+        environment: Optional[str] = None,
     ):
         """Initialize a new Langfuse span wrapper.
 
@@ -78,6 +79,7 @@ class LangfuseSpanWrapper(ABC):
             input: Input data for the span (any JSON-serializable object)
             output: Output data from the span (any JSON-serializable object)
             metadata: Additional metadata to associate with the span
+            environment: The tracing environment
         """
         self._otel_span = otel_span
         self._otel_span.set_attribute(
@@ -87,6 +89,12 @@ class LangfuseSpanWrapper(ABC):
 
         self.trace_id = self._langfuse_client._get_otel_trace_id(otel_span)
         self.id = self._langfuse_client._get_otel_span_id(otel_span)
+
+        self._environment = environment
+        if self._environment is not None:
+            self._otel_span.set_attribute(
+                LangfuseOtelSpanAttributes.ENVIRONMENT, self._environment
+            )
 
         # Handle media only if span is sampled
         if self._otel_span.is_recording:
@@ -490,6 +498,7 @@ class LangfuseSpan(LangfuseSpanWrapper):
         input: Optional[Any] = None,
         output: Optional[Any] = None,
         metadata: Optional[Any] = None,
+        environment: Optional[str] = None,
     ):
         """Initialize a new LangfuseSpan.
 
@@ -499,6 +508,7 @@ class LangfuseSpan(LangfuseSpanWrapper):
             input: Input data for the span (any JSON-serializable object)
             output: Output data from the span (any JSON-serializable object)
             metadata: Additional metadata to associate with the span
+            environment: The tracing environment
         """
         super().__init__(
             otel_span=otel_span,
@@ -507,6 +517,7 @@ class LangfuseSpan(LangfuseSpanWrapper):
             input=input,
             output=output,
             metadata=metadata,
+            environment=environment,
         )
 
     def update(
@@ -643,7 +654,9 @@ class LangfuseSpan(LangfuseSpanWrapper):
                 )
 
         return LangfuseSpan(
-            otel_span=new_otel_span, langfuse_client=self._langfuse_client
+            otel_span=new_otel_span,
+            langfuse_client=self._langfuse_client,
+            environment=self._environment,
         )
 
     def start_as_current_span(
@@ -818,7 +831,9 @@ class LangfuseSpan(LangfuseSpanWrapper):
                 )
 
         return LangfuseGeneration(
-            otel_span=new_otel_span, langfuse_client=self._langfuse_client
+            otel_span=new_otel_span,
+            langfuse_client=self._langfuse_client,
+            environment=self._environment,
         )
 
     def start_as_current_generation(
@@ -936,6 +951,7 @@ class LangfuseGeneration(LangfuseSpanWrapper):
         input: Optional[Any] = None,
         output: Optional[Any] = None,
         metadata: Optional[Any] = None,
+        environment: Optional[str] = None,
     ):
         """Initialize a new LangfuseGeneration span.
 
@@ -945,6 +961,7 @@ class LangfuseGeneration(LangfuseSpanWrapper):
             input: Input data for the generation (e.g., prompts)
             output: Output from the generation (e.g., completions)
             metadata: Additional metadata to associate with the generation
+            environment: The tracing environment
         """
         super().__init__(
             otel_span=otel_span,
@@ -953,6 +970,7 @@ class LangfuseGeneration(LangfuseSpanWrapper):
             input=input,
             output=output,
             metadata=metadata,
+            environment=environment,
         )
 
     def update(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `environment` attribute propagation to span and generation methods in `client.py` and `span.py`.
> 
>   - **Behavior**:
>     - Add `environment` attribute propagation in `start_span()`, `start_as_current_span()`, `_start_as_current_otel_span_with_processed_media()`, `update_current_span()`, and `update_current_trace()` in `client.py`.
>     - Add `environment` attribute to `LangfuseSpan` and `LangfuseGeneration` constructors in `span.py`.
>   - **Classes**:
>     - `LangfuseSpan` and `LangfuseGeneration` now include `environment` in their initialization and attribute setting.
>   - **Misc**:
>     - Update docstrings in `span.py` to include `environment` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 541b2c0a8513d867b6f4a593bb3bc2189ed6e878. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR fixes environment attribute propagation in the Langfuse Python client by ensuring proper environment context handling throughout the tracing system.

- Added `environment` parameter to `LangfuseSpanWrapper` constructor in `langfuse/_client/span.py` to initialize environment context
- Modified span creation methods in `langfuse/_client/client.py` to pass environment attribute to child spans
- Added environment attribute setting in `LangfuseSpanWrapper` when provided to ensure proper tracking
- Ensured environment propagation through all span hierarchy methods for consistent tracing



<!-- /greptile_comment -->