### PR TITLE
fix: prevent authentication warnings when tracing is disabled

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -218,6 +218,8 @@ class Langfuse:
             langfuse_logger.info(
                 "Configuration: Langfuse tracing is explicitly disabled. No data will be sent to the Langfuse API."
             )
+            self._otel_tracer = otel_trace_api.NoOpTracer()
+            return
 
         debug = (
             debug if debug else (os.getenv(LANGFUSE_DEBUG, "false").lower() == "true")

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -2020,3 +2020,17 @@ def test_that_generation_like_properties_are_actually_created():
         assert (
             obs.completion_start_time is not None
         ), f"{obs_type} should persist completion_start_time property"
+
+
+def test_disabled_tracing_no_auth_warnings(monkeypatch, caplog):
+    """Test that disabling tracing prevents authentication warnings."""
+    import logging
+
+    # Remove any existing API keys to simulate missing credentials
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.setenv("LANGFUSE_TRACING_ENABLED", "false")
+
+    with caplog.at_level(logging.WARNING, logger="langfuse"):
+        Langfuse(tracing_enabled=False)
+        assert "Authentication error" not in caplog.text


### PR DESCRIPTION
resolves: https://github.com/langfuse/langfuse/issues/8978

Added early return in `Langfuse.__init__()` when tracing_enabled=False to skip authentication checks entirely.

Only committed the specific hunks related to this fix. Running `$ poetry run ruff format .` creates unrelated diffs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add early return in `Langfuse.__init__()` to skip authentication checks when tracing is disabled, and add a test to verify no warnings are logged.
> 
>   - **Behavior**:
>     - Add early return in `Langfuse.__init__()` in `client.py` to skip authentication checks when `tracing_enabled=False`.
>   - **Tests**:
>     - Add `test_disabled_tracing_no_auth_warnings()` in `test_core_sdk.py` to verify no authentication warnings are logged when tracing is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for bc2f63e2e82554f1670fe78c9d1e5b8d341ef18c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-06 05:21:34 UTC

This PR fixes a user experience issue where authentication warnings were being displayed even when users explicitly disabled Langfuse tracing. The change implements an early return pattern in the `Langfuse.__init__()` method when `tracing_enabled=False` (either via parameter or the `LANGFUSE_TRACING_ENABLED` environment variable).

The core modification is in `langfuse/_client/client.py` at lines 217-222, where the constructor now checks if tracing is disabled and immediately returns after setting up a NoOpTracer, bypassing all subsequent authentication logic. Previously, the constructor would continue executing authentication checks (lines 234-249) regardless of the tracing status, leading to confusing warning messages about missing API keys when users legitimately didn't need them.

The fix includes a comprehensive test in `test_core_sdk.py` that verifies the behavior by simulating missing API credentials and confirming that no 'Authentication error' warnings appear in the logs when tracing is disabled. This test ensures the early return logic works correctly and maintains the expected behavior.

This change integrates well with the existing codebase architecture, where the `NoOpTracer` pattern is already used for disabled tracing scenarios. The early return prevents unnecessary initialization while maintaining API compatibility for any existing code that might call tracing methods on a disabled client.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only affects the initialization flow when tracing is explicitly disabled
- Score reflects a targeted fix with clear test coverage that addresses a specific user experience issue without changing core functionality
- No files require special attention as the changes are straightforward and well-tested

<!-- /greptile_comment -->