### PR TITLE
fix: treat `usage_metadata.total_token_count` of vertex ai as total

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -793,6 +793,7 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]):
         # https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/get-token-count
         ("prompt_token_count", "input"),
         ("candidates_token_count", "output"),
+        ("total_token_count", "total"),
         # Bedrock: https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-cw.html#runtime-cloudwatch-metrics
         ("inputTokenCount", "input"),
         ("outputTokenCount", "output"),


### PR DESCRIPTION
Currently, `langfuse.langchain.CallbackHandler` counts total token count of Vertex AI response as "Other usage".
This PR fixes it.

ref. https://ai.google.dev/gemini-api/docs/tokens?lang=python#count-tokens
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `langfuse.langchain.CallbackHandler` to correctly map `usage_metadata.total_token_count` to `total` in `_parse_usage_model()`.
> 
>   - **Behavior**:
>     - Fixes `langfuse.langchain.CallbackHandler` to correctly treat `usage_metadata.total_token_count` as `total` in `_parse_usage_model()`.
>   - **Files**:
>     - Updates `CallbackHandler.py` to include the mapping for `total_token_count` to `total`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for db9ee41de8ce7878f6eea8319f3d34d0c003d852. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixes token usage tracking for Google Vertex AI by correctly mapping `total_token_count` in the Langfuse CallbackHandler, ensuring accurate usage metrics instead of incorrectly categorizing them as 'Other usage'.

- Maps Vertex AI's `usage_metadata.total_token_count` to the standardized `total` field in `langfuse/langchain/CallbackHandler.py`
- Improves accuracy of token usage reporting for Vertex AI LLM interactions
- Aligns implementation with Google's official token counting documentation



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->