### PR TITLE
feat(media): allow disabling media handling via envvar

### DIFF
--- a/langfuse/_client/environment_variables.py
+++ b/langfuse/_client/environment_variables.py
@@ -110,3 +110,12 @@ input/output setting on your observation to avoid this.
 
 **Default value**: ``True``
 """
+
+LANGFUSE_MEDIA_UPLOAD_ENABLED = "LANGFUSE_MEDIA_UPLOAD_ENABLED"
+"""
+.. envvar: LANGFUSE_MEDIA_UPLOAD_ENABLED
+
+Controls whether media detection and upload is attempted by the SDK.
+
+**Default value**: ``True``
+"""


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `LANGFUSE_MEDIA_UPLOAD_ENABLED` to control media handling in Langfuse SDK, affecting initialization and processing in `resource_manager.py` and `media_manager.py`.
> 
>   - **Environment Variables**:
>     - Add `LANGFUSE_MEDIA_UPLOAD_ENABLED` to `environment_variables.py` to control media detection and upload.
>   - **Resource Management**:
>     - In `resource_manager.py`, initialize `_media_upload_enabled` based on `LANGFUSE_MEDIA_UPLOAD_ENABLED`.
>     - Conditionally start media upload consumers in `_initialize_instance()` based on `_media_upload_enabled`.
>   - **Media Handling**:
>     - In `media_manager.py`, check `_enabled` before processing media in `_find_and_process_media()`.
>     - Initialize `_enabled` in `MediaManager` based on `LANGFUSE_MEDIA_UPLOAD_ENABLED`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 1888ac179fc44b0835f671151749b11544add9b5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added new environment variable `LANGFUSE_MEDIA_UPLOAD_ENABLED` to control media handling functionality in the Python SDK, with a default value of 'True'.

- Added `LANGFUSE_MEDIA_UPLOAD_ENABLED` environment variable definition in `/langfuse/_client/environment_variables.py`
- Implemented media handling toggle in `/langfuse/_task_manager/media_manager.py` to skip processing when disabled
- Modified `/langfuse/_client/resource_manager.py` to conditionally start media upload consumer threads based on the setting



<!-- /greptile_comment -->