### PR TITLE
fix(client): url encoding slashes

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -2249,4 +2249,7 @@ class Langfuse:
         return updated_prompt
 
     def _url_encode(self, url: str) -> str:
-        return urllib.parse.quote(url)
+        # urllib.quote does not escape slashes "/" by default
+        # we need add safe="" to force escaping of slashes
+        # This is necessary for prompts in prompt folders
+        return urllib.parse.quote(url, safe="")

--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -2249,7 +2249,7 @@ class Langfuse:
         return updated_prompt
 
     def _url_encode(self, url: str) -> str:
-        # urllib.quote does not escape slashes "/" by default
+        # urllib.parse.quote does not escape slashes "/" by default; we need to add safe="" to force escaping
         # we need add safe="" to force escaping of slashes
         # This is necessary for prompts in prompt folders
         return urllib.parse.quote(url, safe="")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `_url_encode` method in `client.py` to escape slashes, ensuring correct URL encoding for prompts in folders.
> 
>   - **Behavior**:
>     - Fix `_url_encode` method in `client.py` to escape slashes by setting `safe=""` in `urllib.parse.quote`.
>     - Ensures correct URL encoding for prompts in prompt folders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for f8772e35e2da9a0912b8f04b7ec7ec74ddeed3df. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixed URL encoding in the Python client to properly handle slashes by modifying `_url_encode` method in `langfuse/_client/client.py` to use `urllib.parse.quote()` with `safe=""` parameter.

- Added proper slash encoding in URLs by removing them from the safe characters list, essential for prompts stored in nested folders
- This is a low-risk change that improves URL handling reliability without impacting core functionality



<!-- /greptile_comment -->