### PR TITLE
chore(client): add check for tracing setting

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1639,6 +1639,11 @@ class Langfuse:
                 external_system.process(data, trace_id=trace_id)
             ```
         """
+        if not self._tracing_enabled:
+            langfuse_logger.debug(
+                "Operation skipped: update_current_span - Tracing is disabled or client is in no-op mode."
+            )
+            return
         current_otel_span = self._get_current_otel_span()
 
         return self._get_otel_trace_id(current_otel_span) if current_otel_span else None
@@ -1666,6 +1671,11 @@ class Langfuse:
                 # Process the query...
             ```
         """
+        if not self._tracing_enabled:
+            langfuse_logger.debug(
+                "Operation skipped: update_current_span - Tracing is disabled or client is in no-op mode."
+            )
+            return
         current_otel_span = self._get_current_otel_span()
 
         return self._get_otel_span_id(current_otel_span) if current_otel_span else None

--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1641,7 +1641,7 @@ class Langfuse:
         """
         if not self._tracing_enabled:
             langfuse_logger.debug(
-                "Operation skipped: update_current_span - Tracing is disabled or client is in no-op mode."
+                "Operation skipped: get_current_trace_id - Tracing is disabled or client is in no-op mode."
             )
             return
         current_otel_span = self._get_current_otel_span()
@@ -1673,7 +1673,7 @@ class Langfuse:
         """
         if not self._tracing_enabled:
             langfuse_logger.debug(
-                "Operation skipped: update_current_span - Tracing is disabled or client is in no-op mode."
+                "Operation skipped: get_current_observation_id - Tracing is disabled or client is in no-op mode."
             )
             return
         current_otel_span = self._get_current_otel_span()


### PR DESCRIPTION
Inside `update_current_span` as well as in `update_current_trace` and `update_current_generation` it is checked if tracing is enabled:

```py
if not self._tracing_enabled:
	langfuse_logger.debug(
		"Operation skipped: update_current_generation - Tracing is disabled or client is in no-op mode."
	)
	return
```

This tiny PR simply adds the same check to `get_current_trace_id` and `get_current_observation_id`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tracing enabled check to `get_current_trace_id` and `get_current_observation_id` in `client.py`.
> 
>   - **Behavior**:
>     - Add tracing enabled check to `get_current_trace_id` and `get_current_observation_id` in `client.py`.
>     - Logs debug message and returns early if tracing is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 7ee2aeb9d4b2b8c27e5ca628ce493dff0c595f41. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR adds tracing enablement checks to two getter methods in the Langfuse client: `get_current_trace_id` and `get_current_observation_id`. The change maintains consistency with existing update methods (`update_current_span`, `update_current_trace`, and `update_current_generation`) that already include these checks.

The modification ensures that when tracing is disabled (`self._tracing_enabled` is False), these getter methods will return early with a debug log message rather than attempting to retrieve trace or observation IDs. This aligns with the client's no-op behavior pattern when tracing is explicitly disabled, preventing inconsistent behavior where update operations would be skipped but getter operations would still attempt to access tracing data.

The implementation follows the exact same pattern used in other methods: checking the `_tracing_enabled` flag, logging a debug message when disabled, and returning early to skip the operation.

## Confidence score: 2/5

• This PR has a critical bug in the debug log messages that will cause confusion during debugging
• The incorrect method names in log messages ('update_current_span' instead of the actual method names) make this unsafe to merge as-is
• `langfuse/_client/client.py` needs immediate attention to fix the debug message method names before merging

<!-- /greptile_comment -->