### PR TITLE
fix: add missing release when creating dataset trace

### DIFF
--- a/langfuse/client.py
+++ b/langfuse/client.py
@@ -3371,7 +3371,7 @@ class DatasetItemClient:
             "run_name": run_name,
             "dataset_id": self.dataset_id,
         }
-        trace = self.langfuse.trace(name="dataset-run", metadata=metadata)
+        trace = self.langfuse.trace(name="dataset-run", metadata=metadata, version=self.langfuse.release)
 
         self.link(
             trace, run_name, run_metadata=run_metadata, run_description=run_description


### PR DESCRIPTION
Hi, I love this project

Traces in custom experiments with langfuse datasets via langchain handlers have no release tag.
Noticed that there was missing `version` argument when creating a trace.
Adding missing argument resolves the issue with missing tag.

This fix is based on the v2.60.5 release tag because the function does not exist in main. Please advise if I should rebase onto a different branch or if you prefer to cherry-pick this change.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds missing `version` argument to `trace()` call in `get_langchain_handler()` to fix missing release tags in traces.
> 
>   - **Behavior**:
>     - Adds missing `version=self.langfuse.release` argument to `self.langfuse.trace()` call in `get_langchain_handler()` in `langfuse/client.py`.
>     - Fixes missing release tag in traces for custom experiments with Langfuse datasets via Langchain handlers.
>   - **Context**:
>     - Based on v2.60.5 release tag, not present in the main branch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 97933d2b66688b11048415175439d11c7853d5d6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added missing `version` argument to `trace()` call in `get_langchain_handler()` method to ensure proper release tagging for dataset experiment traces via LangChain handlers.

- Added `version=self.langfuse.release` parameter to `self.langfuse.trace()` call in `langfuse/client.py` to fix missing release tags
- Change targets v2.60.5 since the function doesn't exist in main branch yet



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->