### PR TITLE
fix: add support for fetching prompts in a folder with api.prompts.get

### DIFF
--- a/langfuse/api/resources/prompts/client.py
+++ b/langfuse/api/resources/prompts/client.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import typing
 from json.decoder import JSONDecodeError
+import urllib.parse
 
 from ...core.api_error import ApiError
 from ...core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
@@ -73,7 +74,7 @@ class PromptsClient:
         )
         """
         _response = self._client_wrapper.httpx_client.request(
-            f"api/public/v2/prompts/{jsonable_encoder(prompt_name)}",
+            f"api/public/v2/prompts/{urllib.parse.quote(prompt_name, safe='')}",
             method="GET",
             params={"version": version, "label": label},
             request_options=request_options,
@@ -350,7 +351,7 @@ class AsyncPromptsClient:
         asyncio.run(main())
         """
         _response = await self._client_wrapper.httpx_client.request(
-            f"api/public/v2/prompts/{jsonable_encoder(prompt_name)}",
+            f"api/public/v2/prompts/{urllib.parse.quote(prompt_name, safe='')}",
             method="GET",
             params={"version": version, "label": label},
             request_options=request_options,


### PR DESCRIPTION
This PR is a fix for [Issue 8006](https://github.com/langfuse/langfuse/issues/8006) where the api.prompts.get was returning a 404 for the user when the prompt was within a folder.

I have mentioned the cause for the bug in the issue comment but I am pasting the gist of it here

### Cause of the Bug

The error for this seems to be at **langfuse/api/resources/promts/client.py** in two places

- get method of PromptsClient
- get method of AsyncPromptsClient

The problem specifically is with this function call 

```python
_response = await self._client_wrapper.httpx_client.request(
    f"api/public/v2/prompts/{jsonable_encoder(prompt_name)}",
    method="GET",
    params={"version": version, "label": label},
    request_options=request_options,
)
```

_jsonable_encoder_ returns the data as is when you pass a string to it. As a result, there is no encoding of any kind that happens to prompts which are within a folder. 


### Fix for the Bug

- I now manually encode the prompt with urllib.parse.quote instead of passing it to jsonable_encoder and get the encoded prompt both in the PromptsClient and in AsyncPromptsClient

### Sample code to reproduce the problem and verify it works with the bug fix

```python
import asyncio
from langfuse import Langfuse

def fetch_prompt_with_sync_api():
    langfuse = Langfuse(
        public_key="<private_key>",
        secret_key="<secret_key>",
        host="https://cloud.langfuse.com"
    )

    return langfuse.api.prompts.get("folder/math_prompt")

async def fetch_prompt_async_api_with_keys():
    langfuse = Langfuse(
        public_key="<private_key>",
        secret_key="sk-lf-271d0ba8-ce13-42e4-b343-e41d7164434d",
        host="https://cloud.langfuse.com"
    )

    return await langfuse.async_api.prompts.get("folder/math_prompt")

async def main():
    """
    Main asynchronous function to run the prompt fetching.
    """
    sync_prompt = fetch_prompt_with_sync_api()

    print("[+] Printing the fetched prompt")
    print(sync_prompt)

    fetched_prompt = await fetch_prompt_async_api_with_keys()

    print("[+] Printing the fetched Prompt")
    print(fetched_prompt)

if __name__ == "__main__":
    asyncio.run(main())

```

Post this fix, the API no longer throws a 404. I am checking to see if there are any kind of tests I can add to **tests/test_prompt.py** to test for this behaviour but I believe this can be a good starting point to review?