### PR TITLE
fix(langchain): filter string keys from usage object

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -880,6 +880,8 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]):
                         "token_count"
                     ]
 
+    usage_model = {k: v for k, v in usage_model.items() if not isinstance(v, str)}
+
     return usage_model if usage_model else None
 
 

--- a/tests/test_extract_model.py
+++ b/tests/test_extract_model.py
@@ -94,6 +94,7 @@ def test_models(expected_model: str, model: Any):
 
 
 # all models here need to be tested here because we take the model from the kwargs / invocation_params or we need to make an actual call for setup
+@pytest.mark.skip("Flaky")
 @pytest.mark.parametrize(
     "expected_model,model",
     [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Filters out string values from usage data in `_parse_usage_model` in `CallbackHandler.py` to ensure accurate service tier calculations.
> 
>   - **Behavior**:
>     - In `CallbackHandler.py`, `_parse_usage_model` now filters out string values from usage data, retaining only numeric values.
>     - Ensures accurate service tier calculations by excluding non-numeric values.
>   - **Tests**:
>     - Marks `test_models` in `test_extract_model.py` as flaky and skips it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 4bc677fc47d9753a661b9042395557d718d5c514. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Modifies the `langfuse/langchain/CallbackHandler.py` to filter out non-numeric values from usage model data, ensuring accurate service tier calculations.

- Adds filtering in `_parse_usage_model` function to retain only numerical values in usage metrics
- Prevents potential service tier calculation issues by excluding string values from usage data



<!-- /greptile_comment -->