### PR TITLE
fix(langchain): do not stringify metadata unnecessarily

### DIFF
--- a/langfuse/_client/attributes.py
+++ b/langfuse/_client/attributes.py
@@ -170,6 +170,10 @@ def _flatten_and_serialize_metadata(
         metadata_attributes[prefix] = _serialize(metadata)
     else:
         for key, value in metadata.items():
-            metadata_attributes[f"{prefix}.{key}"] = _serialize(value)
+            metadata_attributes[f"{prefix}.{key}"] = (
+                value
+                if isinstance(value, str) or isinstance(value, int)
+                else _serialize(value)
+            )
 
     return metadata_attributes

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -59,7 +59,7 @@ async def test_concurrency():
         # Verify metadata
         observation = generation_obs[0]
         assert observation.name == str(i)
-        assert observation.metadata["count"] == f"{i}"
+        assert observation.metadata["count"] == i
 
 
 def test_flush():

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -346,9 +346,9 @@ class TestBasicSpans(TestOTelBase):
         output_data = json.loads(
             attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]
         )
-        metadata_data = json.loads(
-            attributes[f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.session"]
-        )
+        metadata_data = attributes[
+            f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.session"
+        ]
 
         # Verify attribute values
         assert input_data == {"prompt": "Test prompt"}
@@ -425,9 +425,7 @@ class TestBasicSpans(TestOTelBase):
             tags = list(attributes[LangfuseOtelSpanAttributes.TRACE_TAGS])
 
         input_data = json.loads(attributes[LangfuseOtelSpanAttributes.TRACE_INPUT])
-        metadata = json.loads(
-            attributes[f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.trace-meta"]
-        )
+        metadata = attributes[f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.trace-meta"]
 
         # Check attribute values
         assert sorted(tags) == sorted(["tag1", "tag2"])
@@ -501,11 +499,9 @@ class TestBasicSpans(TestOTelBase):
         )
 
         # Parse metadata
-        proc_metadata = json.loads(
-            proc["attributes"][
-                f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.step"
-            ]
-        )
+        proc_metadata = proc["attributes"][
+            f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.step"
+        ]
         assert proc_metadata == "processing"
 
         # Parse input/output JSON
@@ -980,12 +976,14 @@ class TestMetadataHandling(TestOTelBase):
         assert (
             f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.key2" in simple_result
         )
-        assert simple_result[
-            f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.key1"
-        ] == _serialize("value1")
-        assert simple_result[
-            f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.key2"
-        ] == _serialize(123)
+        assert (
+            simple_result[f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.key1"]
+            == "value1"
+        )
+        assert (
+            simple_result[f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.key2"]
+            == 123
+        )
 
         # Test case 3: Nested dict (will be flattened in current implementation)
         nested_dict = {
@@ -1037,7 +1035,7 @@ class TestMetadataHandling(TestOTelBase):
 
         # The nested structures are serialized as JSON strings
         assert json.loads(complex_result[level1_key]) == complex_dict["level1"]
-        assert complex_result[sibling_key] == _serialize("value")
+        assert complex_result[sibling_key] == "value"
 
     def test_nested_metadata_updates(self):
         """Test that nested metadata updates don't overwrite unrelated keys."""
@@ -2129,11 +2127,6 @@ class TestConcurrencyAndAsync(TestOTelBase):
                 task_span, LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT
             )
             assert output["result"] == f"Task {i} completed"
-
-            metadata = self.verify_json_attribute(
-                task_span, f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.task_id"
-            )
-            assert metadata == i
 
         # Verify main span output
         main_output = self.verify_json_attribute(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes metadata serialization in Langchain by preventing unnecessary string conversion, ensuring accurate data handling.
> 
>   - **Behavior**:
>     - Modified `_flatten_and_serialize_metadata` in `attributes.py` to preserve string and integer values without additional JSON serialization.
>     - Prevents double-serialization of string values in Langchain user quotes, improving data accuracy.
>   - **Tests**:
>     - Updated `test_core_sdk.py` to verify metadata handling without unnecessary string conversion.
>     - Updated `test_otel.py` to ensure metadata is not double-serialized and is correctly handled in various scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 03fed0d6b4d5b3f4ce49a76b24439149d76f2af9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixes metadata serialization in Langchain integration by preventing unnecessary string value conversion. This change addresses issues where string metadata values were being double-serialized in user quotes.

- Modified `_flatten_and_serialize_metadata` in `langfuse/_client/attributes.py` to preserve string and integer values without additional JSON serialization
- Prevents double-serialization of string values in Langchain user quotes, improving data accuracy



<!-- /greptile_comment -->