### PR TITLE
fix(langchain): deployment version in model name

### DIFF
--- a/langfuse/langchain/utils.py
+++ b/langfuse/langchain/utils.py
@@ -53,11 +53,14 @@ def _extract_model_name(
             return kwargs.get("invocation_params").get("model_name")
 
         deployment_name = None
-        if serialized.get("kwargs").get("openai_api_version"):
-            deployment_name = serialized.get("kwargs").get("deployment_version")
         deployment_version = None
+
+        if serialized.get("kwargs").get("openai_api_version"):
+            deployment_version = serialized.get("kwargs").get("deployment_version")
+
         if serialized.get("kwargs").get("deployment_name"):
             deployment_name = serialized.get("kwargs").get("deployment_name")
+
         return (
             deployment_name + "-" + deployment_version
             if deployment_version not in deployment_name

--- a/langfuse/langchain/utils.py
+++ b/langfuse/langchain/utils.py
@@ -61,6 +61,12 @@ def _extract_model_name(
         if serialized.get("kwargs").get("deployment_name"):
             deployment_name = serialized.get("kwargs").get("deployment_name")
 
+        if not isinstance(deployment_name, str):
+            return None
+
+        if not isinstance(deployment_version, str):
+            return deployment_name
+
         return (
             deployment_name + "-" + deployment_version
             if deployment_version not in deployment_name

--- a/langfuse/langchain/utils.py
+++ b/langfuse/langchain/utils.py
@@ -58,7 +58,11 @@ def _extract_model_name(
         deployment_version = None
         if serialized.get("kwargs").get("deployment_name"):
             deployment_name = serialized.get("kwargs").get("deployment_name")
-        return deployment_name + "-" + deployment_version
+        return (
+            deployment_name + "-" + deployment_version
+            if deployment_version not in deployment_name
+            else deployment_name
+        )
 
     # Third, for some models, we are unable to extract the model by a path in an object. Langfuse provides us with a string representation of the model pbjects
     # We use regex to extract the model from the repr string


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes Azure OpenAI model name extraction in `_extract_model_name()` to prevent duplicate version info in `utils.py`.
> 
>   - **Behavior**:
>     - Fixes `_extract_model_name()` in `utils.py` to correctly assign `deployment_version` and `deployment_name`.
>     - Adds a check to prevent duplicate `deployment_version` in `deployment_name`.
>   - **Logic**:
>     - Ensures `deployment_version` is only appended if not already in `deployment_name`.
>     - Returns `None` if `deployment_name` is not a string.
>   - **Misc**:
>     - Corrects order of operations in Azure OpenAI model extraction logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 15e510ede8fa20f03405244a3ff6ac533648d853. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixes model name extraction logic for Azure OpenAI models in the Langfuse Python SDK to prevent duplicate version information in model names.

- Fixed incorrect variable assignment in `_extract_model_name()` where `deployment_version` was being assigned to `deployment_name`
- Added missing conditional check to prevent duplicate version info when extracting Azure OpenAI model names
- Incorrect order of operations in Azure OpenAI model extraction logic - deployment version check happens before deployment name
- Potential bug where `deployment_name` could be overwritten by `deployment_version` due to variable reuse



<!-- /greptile_comment -->