### PR TITLE
fix(client): set AS_ROOT attribute to False in Langfuse remote span context

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -703,7 +703,7 @@ class Langfuse:
             ) as langfuse_span:
                 if remote_parent_span is not None:
                     langfuse_span._otel_span.set_attribute(
-                        LangfuseOtelSpanAttributes.AS_ROOT, True
+                        LangfuseOtelSpanAttributes.AS_ROOT, False
                     )
 
                 yield langfuse_span


### PR DESCRIPTION
When using multi-level span with SDK v3, with remote parent span (pass `langfuse_trace_id` and `langfuse_parent_observation_id`), the trace input and output reflects the input and output of the latest executed span (the inner one). This creates opposite default behavior to what is written in the documentation and how it behaves if they are not passed:

> ## [Trace Input/Output Behavior](https://langfuse.com/docs/sdk/python/sdk-v3#trace-inputoutput-behavior)
> In v3, trace input and output are automatically set from the root observation (first span/generation) by default. This differs from v2 where integrations could set trace-level inputs/outputs directly.

I reproduced the issue with the following code on version `3.2.1`:

```python
import uuid

from typing import Any

from dotenv import load_dotenv
from langfuse import __version__ as langfuse_version, get_client, observe


print("langfuse_version: ", langfuse_version)

load_dotenv()

langfuse_client = get_client()


WITH_REMOTE_TRACING = True
SUFFIX = "remote" if WITH_REMOTE_TRACING else "no-remote"


def get_tracing_params() -> dict[str, Any]:
    if WITH_REMOTE_TRACING:
        trace_id = langfuse_client.get_current_trace_id()
        parent_observation_id = langfuse_client.get_current_observation_id()
        return {"langfuse_trace_id": trace_id, "langfuse_parent_observation_id": parent_observation_id}
    else:
        return {}


@observe(name=f"root-{SUFFIX}")
async def root(called_by: str):
    id_ = str(uuid.uuid4())
    res = await child("root", **get_tracing_params())
    output = {"output-override": "roman", "id": id_}
    # langfuse_client.update_current_trace(output=output, metadata={"test": "test-tom"})
    return res | {"root_workflow": "root_workflow", "id": id_}


@observe(name=f"child-{SUFFIX}")
async def child(called_by: str):
    return {"child_workflow": "child_workflow"} | await activity("child", **get_tracing_params())


@observe(name=f"activity-{SUFFIX}")
async def activity(called_by: str):
    return {"cool_activity": "cool_activity"}


async def main():
    """Execute the workflows with proper context"""
    try:
        # Wait for the workflow to complete
        result = await root("main")
        print("✅ completed successfully!")
        print(f"📊 Result: {result}")

        return result

    except Exception as e:
        print(f"❌ execution failed: {e}")
        raise


if __name__ == "__main__":
    import asyncio

    asyncio.run(main())

```

Following a trace and an activity examples with the issue:
<img width="1137" height="687" alt="before trace" src="https://github.com/user-attachments/assets/273a9699-dcdc-402c-870d-e660096558be" />
<img width="1135" height="689" alt="before span" src="https://github.com/user-attachments/assets/8e91c451-a63f-4a1c-a919-dec91d343c43" />

And here a trace example after the fix:
<img width="1140" height="730" alt="after trace" src="https://github.com/user-attachments/assets/6c98fd63-5320-4b46-9c0e-42a684ee00ba" />
