### PR TITLE
feat(langchain): langfuse trace attributes in run invocation config

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -972,11 +972,7 @@ def _strip_langfuse_keys_from_dict(metadata: Optional[Dict[str, Any]]):
     if metadata is None or not isinstance(metadata, dict):
         return metadata
 
-    langfuse_metadata_keys = [
-        "langfuse_prompt",
-        "langfuse_session_id",
-        "langfuse_user_id",
-    ]
+    langfuse_metadata_keys = ["langfuse_prompt"]
 
     metadata_copy = metadata.copy()
 

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1313,7 +1313,7 @@ def test_response_api_text_input(openai):
     assert generationData.output is not None
 
 
-@pytest.skip("Flaky")
+@pytest.mark.skip("Flaky")
 def test_response_api_image_input(openai):
     client = openai.OpenAI()
     generation_name = "test_response_api_image_input" + create_uuid()[:8]

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1313,6 +1313,7 @@ def test_response_api_text_input(openai):
     assert generationData.output is not None
 
 
+@pytest.skip("Flaky")
 def test_response_api_image_input(openai):
     client = openai.OpenAI()
     generation_name = "test_response_api_image_input" + create_uuid()[:8]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modified metadata handling in `CallbackHandler.py` to retain session/user keys for better tracking and marked a test as flaky in `test_openai.py`.
> 
>   - **Metadata Handling**:
>     - Modified `_strip_langfuse_keys_from_dict` in `CallbackHandler.py` to retain `langfuse_session_id` and `langfuse_user_id` keys.
>     - Enhances cross-session user activity tracking and request correlation.
>     - Aligns with OpenTelemetry trace attributes for better observability.
>   - **Testing**:
>     - Marked `test_response_api_image_input` in `test_openai.py` as flaky and skipped.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 1946a76fc7b49f45e0f691fe85651242edd843cf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Modified metadata handling in LangChain callback handler to preserve session and user tracking information for improved request tracing.

- Changed `_strip_langfuse_keys_from_dict` in `langfuse/langchain/CallbackHandler.py` to retain `langfuse_session_id` and `langfuse_user_id` keys in metadata
- Enhancement enables better cross-session user activity tracking and request correlation
- Aligns with OpenTelemetry trace attributes implementation for more comprehensive observability



<!-- /greptile_comment -->