### PR TITLE
fix: avoid private import of Langfuse to satisify Pyright

### DIFF
--- a/langfuse/__init__.py
+++ b/langfuse/__init__.py
@@ -1,10 +1,12 @@
 """.. include:: ../README.md"""
 
 from ._client.attributes import LangfuseOtelSpanAttributes
-from ._client.client import Langfuse
 from ._client.get_client import get_client
+from ._client import client as _client
 from ._client.observe import observe
 from ._client.span import LangfuseEvent, LangfuseGeneration, LangfuseSpan
+
+Langfuse = _client.Langfuse
 
 __all__ = [
     "Langfuse",


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/8176

Pyright flags Langfuse import as private after py.typed was added. 

Fix: explicitly re-export in __init__.py