### PR TITLE
fix(langchain): token counts for vertex

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -844,9 +844,11 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]):
                     and "modality" in item
                     and "token_count" in item
                 ):
-                    usage_model[f"input_modality_{item['modality']}"] = item[
-                        "token_count"
-                    ]
+                    value = item["token_count"]
+                    usage_model[f"input_modality_{item['modality']}"] = value
+
+                    if "input" in usage_model:
+                        usage_model["input"] = max(0, usage_model["input"] - value)
 
         # Vertex AI
         if "candidates_tokens_details" in usage_model and isinstance(
@@ -860,9 +862,11 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]):
                     and "modality" in item
                     and "token_count" in item
                 ):
-                    usage_model[f"output_modality_{item['modality']}"] = item[
-                        "token_count"
-                    ]
+                    value = item["token_count"]
+                    usage_model[f"output_modality_{item['modality']}"] = value
+
+                    if "output" in usage_model:
+                        usage_model["output"] = max(0, usage_model["output"] - value)
 
         # Vertex AI
         if "cache_tokens_details" in usage_model and isinstance(
@@ -876,9 +880,11 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]):
                     and "modality" in item
                     and "token_count" in item
                 ):
-                    usage_model[f"cached_modality_{item['modality']}"] = item[
-                        "token_count"
-                    ]
+                    value = item["token_count"]
+                    usage_model[f"cached_modality_{item['modality']}"] = value
+
+                    if "input" in usage_model:
+                        usage_model["input"] = max(0, usage_model["input"] - value)
 
     usage_model = {k: v for k, v in usage_model.items() if not isinstance(v, str)}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts token count calculations for Vertex AI in `_parse_usage_model()` to handle modality-specific token counts without going below zero.
> 
>   - **Behavior**:
>     - Adjusts token count calculations in `_parse_usage_model()` in `CallbackHandler.py` for Vertex AI.
>     - Subtracts modality-specific token counts from `input` and `output` ensuring they do not go below zero.
>     - Applies changes to `prompt_tokens_details`, `candidates_tokens_details`, and `cache_tokens_details`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 33e09bccea38ae18fc2a7b342732eb29520ef031. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Updates token count handling for Vertex AI in the Langchain integration to ensure accurate usage statistics for multi-modal interactions.

- Fixed token count processing in `langfuse/langchain/CallbackHandler.py` to properly subtract prompt, candidate, and cache tokens from total counts
- Added support for multi-modal input/output token tracking in Vertex AI integrations
- Improved accuracy of usage statistics by correctly handling different token types (prompt, completion, cache)



<!-- /greptile_comment -->