### PR TITLE
fix(client): add warning message if OTEL_SDK_DISABLED

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -221,6 +221,11 @@ class Langfuse:
             self._otel_tracer = otel_trace_api.NoOpTracer()
             return
 
+        if os.environ.get("OTEL_SDK_DISABLED", "false").lower() == "true":
+            langfuse_logger.warning(
+                "OTEL_SDK_DISABLED is set. Langfuse tracing will be disabled and no traces will appear in the UI."
+            )
+
         # Initialize api and tracer if requirements are met
         self._resources = LangfuseResourceManager(
             public_key=public_key,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a warning log in `Langfuse` class to notify when `OTEL_SDK_DISABLED` is set, disabling tracing.
> 
>   - **Behavior**:
>     - Adds a warning log in `__init__()` of `Langfuse` class in `client.py` if `OTEL_SDK_DISABLED` environment variable is set to true, indicating that Langfuse tracing will be disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 89501a57dccc1c4e2dab84be443e4c926bf882e7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR adds a helpful warning message to the Langfuse client initialization process. The change detects when the `OTEL_SDK_DISABLED` environment variable is set to 'true' and displays a clear warning that Langfuse tracing will be disabled and no traces will appear in the UI.

The warning is strategically placed in the client constructor after authentication validation but before the LangfuseResourceManager initialization. This timing ensures that users receive immediate feedback about a configuration that would silently prevent tracing from working. The implementation uses the existing `langfuse_logger` and follows a simple check against the environment variable with appropriate case-insensitive handling.

This change addresses a common user experience issue where developers might have `OTEL_SDK_DISABLED=true` set in their environment (perhaps from other OpenTelemetry work) and then wonder why their Langfuse traces aren't appearing. Instead of silent failure, users now get explicit notification about why tracing is disabled, which significantly improves the debugging experience.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only adds a logging statement with no functional changes
- Score reflects the simple, non-invasive nature of adding a warning message that improves user experience
- No files require special attention as this is a straightforward logging addition

<!-- /greptile_comment -->