### PR TITLE
fix(openai): handle async response api input and outputs

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -408,6 +408,12 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
         else float("inf")
     )
 
+    parsed_max_completion_tokens = (
+        kwargs.get("max_completion_tokens", None)
+        if not isinstance(kwargs.get("max_completion_tokens", float("inf")), NotGiven)
+        else None
+    )
+
     parsed_top_p = (
         kwargs.get("top_p", 1)
         if not isinstance(kwargs.get("top_p", 1), NotGiven)
@@ -441,6 +447,11 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
         "frequency_penalty": parsed_frequency_penalty,
         "presence_penalty": parsed_presence_penalty,
     }
+
+    if parsed_max_completion_tokens is not None:
+        modelParameters.pop("max_tokens", None)
+        modelParameters["max_completion_tokens"] = parsed_max_completion_tokens
+
     if parsed_n is not None and parsed_n > 1:
         modelParameters["n"] = parsed_n
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes compatibility with OpenAI's AsyncResponses API by updating conditional checks in `langfuse/openai.py` to handle both sync and async response objects.
> 
>   - **Behavior**:
>     - Updates conditional checks in `langfuse/openai.py` to handle both `Responses` and `AsyncResponses` objects.
>     - Ensures prompt extraction uses 'input' for async responses (lines 394-395).
>     - Corrects output processing for async responses (lines 675-676).
>     - Maintains consistent handling for sync and async response streaming (lines 924-926, 995-997).
>   - **Misc**:
>     - Adds handling for `max_completion_tokens` in `modelParameters` (lines 408-414, 451-453).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for c61b70bf3dbc0b6c75ba7d8747ee375b5d23bd7b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR fixes a compatibility issue with OpenAI's AsyncResponses API in the Langfuse OpenAI integration. The OpenAI Python SDK version 1.66.0 introduced separate `Responses` (sync) and `AsyncResponses` (async) objects for response API endpoints, but the existing Langfuse code was only checking for `Responses` objects.

The fix extends four key conditional checks throughout the OpenAI integration to handle both object types:
- **Prompt extraction logic** (lines 394-395): Ensures async response API calls extract prompts from the 'input' parameter rather than treating them as chat completions
- **Response parsing logic** (lines 675-676): Ensures async responses use the correct output processing specific to response APIs
- **Sync streaming finalization** (lines 924-926): Maintains consistent handling for both sync and async response streaming
- **Async streaming finalization** (lines 995-997): Ensures async streaming responses are processed with the same logic as sync ones

Without this fix, async response API calls would incorrectly fall through to the default chat completion logic, leading to improper input/output extraction and potentially incorrect trace data in Langfuse. The change maintains backward compatibility while ensuring that both sync and async response API calls receive identical treatment in terms of prompt extraction, output processing, and streaming response handling.

This change fits into the broader OpenAI integration pattern where different API endpoints (chat completions vs. response APIs) require different handling logic, and the code uses the `resource.object` property to determine the appropriate processing path.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects a simple, targeted fix that addresses a specific compatibility issue without introducing complex logic changes
- No files require special attention as the changes are straightforward conditional additions

<!-- /greptile_comment -->