### PR TITLE
Update packaging

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -11,6 +11,7 @@ files = [
     {file = "aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"},
     {file = "aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558"},
 ]
+markers = {main = "extra == \"langchain\""}
 
 [[package]]
 name = "aiohttp"
@@ -107,6 +108,7 @@ files = [
     {file = "aiohttp-3.12.14-cp39-cp39-win_amd64.whl", hash = "sha256:196858b8820d7f60578f8b47e5669b3195c21d8ab261e39b1d705346458f445f"},
     {file = "aiohttp-3.12.14.tar.gz", hash = "sha256:6e06e120e34d93100de448fd941522e11dafa78ef1a893c179901b7d66aa29f2"},
 ]
+markers = {main = "extra == \"langchain\""}
 
 [package.dependencies]
 aiohappyeyeballs = ">=2.5.0"
@@ -132,6 +134,7 @@ files = [
     {file = "aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e"},
     {file = "aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7"},
 ]
+markers = {main = "extra == \"langchain\""}
 
 [package.dependencies]
 frozenlist = ">=1.1.0"
@@ -244,11 +247,11 @@ description = "Timeout context manager for asyncio programs"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
-markers = "python_version <= \"3.10\""
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
     {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
 ]
+markers = {main = "extra == \"langchain\" and python_version <= \"3.10\"", dev = "python_version <= \"3.10\""}
 
 [[package]]
 name = "attrs"
@@ -261,6 +264,7 @@ files = [
     {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
     {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
 ]
+markers = {main = "extra == \"langchain\""}
 
 [package.extras]
 cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
@@ -1134,6 +1138,7 @@ files = [
     {file = "frozenlist-1.4.1-py3-none-any.whl", hash = "sha256:04ced3e6a46b4cfffe20f9ae482818e34eba9b5fb0ce4056e4cc9b6e212d09b7"},
     {file = "frozenlist-1.4.1.tar.gz", hash = "sha256:c037a86e8513059a2613aaba4d817bb90b9d9b6b69aace3ce9c877e8c8ed402b"},
 ]
+markers = {main = "extra == \"langchain\""}
 
 [[package]]
 name = "fsspec"
@@ -2970,6 +2975,7 @@ files = [
     {file = "multidict-6.0.5-py3-none-any.whl", hash = "sha256:0d63c74e3d7ab26de115c49bffc92cc77ed23395303d496eae515d4204a625e7"},
     {file = "multidict-6.0.5.tar.gz", hash = "sha256:f7e301075edaf50500f0b341543c41194d8df3ae5caf4702f2095f3ca73dd8da"},
 ]
+markers = {main = "extra == \"langchain\""}
 
 [[package]]
 name = "mypy"
@@ -3953,6 +3959,7 @@ files = [
     {file = "propcache-0.2.0-py3-none-any.whl", hash = "sha256:2ccc28197af5313706511fab3a8b66dcd6da067a1331372c82ea1cb74285e036"},
     {file = "propcache-0.2.0.tar.gz", hash = "sha256:df81779732feb9d01e5d513fad0122efb3d53bbc75f61b2a4f29a020bc985e70"},
 ]
+markers = {main = "extra == \"langchain\""}
 
 [[package]]
 name = "proto-plus"
@@ -5818,6 +5825,7 @@ files = [
     {file = "yarl-1.18.3-py3-none-any.whl", hash = "sha256:b57f4f58099328dfb26c6a771d09fb20dbbae81d20cfb66141251ea063bd101b"},
     {file = "yarl-1.18.3.tar.gz", hash = "sha256:ac1801c45cbf77b6c99242eeff4fffb5e4e73a800b5c4ad4fc0be5def634d2e1"},
 ]
+markers = {main = "extra == \"langchain\""}
 
 [package.dependencies]
 idna = ">=2.0"
@@ -5848,4 +5856,4 @@ openai = ["openai"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "acdcf5642aba80585f46a67189b0ae2931af42d63551ce3061c09353d6dbf230"
+content-hash = "ac31e0db93cfcbf0adbb201a20b1547d1af5347437062d55142d3b24838f711e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ backoff = ">=1.10.0"
 openai = { version = ">=0.27.8", optional = true }
 wrapt = "^1.14"
 langchain = { version = ">=0.0.309", optional = true }
-packaging = ">=23.2,<25.0"
+packaging = ">=23.2,<26.0"
 requests = "^2"
 opentelemetry-api = "^1.33.1"
 opentelemetry-sdk = "^1.33.1"


### PR DESCRIPTION
We'd like to use both langfuse as well as packaging==25.0, so it would be great if you could allow langfuse to install with this newer release of packaging.

Thank you!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `packaging` dependency version range in `pyproject.toml` to `>=23.2,<26.0`.
> 
>   - **Dependencies**:
>     - Update `packaging` version in `pyproject.toml` from `>=23.2,<25.0` to `>=23.2,<26.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 026c330f12eeb1edecd2d6ca8fd96a5f95270d8a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR requests a modification to allow langfuse to be compatible with `packaging==25.0`. This would be a dependency update that enables users to use both langfuse and the newer version of the packaging library in their projects. The packaging library is a core utility in Python's ecosystem used for parsing, managing and working with Python package versions and requirements.

## Confidence score: 1/5

* Safety: This PR cannot be safely merged as is
* Reason: The PR describes a compatibility request but contains no actual code changes to implement it
* Files needing attention: `setup.py` or `pyproject.toml` need to be modified to update dependency specifications

PR Description Notes:
* The PR description clearly states the desired outcome but doesn't include any implementation

<!-- /greptile_comment -->