### PR TITLE
feat(langchain): add last trace id property to CallbackHandler

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -63,6 +63,8 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
         self.prompt_to_parent_run_map: Dict[UUID, Any] = {}
         self.updated_completion_start_time_memo: Set[UUID] = set()
 
+        self.last_trace_id = None
+
     def on_llm_new_token(
         self,
         token: str,
@@ -186,6 +188,8 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                     input=inputs,
                     level=span_level,
                 )
+
+            self.last_trace_id = self.runs[run_id].trace_id
 
         except Exception as e:
             langfuse_logger.exception(e)
@@ -572,6 +576,8 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                 ).start_generation(**content)
             else:
                 self.runs[run_id] = self.client.start_generation(**content)
+
+            self.last_trace_id = self.runs[run_id].trace_id
 
         except Exception as e:
             langfuse_logger.exception(e)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `last_trace_id` property to `LangchainCallbackHandler` to track the last run's trace ID in `CallbackHandler.py`.
> 
>   - **Feature**:
>     - Add `last_trace_id` property to `LangchainCallbackHandler` in `CallbackHandler.py`.
>     - Update `last_trace_id` in `on_chain_start()` and `__on_llm_action()` to store the trace ID of the last run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 43cc5fff019808d0c72f5f85424bbdbf8b27fc5d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added `last_trace_id` property to langchain CallbackHandler for easier access to the most recent trace identifier without parsing the runs dictionary.

- Added new property `last_trace_id` in `langfuse/langchain/CallbackHandler.py` that tracks the most recently used trace ID
- Updated property during chain start, LLM generation start, and LLM action events
- Implementation maintains existing error handling patterns and integrates with current tracing functionality
- Feature supports better tracing/debugging in LangChain integration as shown in test cases



<!-- /greptile_comment -->