### PR TITLE
fix(langchain): take only int values in parsed usage

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -875,15 +875,28 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]) -> Any:
     usage_model = cast(Dict, usage.copy())  # Copy all existing key-value pairs
 
     # Skip OpenAI usage types as they are handled server side
-    if all(
-        openai_key in usage_model
-        for openai_key in [
-            "prompt_tokens",
-            "completion_tokens",
-            "total_tokens",
-            "prompt_tokens_details",
-            "completion_tokens_details",
-        ]
+    if (
+        all(
+            openai_key in usage_model
+            for openai_key in [
+                "prompt_tokens",
+                "completion_tokens",
+                "total_tokens",
+                "prompt_tokens_details",
+                "completion_tokens_details",
+            ]
+        )
+        and len(usage_model.keys()) == 5
+    ) or (
+        all(
+            openai_key in usage_model
+            for openai_key in [
+                "prompt_tokens",
+                "completion_tokens",
+                "total_tokens",
+            ]
+        )
+        and len(usage_model.keys()) == 3
     ):
         return usage_model
 
@@ -971,7 +984,7 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]) -> Any:
                     if "input" in usage_model:
                         usage_model["input"] = max(0, usage_model["input"] - value)
 
-    usage_model = {k: v for k, v in usage_model.items() if type(v) is int}
+    usage_model = {k: v for k, v in usage_model.items() if isinstance(v, int)}
 
     return usage_model if usage_model else None
 

--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -965,7 +965,7 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]) -> Any:
                     if "input" in usage_model:
                         usage_model["input"] = max(0, usage_model["input"] - value)
 
-    usage_model = {k: v for k, v in usage_model.items() if not isinstance(v, str)}
+    usage_model = {k: v for k, v in usage_model.items() if isinstance(v, int)}
 
     return usage_model if usage_model else None
 

--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -971,7 +971,7 @@ def _parse_usage_model(usage: typing.Union[pydantic.BaseModel, dict]) -> Any:
                     if "input" in usage_model:
                         usage_model["input"] = max(0, usage_model["input"] - value)
 
-    usage_model = {k: v for k, v in usage_model.items() if isinstance(v, int)}
+    usage_model = {k: v for k, v in usage_model.items() if type(v) is int}
 
     return usage_model if usage_model else None
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Updates `_parse_usage_model` in `CallbackHandler.py` to filter usage model values, retaining only integers, potentially causing data loss for float values.
> 
>   - **Behavior**:
>     - Updates `_parse_usage_model` in `CallbackHandler.py` to filter usage model values, retaining only integers.
>     - Previous logic excluded strings but allowed other types; now only integers are allowed.
>   - **Potential Issues**:
>     - May cause data loss by excluding legitimate float values representing costs or fractional metrics.
>     - Could break functionality for models returning float-based usage data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 3bb9c43472bf01e68e11d18c44c5728cc82906d3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR modifies the usage parsing logic in the LangChain callback handler (`CallbackHandler.py`) to be more restrictive when filtering usage model values. The change on line 968 updates the filtering condition from `not isinstance(v, str)` to `isinstance(v, int)`, meaning only integer values are now kept in the parsed usage model.

Based on the PR title referencing "qwen", this change appears to address an issue with Qwen models that return non-numeric string values in their usage metadata. The previous logic excluded only strings but allowed other types (including floats) to pass through. The new logic takes a more restrictive approach by only allowing integers.

This change integrates with Langfuse's usage tracking system, which uses Pydantic models like `Usage` and `OpenAiUsage` to structure token and cost data. These models typically accept optional integer fields for counts like `input`, `output`, `total`, and optional float fields for costs like `input_cost`, `output_cost`, `total_cost`. The filtering happens before this data reaches the Pydantic models.

## Confidence score: 2/5

- This PR introduces potential data loss by filtering out legitimate float values that could represent costs or fractional usage metrics
- Score lowered due to overly restrictive filtering logic that may break existing functionality for models that return float-based usage data
- Pay close attention to `langfuse/langchain/CallbackHandler.py` line 968 and consider testing with various model providers that return float usage values

<!-- /greptile_comment -->