### PR TITLE
fix(langchain): deployment version in azure model

### DIFF
--- a/langfuse/extract_model.py
+++ b/langfuse/extract_model.py
@@ -58,7 +58,12 @@ def _extract_model_name(
         deployment_version = None
         if serialized.get("kwargs").get("deployment_name"):
             deployment_name = serialized.get("kwargs").get("deployment_name")
-        return deployment_name + "-" + deployment_version
+
+        return (
+            deployment_name + "-" + deployment_version
+            if deployment_version not in deployment_name
+            else deployment_name
+        )
 
     # Third, for some models, we are unable to extract the model by a path in an object. Langfuse provides us with a string representation of the model pbjects
     # We use regex to extract the model from the repr string

--- a/langfuse/extract_model.py
+++ b/langfuse/extract_model.py
@@ -61,8 +61,12 @@ def _extract_model_name(
         if serialized.get("kwargs").get("deployment_name"):
             deployment_name = serialized.get("kwargs").get("deployment_name")
 
-        if not deployment_name:
+        if not isinstance(deployment_name, str):
             return None
+
+        if not isinstance(deployment_version, str):
+            return deployment_name
+
         return (
             f"{deployment_name}-{deployment_version}"
             if deployment_version and deployment_version not in deployment_name

--- a/langfuse/extract_model.py
+++ b/langfuse/extract_model.py
@@ -59,9 +59,11 @@ def _extract_model_name(
         if serialized.get("kwargs").get("deployment_name"):
             deployment_name = serialized.get("kwargs").get("deployment_name")
 
+        if not deployment_name:
+            return None
         return (
-            deployment_name + "-" + deployment_version
-            if deployment_version not in deployment_name
+            f"{deployment_name}-{deployment_version}"
+            if deployment_version and deployment_version not in deployment_name
             else deployment_name
         )
 

--- a/langfuse/extract_model.py
+++ b/langfuse/extract_model.py
@@ -53,9 +53,11 @@ def _extract_model_name(
             return kwargs.get("invocation_params").get("model_name")
 
         deployment_name = None
-        if serialized.get("kwargs").get("openai_api_version"):
-            deployment_name = serialized.get("kwargs").get("deployment_version")
         deployment_version = None
+
+        if serialized.get("kwargs").get("openai_api_version"):
+            deployment_version = serialized.get("kwargs").get("deployment_version")
+
         if serialized.get("kwargs").get("deployment_name"):
             deployment_name = serialized.get("kwargs").get("deployment_name")
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes AzureOpenAI model name extraction to prevent duplicate version strings and updates version to 2.60.7.
> 
>   - **Behavior**:
>     - Fixes AzureOpenAI model name extraction in `_extract_model_name()` to prevent duplicate version strings in deployment names.
>     - Ensures `deployment_version` is not appended if already present in `deployment_name`.
>   - **Misc**:
>     - Updates version from 2.60.5 to 2.60.7 in `version.py` and `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for edf42ae8676a2cc9453aff3cf02cb615504ae4c2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR fixes Anthropic usage parsing in the Langchain integration and improves model name extraction for Azure OpenAI, with version bump to 2.60.7.

- Fixed AzureOpenAI model name extraction to prevent duplicate version strings in deployment names
- Improved token usage parsing for various LLM providers to avoid double-counting modality-specific tokens
- Added validation to ensure token counts don't go below 0 using max(0, value)
- Enhanced handling of Vertex AI token details across different modalities
- Updated version from 2.60.5 to 2.60.7 consistently across `version.py` and `pyproject.toml`



<!-- /greptile_comment -->