### PR TITLE
feat(client): allow filtering spans by instrumentation scope name

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -102,6 +102,7 @@ class Langfuse:
         media_upload_thread_count (Optional[int]): Number of background threads for handling media uploads. Defaults to 1. Can also be set via LANGFUSE_MEDIA_UPLOAD_THREAD_COUNT environment variable.
         sample_rate (Optional[float]): Sampling rate for traces (0.0 to 1.0). Defaults to 1.0 (100% of traces are sampled). Can also be set via LANGFUSE_SAMPLE_RATE environment variable.
         mask (Optional[MaskFunction]): Function to mask sensitive data in traces before sending to the API.
+        blocked_instrumentation_scopes (Optional[List[str]]): List of instrumentation scope names to block from being exported to Langfuse. Spans from these scopes will be filtered out before being sent to the API. Useful for filtering out spans from specific libraries or frameworks. For exported spans, you can see the instrumentation scope name in the span metadata in Langfuse (`metadata.scope.name`)
 
     Example:
         ```python
@@ -159,6 +160,7 @@ class Langfuse:
         media_upload_thread_count: Optional[int] = None,
         sample_rate: Optional[float] = None,
         mask: Optional[MaskFunction] = None,
+        blocked_instrumentation_scopes: Optional[List[str]] = None,
     ):
         self._host = host or os.environ.get(LANGFUSE_HOST, "https://cloud.langfuse.com")
         self._environment = environment or os.environ.get(LANGFUSE_TRACING_ENVIRONMENT)
@@ -220,6 +222,7 @@ class Langfuse:
             sample_rate=sample_rate,
             mask=mask,
             tracing_enabled=self._tracing_enabled,
+            blocked_instrumentation_scopes=blocked_instrumentation_scopes,
         )
         self._mask = self._resources.mask
 

--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -18,7 +18,7 @@ import atexit
 import os
 import threading
 from queue import Full, Queue
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 import httpx
 from opentelemetry import trace as otel_trace_api
@@ -93,6 +93,7 @@ class LangfuseResourceManager:
         sample_rate: Optional[float] = None,
         mask: Optional[MaskFunction] = None,
         tracing_enabled: Optional[bool] = None,
+        blocked_instrumentation_scopes: Optional[List[str]] = None,
     ) -> "LangfuseResourceManager":
         if public_key in cls._instances:
             return cls._instances[public_key]
@@ -117,6 +118,7 @@ class LangfuseResourceManager:
                     tracing_enabled=tracing_enabled
                     if tracing_enabled is not None
                     else True,
+                    blocked_instrumentation_scopes=blocked_instrumentation_scopes,
                 )
 
                 cls._instances[public_key] = instance
@@ -139,6 +141,7 @@ class LangfuseResourceManager:
         sample_rate: Optional[float] = None,
         mask: Optional[MaskFunction] = None,
         tracing_enabled: bool = True,
+        blocked_instrumentation_scopes: Optional[List[str]] = None,
     ):
         self.public_key = public_key
         self.secret_key = secret_key
@@ -159,6 +162,7 @@ class LangfuseResourceManager:
                 timeout=timeout,
                 flush_at=flush_at,
                 flush_interval=flush_interval,
+                blocked_instrumentation_scopes=blocked_instrumentation_scopes,
             )
             tracer_provider.add_span_processor(langfuse_processor)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add feature to filter spans by instrumentation scope name in Langfuse client, with tests verifying the behavior.
> 
>   - **Feature**:
>     - Add `blocked_instrumentation_scopes` parameter to `Langfuse` in `client.py`, `LangfuseResourceManager` in `resource_manager.py`, and `LangfuseSpanProcessor` in `span_processor.py` to filter spans by instrumentation scope name.
>     - Spans from blocked scopes are not exported to Langfuse.
>   - **Tests**:
>     - Add `TestInstrumentationScopeFiltering` in `test_otel.py` to verify filtering behavior.
>     - Tests include scenarios with blocked scopes, no blocked scopes, and blocking Langfuse's own scope.
>   - **Misc**:
>     - Update imports in `resource_manager.py` and `span_processor.py` to include `List` for type hinting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 5dc0efceeca790494e4d5b474ad143e3a06e3150. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added instrumentation scope filtering to the Langfuse Python SDK, allowing selective blocking of spans from specific sources before export to Langfuse.

- Added `blocked_instrumentation_scopes` parameter to `Langfuse` client and `LangfuseResourceManager` for configuring span filtering
- Implemented `_is_blocked_instrumentation_scope` method in `LangfuseSpanProcessor` to handle span filtering logic
- Updated type hints and docstrings across affected modules to reflect new filtering capabilities
- Added comprehensive test suite in `tests/test_otel.py` covering various filtering scenarios (empty lists, specific libraries, edge cases)



<!-- /greptile_comment -->