### PR TITLE
fix openai.py: when `tool_call` is a empty list, it raise an `list in…

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -570,7 +570,7 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                         )
                         curr["arguments"] += getattr(tool_call_chunk, "arguments", "")
 
-                elif delta.get("tool_calls", None) is not None:
+                elif delta.get("tool_calls", None) is not None and len(delta.get("tool_calls")) > 0:
                     curr = completion["tool_calls"]
                     tool_call_chunk = getattr(
                         delta.get("tool_calls", None)[0], "function", None


### PR DESCRIPTION
when `tool_call` is a empty list, it raise an `list index out of range` error
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `list index out of range` error in `_extract_streamed_openai_response()` by checking if `tool_calls` is not empty.
> 
>   - **Bug Fix**:
>     - Fix `list index out of range` error in `_extract_streamed_openai_response()` in `openai.py` by checking if `tool_calls` is not empty before accessing its elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for a3c17945d6f68421339520ec3427700e1446e901. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR fixes a critical defensive programming issue in the OpenAI response handling within the Langfuse Python library. The change adds a length check when processing tool calls from OpenAI's API responses.

Specifically, the fix modifies the condition that checks for tool calls in the response by adding `len(delta.get("tool_calls")) > 0`. This ensures that the code only attempts to access tool call data when the array actually contains elements, preventing index out of range errors when OpenAI returns an empty tool_calls list.

This change makes the library more robust by properly handling edge cases in the OpenAI API responses, which is particularly important for the reliability of the logging and monitoring functionality that Langfuse provides.

## Confidence score: 5/5

1. This PR is extremely safe to merge as it adds defensive programming without changing core behavior
2. The change is minimal, focused, and fixes a clear bug with no potential side effects
3. Files needing attention:
   - langfuse/openai.py - verify the condition covers all edge cases for tool_calls

<!-- /greptile_comment -->