### PR TITLE
Fix LangfuseMedia for Vertex: TypeError: expected bytes, LangfuseMedia found

### DIFF
--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -145,9 +145,10 @@ class MediaManager:
                     field=field,
                 )
 
-                data["data"] = media
+                copied = data.copy()
+                copied["data"] = media
 
-                return data
+                return copied
 
             if isinstance(data, list):
                 return [_process_data_recursively(item, level + 1) for item in data]


### PR DESCRIPTION
Do not modify existing input prompt data, but modify it's copy
Implemented the same way as for Anthropic