### PR TITLE
fix(openai): openrouter non-streamed cost tracking

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -791,6 +791,9 @@ def _wrap(
                 model=model,
                 output=completion,
                 usage_details=usage,
+                cost_details=_parse_cost(openai_response.usage)
+                if hasattr(openai_response, "usage")
+                else None,
             ).end()
 
         return openai_response
@@ -855,6 +858,9 @@ async def _wrap_async(
                 output=completion,
                 usage=usage,  # backward compat for all V2 self hosters
                 usage_details=usage,
+                cost_details=_parse_cost(openai_response.usage)
+                if hasattr(openai_response, "usage")
+                else None,
             ).end()
 
         return openai_response


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds cost tracking for non-streamed OpenRouter responses in synchronous and asynchronous wrappers in `langfuse/openai.py`.
> 
>   - **Behavior**:
>     - Adds cost tracking for non-streamed OpenRouter responses in `_wrap()` and `_wrap_async()` functions in `langfuse/openai.py`.
>     - Uses `_parse_cost()` to extract cost details from `openai_response.usage` if available.
>   - **Functions**:
>     - Updates `generation.update()` in `_wrap()` and `_wrap_async()` to include `cost_details`.
>     - `_parse_cost()` checks for `cost` attribute in `usage` and returns a dictionary with total cost if present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 51bbad1afd9ab82551d7e75ea49648df57a06ac3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-02 14:15:53 UTC

This PR fixes cost tracking for non-streamed OpenRouter API responses in the Langfuse OpenAI integration. The changes add explicit cost extraction logic to both synchronous and asynchronous wrapper functions that handle non-streamed OpenAI API responses.

The core issue was that OpenRouter (an OpenAI-compatible API provider) returns cost information in a different format than standard OpenAI responses - specifically in a `cost` field within the usage object. While Langfuse already had cost parsing logic for streamed responses via the `_create_langfuse_update` function, non-streamed responses were missing this cost tracking capability for OpenRouter.

The implementation leverages the existing `_parse_cost()` function, which already contains OpenRouter-specific logic to extract cost data from the usage object's `cost` attribute and format it as `{"total": cost_value}`. The fix adds conditional cost parsing in two locations:

1. Line 794-796 in the sync wrapper (`_wrap` function)
2. Line 861-863 in the async wrapper (`_wrap_async` function)

Both additions use the same pattern: `cost_details=_parse_cost(openai_response.usage) if hasattr(openai_response, "usage") else None`. This ensures cost tracking works for OpenRouter while maintaining backward compatibility with other OpenAI-compatible providers that may not have usage data available.

The change integrates seamlessly with Langfuse's existing cost tracking infrastructure and follows the established pattern of conditional attribute checking before attempting to extract cost information.

## Confidence score: 4/5

- This PR is safe to merge with low risk of breaking existing functionality
- Score reflects targeted fix with proper conditional checks and reuse of existing parsing logic
- Pay close attention to `langfuse/openai.py` for integration testing with different API providers

<!-- /greptile_comment -->