### PR TITLE
feat(langchain): set callback spans to active in OTEL context

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -763,7 +763,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                 "prompt": registered_prompt,
             }
 
-            generation = self.client.start_observation(as_type="generation", **content)
+            generation = self.client.start_observation(as_type="generation", **content)  # type: ignore
             self._attach_observation(run_id, generation)
 
             self.last_trace_id = self.runs[run_id].trace_id


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances LangChain CallbackHandler with OTEL context management for better distributed tracing in Langfuse.
> 
>   - **Behavior**:
>     - Adds `_attach_observation()` and `_detach_observation()` methods in `CallbackHandler.py` to manage OTEL context.
>     - Replaces direct `self.runs` assignments with span attachment/detachment in methods like `on_chain_start`, `on_tool_start`, `on_llm_start`, etc.
>     - Ensures Langfuse spans are active in OTEL context for proper trace hierarchy.
>   - **Data Structures**:
>     - Introduces `context_tokens` dictionary to track OTEL context tokens alongside `runs`.
>   - **Error Handling**:
>     - Consistent error handling and resource cleanup in span management methods.
>   - **Misc**:
>     - Minor import reordering in `CallbackHandler.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for a0ce171d3a735c08aa69f2b8612fbf9d068fcfdd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR enhances the LangChain CallbackHandler in Langfuse to properly integrate with OpenTelemetry (OTEL) context management. The changes implement systematic span attachment and detachment methods that ensure Langfuse spans become the "active span" in OTEL context, which is crucial for distributed tracing and frameworks like LangGraph that rely on OTEL context propagation.

The implementation adds two key methods:
- `_attach_observation()`: Sets a Langfuse span as active in OTEL context using `trace.set_span_in_context()` and `context.attach()`, storing the context token for later cleanup
- `_detach_observation()`: Properly cleans up OTEL context by calling `context.detach()` with the stored token and removes the span from tracking

These methods replace direct assignment to `self.runs` throughout all callback lifecycle methods (`on_chain_start`, `on_tool_start`, `on_llm_start`, etc.). The change adds a `context_tokens` dictionary to track OTEL context tokens alongside the existing `runs` dictionary, ensuring proper pairing of attach/detach operations.

This integration allows Langfuse spans to participate correctly in OTEL's context propagation mechanism, ensuring that child operations created by other OTEL-aware libraries are properly nested under Langfuse spans in the trace hierarchy. This is particularly important for complex workflows using frameworks like LangGraph where multiple tracing systems need to work together seamlessly.

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it maintains backward compatibility while adding essential OTEL integration
- Score reflects well-structured implementation with consistent error handling and proper resource cleanup patterns
- Pay close attention to the `_attach_observation()` and `_detach_observation()` methods to ensure OTEL context management is working correctly

<!-- /greptile_comment -->