### PR TITLE
feat(callback): add trace context to span and generation start methods, use Langchain run_id UUID to generate OTEL-compliant trace_id

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -2,9 +2,11 @@ import typing
 
 import pydantic
 
+from langfuse._client.client import Langfuse
 from langfuse._client.get_client import get_client
 from langfuse._client.span import LangfuseGeneration, LangfuseSpan
 from langfuse.logger import langfuse_logger
+from langfuse.types import TraceContext
 
 try:
     import langchain  # noqa
@@ -172,6 +174,9 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
 
             if parent_run_id is None:
                 self.runs[run_id] = self.client.start_span(
+                    trace_context=TraceContext(
+                        trace_id=Langfuse.create_trace_id(seed=str(run_id)),
+                    ),
                     name=span_name,
                     metadata=span_metadata,
                     input=inputs,
@@ -444,6 +449,9 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
 
             if parent_run_id is None:
                 self.runs[run_id] = self.client.start_span(
+                    trace_context=TraceContext(
+                        trace_id=Langfuse.create_trace_id(seed=str(run_id)),
+                    ),
                     name=span_name,
                     metadata=span_metadata,
                     input=query,
@@ -571,7 +579,12 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                     LangfuseSpan, self.runs[parent_run_id]
                 ).start_generation(**content)
             else:
-                self.runs[run_id] = self.client.start_generation(**content)
+                self.runs[run_id] = self.client.start_generation(
+                    trace_context=TraceContext(
+                        trace_id=Langfuse.create_trace_id(seed=str(run_id)),
+                    ),
+                    **content,
+                )
 
         except Exception as e:
             langfuse_logger.exception(e)


### PR DESCRIPTION
Replace random trace_id generation with deterministic creation based on
Langchain's run_id for better trace correlation and retrieval.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces random `trace_id` generation with deterministic creation using `Langchain`'s `run_id` in `CallbackHandler.py` for better trace correlation.
> 
>   - **Behavior**:
>     - Replaces random `trace_id` generation with deterministic creation using `Langchain`'s `run_id` in `CallbackHandler.py`.
>     - Adds `trace_context` parameter to `start_span` and `start_generation` methods in `on_chain_start`, `on_retriever_start`, and `__on_llm_action`.
>   - **Imports**:
>     - Adds import for `TraceContext` in `CallbackHandler.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for c5ccb74d4b21ee562e38ec2ba4cf0aab0daf0f63. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Enhances the LangChain callback handler by implementing deterministic trace ID generation using Langchain's run_id, improving trace correlation and debugging capabilities.

- Modified `langfuse/langchain/CallbackHandler.py` to use Langchain's run_id for generating OTEL-compliant trace IDs instead of random generation
- Added new `trace_context` parameter to `start_span` and `start_generation` methods for explicit trace ID control
- Improved trace correlation between spans and parent traces through deterministic ID generation
- Test coverage in `test_langchain.py` and `test_core_sdk.py` verifies trace ID consistency and proper handler behavior



<!-- /greptile_comment -->