### PR TITLE
Fix async generator case in decorator

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 import logging
 import os
@@ -169,7 +168,7 @@ class LangfuseDecorator:
                     capture_output=should_capture_output,
                     transform_to_string=transform_to_string,
                 )
-                if asyncio.iscoroutinefunction(func)
+                if inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func) 
                 else self._sync_observe(
                     func,
                     name=name,


### PR DESCRIPTION
The decorator code in `langfuse/_client/observe.py` seems to have been built to support the case of observing an async generator however it misses the mark by using `asyncio.iscoroutinefunction` to decide whether to wrap it in the async or the sync implementation. That method doesn't detect async generators.

The solution is to use the inspect module and check for both cases.