### PR TITLE
fix(observe): wrap returned async generators

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -19,8 +19,8 @@ from typing import (
     overload,
 )
 
-from typing_extensions import ParamSpec
 from opentelemetry.util._decorator import _AgnosticContextManager
+from typing_extensions import ParamSpec
 
 from langfuse._client.environment_variables import (
     LANGFUSE_OBSERVE_DECORATOR_IO_CAPTURE_ENABLED,
@@ -267,6 +267,15 @@ class LangfuseDecorator:
                     result = await func(*args, **kwargs)
 
                     if capture_output is True:
+                        if inspect.isgenerator(result):
+                            is_return_type_generator = True
+
+                            return self._wrap_sync_generator_result(
+                                langfuse_span_or_generation,
+                                result,
+                                transform_to_string,
+                            )
+
                         if inspect.isasyncgen(result):
                             is_return_type_generator = True
 
@@ -364,6 +373,15 @@ class LangfuseDecorator:
                             is_return_type_generator = True
 
                             return self._wrap_sync_generator_result(
+                                langfuse_span_or_generation,
+                                result,
+                                transform_to_string,
+                            )
+
+                        if inspect.isasyncgen(result):
+                            is_return_type_generator = True
+
+                            return self._wrap_async_generator_result(
                                 langfuse_span_or_generation,
                                 result,
                                 transform_to_string,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -798,7 +798,7 @@ async def test_async_generator_as_return_value():
     assert main_observation.output == mock_output
 
     assert nested_observation.name == "async_generator_function"
-    assert nested_observation.output == "<async_generator>"
+    assert nested_observation.output == "Hello--, async --World!"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps async generators in `async_wrapper` and `sync_wrapper` in `observe.py` to capture and transform results, updating tests accordingly.
> 
>   - **Behavior**:
>     - Wraps async generators in `async_wrapper` and `sync_wrapper` in `observe.py` to capture and transform results.
>     - Updates `test_async_generator_as_return_value` in `test_decorators.py` to check transformed async generator output.
>   - **Functions**:
>     - Modifies `async_wrapper` and `sync_wrapper` to handle async generators using `_wrap_async_generator_result` and `_wrap_sync_generator_result`.
>   - **Tests**:
>     - Updates `test_async_generator_as_return_value` to assert transformed output of async generators.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 0b88c30558c9f28a2ad2587861a2675632c24576. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR fixes an important limitation in the Langfuse Python SDK's `@observe` decorator regarding how it handles asynchronous generators. Previously, when an async generator was returned from a decorated function, the observation would only record `<async_generator>` as the output instead of the actual yielded values. The changes implement proper wrapping and output capture for both synchronous and asynchronous generators.

Key changes:
- Added symmetric support for both sync and async generators in the observe decorator
- Implemented proper wrapping logic using `inspect.isgenerator` and `inspect.isasyncgen` checks
- Modified tests to verify actual generator output is captured instead of just the generator type
- Ensures consistent behavior between sync and async generator handling

This improvement is particularly valuable for applications that use streaming responses or process data incrementally, as it provides better observability into the actual data being generated.

## Confidence score: 4/5

1. This PR is safe to merge with normal code review attention
2. The changes are well-contained, properly tested, and follow a clear pattern of symmetric implementation
3. Special attention should be paid to: 
   - tests/test_decorators.py to ensure all generator scenarios are covered
   - langfuse/_client/observe.py for the generator wrapping implementation

<sub>2 files reviewed, 1 comment</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=langfuse-python_1259)</sub>

<!-- /greptile_comment -->