### PR TITLE
fix(flushing): rely on OTEL default flush settings

### DIFF
--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -63,9 +63,15 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
             if blocked_instrumentation_scopes is not None
             else []
         )
-        flush_at = flush_at or int(os.environ.get(LANGFUSE_FLUSH_AT, 15))
-        flush_interval = flush_interval or float(
-            os.environ.get(LANGFUSE_FLUSH_INTERVAL, 0.5)
+
+        env_flush_at = os.environ.get(LANGFUSE_FLUSH_AT, None)
+        flush_at = flush_at or int(env_flush_at) if env_flush_at is not None else None
+
+        env_flush_interval = os.environ.get(LANGFUSE_FLUSH_INTERVAL, None)
+        flush_interval = (
+            flush_interval or float(env_flush_interval)
+            if env_flush_interval is not None
+            else None
         )
 
         basic_auth_header = "Basic " + base64.b64encode(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `LangfuseSpanProcessor` to use OpenTelemetry's default flush settings when environment variables are not set.
> 
>   - **Behavior**:
>     - Modify `LangfuseSpanProcessor` in `span_processor.py` to use OpenTelemetry's default flush settings when `LANGFUSE_FLUSH_AT` and `LANGFUSE_FLUSH_INTERVAL` are not set.
>     - `flush_at` and `flush_interval` are set to `None` if environment variables are not provided, allowing OpenTelemetry defaults to apply.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for eace769312594b824c39c75f5aeb66a70b483d0c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Modifies flush settings handling in `langfuse/_client/span_processor.py` to better align with OpenTelemetry's default behavior, removing hardcoded fallback values.

- Removes hardcoded defaults (15 for flush_at, 0.5 for flush_interval) in favor of OpenTelemetry's native BatchSpanProcessor defaults
- Changes environment variable handling to pass through None values when not explicitly set
- Improves integration with OpenTelemetry's standard behavior for span processing



<!-- /greptile_comment -->