### PR TITLE
Fix premature end of langchain agent span

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -370,11 +370,6 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                     LangfuseOtelSpanAttributes.OBSERVATION_TYPE, "agent"
                 )
 
-            agent_run.update(
-                output=action,
-                input=kwargs.get("inputs"),
-            ).end()
-
         except Exception as e:
             langfuse_logger.exception(e)
 
@@ -398,11 +393,6 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                 agent_run._otel_span.set_attribute(
                     LangfuseOtelSpanAttributes.OBSERVATION_TYPE, "agent"
                 )
-
-            agent_run.update(
-                output=finish,
-                input=kwargs.get("inputs"),
-            ).end()
 
         except Exception as e:
             langfuse_logger.exception(e)


### PR DESCRIPTION
LangChain sends the same `run_id` for `agent_action`, `agent_finish`, and `chain_end` during an agent interaction.

Therefore, only the `chain_end` callback is used to end the agent span to avoid it being prematurely ended.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `on_agent_action` and `on_agent_finish` methods from `CallbackHandler.py` to prevent premature span termination, relying solely on `on_chain_end` to end spans.
> 
>   - **Behavior**:
>     - Removes `on_agent_action` and `on_agent_finish` methods from `CallbackHandler.py`.
>     - `on_chain_end` now solely ends the agent span, preventing premature span termination.
>   - **Imports**:
>     - Removes unused imports `AgentAction` and `AgentFinish` from `CallbackHandler.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 2781062301eb324fc589e74d85404c6b7f02d937. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR fixes a critical issue in the LangChain callback handler where agent spans were being prematurely terminated. The root cause was that LangChain reuses the same `run_id` across multiple callback events (`agent_action`, `agent_finish`, and `chain_end`) during a single agent interaction, causing spans to be ended multiple times.

The solution removes two callback methods (`on_agent_action` and `on_agent_finish`) from the `CallbackHandler` class in `langfuse/langchain/CallbackHandler.py`. These methods were calling `.end()` on spans when they received their respective events, but since all three events share the same `run_id`, this resulted in spans being closed before the agent interaction was actually complete.

By eliminating these intermediate callbacks and relying solely on `on_chain_end` to handle span termination, the change ensures that agent spans remain active throughout the entire agent execution lifecycle and are only closed when the agent's work is truly finished. The PR also removes the now-unused imports for `AgentAction` and `AgentFinish` from `langchain.schema.agent`.

This change integrates well with the existing codebase architecture, as the callback handler already has a robust span management system through the `self.runs` dictionary that tracks active spans by their `run_id`. The fix aligns with LangChain's callback model where `chain_end` represents the definitive completion of an agent's execution cycle.

## Confidence score: 4/5

- This PR addresses a well-defined bug with a targeted solution that has minimal risk of side effects
- Score reflects the focused nature of the change and clear understanding of LangChain's callback architecture
- Pay close attention to testing with agent-based workflows to ensure the fix works as expected in production scenarios

<!-- /greptile_comment -->