### PR TITLE
add max_version for deprecated imports

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -60,6 +60,7 @@ class OpenAiDefinition:
     type: str
     sync: bool
     min_version: Optional[str] = None
+    max_version: Optional[str] = None
 
 
 OPENAI_METHODS_V0 = [
@@ -116,6 +117,7 @@ OPENAI_METHODS_V1 = [
         type="chat",
         sync=True,
         min_version="1.50.0",
+        max_version="1.91.0",
     ),
     OpenAiDefinition(
         module="openai.resources.beta.chat.completions",
@@ -124,6 +126,23 @@ OPENAI_METHODS_V1 = [
         type="chat",
         sync=False,
         min_version="1.50.0",
+        max_version="1.91.0",
+    ),
+    OpenAiDefinition(
+        module="openai.resources.chat.completions",
+        object="Completions",
+        method="parse",
+        type="chat",
+        sync=True,
+        min_version="1.92.0",
+    ),
+    OpenAiDefinition(
+        module="openai.resources.chat.completions",
+        object="AsyncCompletions",
+        method="parse",
+        type="chat",
+        sync=False,
+        min_version="1.92.0",
     ),
     OpenAiDefinition(
         module="openai.resources.responses",
@@ -796,6 +815,11 @@ def register_tracing():
     for resource in resources:
         if resource.min_version is not None and Version(openai.__version__) < Version(
             resource.min_version
+        ):
+            continue
+
+        if resource.max_version is not None and Version(openai.__version__) > Version(
+            resource.max_version
         ):
             continue
 


### PR DESCRIPTION
In OpenAI 1.92.0 some paths for imports were migrated. This change implements a max_version to prevent deprecated `beta` imports which have migrated from being referenced on versions after.

See issue: https://github.com/langfuse/langfuse/issues/7533

## Testing

I hacked changed lines on my end in the `2.60.8` SDK. Seeing traces successfully populate in Langfuse and no more import errors on application start.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `max_version` to `OpenAiDefinition` and updates `register_tracing` to prevent deprecated imports post version 1.91.0.
> 
>   - **Behavior**:
>     - Adds `max_version` attribute to `OpenAiDefinition` class in `openai.py`.
>     - Updates `register_tracing()` to skip imports with `max_version` less than current `openai` version.
>   - **Definitions**:
>     - Sets `max_version` to `1.91.0` for `openai.resources.beta.chat.completions` in `OPENAI_METHODS_V1`.
>     - Adds new definitions for `openai.resources.chat.completions` with `min_version` `1.92.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 20ddd243e97bf1553ed33efbc3e321e2fb34080e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Adds version control for OpenAI SDK path migrations in version 1.92.0, ensuring compatibility with the new module structure while maintaining support for older versions.

- Added `max_version` field to `OpenAiDefinition` class in `langfuse/openai.py` to handle version-specific imports
- Implemented version check logic in `register_tracing` to prevent usage of deprecated beta paths after v1.92.0
- Added new definitions for parse method in non-beta chat completions path for v1.92.0+



<!-- /greptile_comment -->