### PR TITLE
fix(client): do not escape url param with httpx > 0.28

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -21,6 +21,7 @@ from opentelemetry.util._decorator import (
     _AgnosticContextManager,
     _agnosticcontextmanager,
 )
+from packaging.version import Version
 
 from langfuse._client.attributes import LangfuseOtelSpanAttributes
 from langfuse._client.datasets import DatasetClient, DatasetItemClient
@@ -1709,7 +1710,7 @@ class Langfuse:
 
             while True:
                 new_items = self.api.dataset_items.list(
-                    dataset_name=self._url_encode(name),
+                    dataset_name=self._url_encode(name, is_url_param=True),
                     page=page,
                     limit=fetch_items_page_size,
                 )
@@ -2261,7 +2262,14 @@ class Langfuse:
 
         return updated_prompt
 
-    def _url_encode(self, url: str) -> str:
+    def _url_encode(self, url: str, *, is_url_param: Optional[bool] = False) -> str:
+        # httpx ≥ 0.28 does its own WHATWG-compliant quoting (eg. encodes bare
+        # “%”, “?”, “#”, “|”, … in query/path parts).  Re-quoting here would
+        # double-encode, so we skip when the value is about to be sent straight
+        # to httpx (`is_url_param=True`) and the installed version is ≥ 0.28.
+        if is_url_param and Version(httpx.__version__) >= Version("0.28.0"):
+            return url
+
         # urllib.parse.quote does not escape slashes "/" by default; we need to add safe="" to force escaping
         # we need add safe="" to force escaping of slashes
         # This is necessary for prompts in prompt folders


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix URL parameter encoding in `client.py` for compatibility with `httpx` version 0.28+ by modifying `_url_encode` function.
> 
>   - **Behavior**:
>     - Modify `_url_encode` in `client.py` to skip re-quoting URL parameters if `httpx` version is 0.28 or higher.
>     - Adds `is_url_param` argument to `_url_encode` to control this behavior.
>   - **Compatibility**:
>     - Ensures compatibility with `httpx` version 0.28+ by checking `httpx.__version__`.
>   - **Misc**:
>     - Import `Version` from `packaging.version` in `client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 871bf294cb0511d32def396c6906ae3890d76d5d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixed URL parameter encoding compatibility issue with httpx >0.28 in the Python SDK to prevent double-encoding of URL parameters.

- Modified `_url_encode` method in `langfuse/_client/client.py` to avoid double URL encoding, as httpx >0.28 now handles WHATWG-compliant encoding internally
- Change ensures proper handling of special characters in API request URLs across different httpx versions



<!-- /greptile_comment -->