### PR TITLE
fix(client): correctly scope client in multiproject setups

### DIFF
--- a/langfuse/_client/get_client.py
+++ b/langfuse/_client/get_client.py
@@ -90,4 +90,8 @@ def get_client(*, public_key: Optional[str] = None) -> Langfuse:
                     tracing_enabled=False, public_key="fake", secret_key="fake"
                 )
 
-            return Langfuse(public_key=public_key)
+            return Langfuse(
+                public_key=public_key,
+                secret_key=instance.secret_key,
+                host=instance.host,
+            )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `get_client()` to correctly include `secret_key` and `host` for clients in multi-project setups, preventing misconfiguration.
> 
>   - **Behavior**:
>     - In `get_client()`, ensure returned `Langfuse` client includes `secret_key` and `host` from existing instance.
>     - Addresses potential misconfiguration in multi-project setups by correctly scoping client details.
>   - **Logging**:
>     - Logs a warning if no `public_key` is provided in a multi-project setup, indicating tracing is disabled to prevent data leakage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for b21e2fc4e52592e21658031ffc2ba9171ad95a45. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixes critical client initialization issues in multi-project setups by ensuring proper propagation of host and secret_key parameters when creating new Langfuse client instances via `get_client()`.

- Ensures proper scoping of connection parameters (host, secret_key) in `langfuse/_client/get_client.py` for consistent client configuration
- Prevents potential data routing issues by inheriting connection parameters from original instance instead of using defaults
- Critical for scenarios where multiple projects are being monitored simultaneously



<!-- /greptile_comment -->