### PR TITLE
fix: encode dataset name with urllib, removing default `safe='/'` config

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1654,7 +1654,7 @@ class Langfuse:
 
             while True:
                 new_items = self.api.dataset_items.list(
-                    dataset_name=self._url_encode(name),
+                    dataset_name=name,
                     page=page,
                     limit=fetch_items_page_size,
                 )

--- a/langfuse/api/resources/datasets/client.py
+++ b/langfuse/api/resources/datasets/client.py
@@ -3,6 +3,8 @@
 import typing
 from json.decoder import JSONDecodeError
 
+import urllib.parse
+
 from ...core.api_error import ApiError
 from ...core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 from ...core.jsonable_encoder import jsonable_encoder
@@ -136,7 +138,7 @@ class DatasetsClient:
         )
         """
         _response = self._client_wrapper.httpx_client.request(
-            f"api/public/v2/datasets/{jsonable_encoder(dataset_name)}",
+            f"api/public/v2/datasets/{urllib.parse.quote(dataset_name, safe='')}",
             method="GET",
             request_options=request_options,
         )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -140,6 +140,21 @@ def test_upsert_and_get_dataset_item():
     assert get_new_item.status == DatasetStatus.ARCHIVED
 
 
+def test_dataset_special_characters():
+    langfuse = Langfuse(debug=False)
+
+    special_name = "Special Characters !@#/$%^&"
+    langfuse.create_dataset(name=special_name)
+    dataset = langfuse.get_dataset(special_name)
+    assert dataset.name == special_name
+
+    # Test with unicode characters
+    unicode_name = "Unicode Characters ñáéíóú"
+    langfuse.create_dataset(name=unicode_name)
+    dataset = langfuse.get_dataset(unicode_name)
+    assert dataset.name == unicode_name
+
+
 def test_dataset_run_with_metadata_and_description():
     langfuse = Langfuse(debug=False)
 


### PR DESCRIPTION
This fixes an issue where the `urllib.parse.quote` fn is used to encode a path component that has a slash in it.  Ex: if you name a dataset `test/me`, it needs to encode the slash.

```python
>>> import urllib.parse
>>> urllib.parse.quote('test/me')
'test/me'
>>> urllib.parse.quote('test/me', safe='')
'test%2Fme'
```

You can see here that `urllib.parse.quote` does not encode the `/` by default, which is what is used in the `_url_encode` fn.  

Related: https://github.com/langfuse/langfuse/pull/7026
Part of the fix for [#5962](https://github.com/langfuse/langfuse/issues/5962)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix dataset name encoding to handle special characters using `urllib.parse.quote` with `safe=''` and add tests for special character handling.
> 
>   - **Behavior**:
>     - Fix encoding of dataset names with special characters in `get_dataset` in `client.py` and `get` in `datasets/client.py` using `urllib.parse.quote` with `safe=''`.
>   - **Tests**:
>     - Add `test_dataset_special_characters` in `test_datasets.py` to verify handling of special and unicode characters in dataset names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 73421d59226d44675a3371c24b38509a6fc5d481. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR fixes URL encoding issues for dataset names in the langfuse-python client, particularly addressing the handling of forward slashes and special characters in URLs.

- Modified `_url_encode()` in `langfuse/_client/client.py` to properly encode forward slashes by removing default `safe='/'` parameter
- Added test case `test_dataset_special_characters()` in `tests/test_datasets.py` to validate handling of special and Unicode characters
- Updated `get` method in `datasets/client.py` to use `urllib.parse.quote(dataset_name, safe='')` for consistent encoding
- Potential issue: Some methods still use `jsonable_encoder` for dataset names which may cause inconsistent encoding behavior



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->