### PR TITLE
Dynamic Header Support

### DIFF
--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -464,7 +464,7 @@ class _LangfuseInstrumentedHttpx(httpx.Auth):
     def __init__(
         self,
         headers_provider: Optional[
-            Union[Mapping[str, Any], Callable[[], Mapping[str, Any]]]
+            Union[Mapping[str, str], Callable[[], Mapping[str, str]]]
         ],
     ):
         self._headers_provider = headers_provider


### PR DESCRIPTION
Support for dynamic headers in OTEL and Langfuse requests

- resolves issues with hosting Langfuse behind authentication/proxies (Google IAP, etc) that require dynamic auth tokens or other header values with limited lifetimes.

- handling/rotation of these headers for auth is outside the scope of, but any values will be read in on each request from a provided dict on each request so the user can provide these dynamically.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds dynamic header support for Langfuse and OTEL requests, enabling runtime evaluation of headers, and updates version to 3.3.3.
> 
>   - **Dynamic Header Support**:
>     - Introduces `_LangfuseInstrumentedHttpx` in `resource_manager.py` for dynamic headers in Langfuse requests.
>     - Implements `_LangfuseInstrumentedSession` in `span_processor.py` for dynamic headers in OTEL requests.
>     - Supports callable or mapping for dynamic headers, allowing runtime evaluation.
>   - **Version Update**:
>     - Bumps version to `3.3.3` in `version.py` and `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 68d604aefa7acdc54746eb418098dca9639f3d78. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-02 09:57:46 UTC

This PR adds dynamic header support to both OpenTelemetry (OTEL) and Langfuse API requests, addressing limitations when hosting Langfuse behind authentication proxies like Google Identity-Aware Proxy (IAP) that require dynamic authentication tokens with limited lifetimes.

The implementation introduces two custom HTTP client classes:

1. **`_LangfuseInstrumentedHttpx`** - A custom httpx.Auth class for Langfuse API requests that overrides the `auth_flow` method to dynamically evaluate headers on each request
2. **`_LangfuseInstrumentedSession`** - A custom requests.Session subclass for OTEL span exports that overrides the `send()` method to inject dynamic headers before each HTTP request

Both classes accept `additional_headers` as either a static `Mapping[str, Any]` or a `Callable[[], Mapping[str, Any]]`, maintaining backward compatibility while enabling dynamic header generation. The change modifies the `LangfuseResourceManager` and `LangfuseSpanProcessor` constructors to accept this Union type and instantiate the custom client classes instead of using static headers.

The version has been bumped from 3.3.2 to 3.3.3 in both `pyproject.toml` and `langfuse/version.py`, following semantic versioning conventions for a minor feature addition.

## Confidence score: 3/5

- This PR addresses a legitimate enterprise use case but introduces some design complexity that could be problematic
- Score reflects concerns about thread safety, error handling, and potential performance implications of the custom HTTP client implementations
- Pay close attention to the custom authentication classes in `resource_manager.py` and `span_processor.py` as they override core HTTP functionality

<!-- /greptile_comment -->