### PR TITLE
fix: fix Chinese character escaping issue

### DIFF
--- a/langfuse/_client/attributes.py
+++ b/langfuse/_client/attributes.py
@@ -174,7 +174,7 @@ def _serialize(obj: Any) -> Optional[str]:
     if obj is None or isinstance(obj, str):
         return obj
 
-    return json.dumps(obj, cls=EventSerializer)
+    return json.dumps(obj, cls=EventSerializer, ensure_ascii=False)
 
 
 def _flatten_and_serialize_metadata(

--- a/langfuse/_client/utils.py
+++ b/langfuse/_client/utils.py
@@ -59,6 +59,7 @@ def span_formatter(span: ReadableSpan) -> str:
                 "instrumentationScope": instrumentationScope,
             },
             indent=2,
+            ensure_ascii=False,
         )
         + "\n"
     )

--- a/langfuse/_task_manager/score_ingestion_consumer.py
+++ b/langfuse/_task_manager/score_ingestion_consumer.py
@@ -85,7 +85,7 @@ class ScoreIngestionConsumer(threading.Thread):
 
                 # check for serialization errors
                 try:
-                    json.dumps(event, cls=EventSerializer)
+                    json.dumps(event, cls=EventSerializer, ensure_ascii=False)
                 except Exception as e:
                     self._log.error(
                         f"Data error: Failed to serialize score object for ingestion. Score will be dropped. Error: {e}"
@@ -117,7 +117,7 @@ class ScoreIngestionConsumer(threading.Thread):
 
     def _get_item_size(self, item: Any) -> int:
         """Return the size of the item in bytes."""
-        return len(json.dumps(item, cls=EventSerializer).encode())
+        return len(json.dumps(item, cls=EventSerializer, ensure_ascii=False).encode())
 
     def run(self) -> None:
         """Run the consumer."""

--- a/langfuse/_utils/request.py
+++ b/langfuse/_utils/request.py
@@ -60,7 +60,7 @@ class LangfuseClient:
         """Post the `kwargs` to the API"""
         log = logging.getLogger("langfuse")
         url = self._remove_trailing_slash(self._base_url) + "/api/public/ingestion"
-        data = json.dumps(kwargs, cls=EventSerializer)
+        data = json.dumps(kwargs, cls=EventSerializer, ensure_ascii=False)
         log.debug("making request: %s to %s", data, url)
         headers = self.generate_headers()
         res = self._session.post(

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -174,3 +174,27 @@ def test_slots():
     obj = SlotClass()
     serializer = EventSerializer()
     assert json.loads(serializer.encode(obj)) == {"field": "value"}
+
+
+def test_non_ascii_characters_not_escaped():
+    """Test that non-ASCII characters are serialized directly without \\uXXXX escaping."""
+    data = {
+        "chinese": "你好世界",
+        "japanese": "こんにちは",
+        "korean": "안녕하세요",
+        "emoji": "🎉",
+    }
+
+    result = json.dumps(data, cls=EventSerializer, ensure_ascii=False)
+
+    # Verify non-ASCII characters appear directly in output
+    assert "你好世界" in result
+    assert "こんにちは" in result
+    assert "안녕하세요" in result
+    assert "🎉" in result
+
+    # Verify no unicode escape sequences
+    assert "\\u" not in result
+
+    # Verify JSON is still valid
+    assert json.loads(result) == data


### PR DESCRIPTION
Add the ensure_ascii=False parameter to all json.dumps calls to ensure non-ASCII characters (such as Chinese) are not escaped into \uXXXX format.

Files to modify:

langfuse/_client/attributes.py: Core serialization functions
langfuse/_utils/request.py: API request data serialization
langfuse/_client/utils.py: Debug output formatting
langfuse/_task_manager/score_ingestion_consumer.py: Score processing serialization

Before Fix & After Fix: 
<img width="1958" height="290" alt="CleanShot 2025-09-09 at 14 06 54@2x" src="https://github.com/user-attachments/assets/e887a44a-ee10-4672-8403-e07cd42c052d" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ensure_ascii=False` to `json.dumps` calls to prevent non-ASCII character escaping in multiple files.
> 
>   - **Behavior**:
>     - Add `ensure_ascii=False` to `json.dumps` in `attributes.py` for core serialization functions.
>     - Add `ensure_ascii=False` to `json.dumps` in `request.py` for API request data serialization.
>     - Add `ensure_ascii=False` to `json.dumps` in `utils.py` for debug output formatting.
>     - Add `ensure_ascii=False` to `json.dumps` in `score_ingestion_consumer.py` for score processing serialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 843ed967a7c63db4e302a16ca04060b96856d465. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-09 06:09:40 UTC

This PR addresses a localization issue where non-ASCII characters (specifically Chinese characters) were being escaped to \uXXXX format in JSON serialization throughout the Langfuse Python SDK. The fix adds the `ensure_ascii=False` parameter to all `json.dumps()` calls across four key files to preserve Unicode characters in their original readable form.

The changes affect multiple serialization touchpoints:
- **langfuse/_client/attributes.py**: Core serialization for OpenTelemetry span attributes
- **langfuse/_utils/request.py**: API request data serialization sent to Langfuse servers
- **langfuse/_client/utils.py**: Debug output formatting for span data
- **langfuse/_task_manager/score_ingestion_consumer.py**: Score processing serialization and size calculations

All modified files use the existing `EventSerializer` class but now explicitly disable ASCII-only encoding. This ensures that when users trace LLM applications containing Chinese text (or other Unicode content), the data remains human-readable in the Langfuse UI, logs, and debug output. The change maintains JSON validity while improving the user experience for international developers.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only affects JSON output formatting without changing data structures or API compatibility
- Score reflects that the changes are straightforward, well-targeted, and follow a consistent pattern across all affected files
- No files require special attention as all changes follow the same simple pattern of adding the `ensure_ascii=False` parameter

<!-- /greptile_comment -->