### PR TITLE
feat(openai): add openrouter cost tracking

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -494,6 +494,7 @@ def _create_langfuse_update(
 
     if usage is not None:
         update["usage_details"] = _parse_usage(usage)
+        update["cost_details"] = _parse_cost(usage)
 
     generation.update(**update)
 
@@ -521,6 +522,18 @@ def _parse_usage(usage: Optional[Any] = None) -> Any:
             }
 
     return usage_dict
+
+
+def _parse_cost(usage: Optional[Any] = None) -> Any:
+    if usage is None:
+        return
+
+    # OpenRouter is returning total cost of the invocation
+    # https://openrouter.ai/docs/use-cases/usage-accounting#cost-breakdown
+    if hasattr(usage, "cost") and isinstance(getattr(usage, "cost"), float):
+        return {"total": getattr(usage, "cost")}
+
+    return None
 
 
 def _extract_streamed_response_api_response(chunks: Any) -> Any:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds cost tracking for OpenRouter in Langfuse OpenAI integration by updating `_create_langfuse_update()` and introducing `_parse_cost()` in `langfuse/openai.py`.
> 
>   - **Behavior**:
>     - Adds cost tracking for OpenRouter in `langfuse/openai.py` by updating `_create_langfuse_update()` to include `cost_details`.
>     - Introduces `_parse_cost()` to extract cost from `usage` if available.
>   - **Functions**:
>     - `_create_langfuse_update()` now calls `_parse_cost()` to add `cost_details` to the update.
>     - `_parse_cost()` checks for `cost` attribute in `usage` and returns it if it's a float.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 7ca7ff0fd5b5cbc0bc4ec3357ace43a939c1bcf6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR adds cost tracking support for OpenRouter API usage in Langfuse's OpenAI integration. The change introduces a new `_parse_cost()` function that extracts cost information from OpenRouter's usage response and integrates it into the existing generation update workflow.

The implementation is straightforward: it checks if the usage object has a `cost` attribute (which OpenRouter provides as the total USD cost of the API call) and maps it to the `cost_details.total` field in the generation update. This follows OpenRouter's documented API format where cost is provided directly as a float value, unlike standard OpenAI responses that require model pricing lookups.

The change integrates cleanly with the existing usage parsing infrastructure in `langfuse/openai.py`. The cost parsing is called alongside the existing `_parse_usage()` function at line 497, maintaining consistency with the current architecture. This allows users to see actual costs in Langfuse when using OpenRouter models without needing to manually configure custom model definitions for cost tracking.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects simple, focused implementation with proper error handling and clear integration point
- No files require special attention

<!-- /greptile_comment -->