### PR TITLE
fix(client): allow using get_trace_url without active span

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1683,8 +1683,7 @@ class Langfuse:
             ```
         """
         project_id = self._get_project_id()
-        current_trace_id = self.get_current_trace_id()
-        final_trace_id = trace_id or current_trace_id
+        final_trace_id = trace_id or self.get_current_trace_id()
 
         return (
             f"{self._host}/project/{project_id}/traces/{final_trace_id}"


### PR DESCRIPTION
Currently `langfuse.get_trace_url(trace_id='my-trace-id')` cannot be used outside of an active span without generating the following warning:

```
Context error: No active span in current context. Operations that depend on an active span will be skipped. Ensure spans are created with start_as_current_span() or that you're operating within an active span context.
```

This is caused by `self. get_current_trace_id()` being evaluated even though one was provided. To fix this, I'd suggest only getting the current trace id if none was provided.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `get_trace_url()` in `client.py` to prevent warnings when used without an active span by only calling `get_current_trace_id()` if `trace_id` is not provided.
> 
>   - **Behavior**:
>     - Fix `get_trace_url()` in `client.py` to only call `get_current_trace_id()` if `trace_id` is not provided, preventing warnings when used without an active span.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for aa1577c1d022547526e11df9051ce3d8805d15b7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Fixed the `get_trace_url()` method in the Python client to avoid unnecessary context warnings when providing an explicit `trace_id` parameter outside of an active span context.

- Modified `langfuse/_client/client.py` to only call `get_current_trace_id()` when no explicit `trace_id` is provided
- Eliminates unnecessary warning messages about missing active spans when using `get_trace_url(trace_id='...')`



<!-- /greptile_comment -->