### PR TITLE
fix(prompt-folders): update prompt in folder failed with wrong encoding

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -2974,7 +2974,7 @@ class Langfuse:
 
         """
         updated_prompt = self.api.prompt_version.update(
-            name=name,
+            name=self._url_encode(name),
             version=version,
             new_labels=new_labels,
         )

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1410,3 +1410,37 @@ def test_update_prompt():
     expected_labels = sorted(["latest", "doe", "production", "john"])
     assert sorted(fetched_prompt.labels) == expected_labels
     assert sorted(updated_prompt.labels) == expected_labels
+
+
+def test_update_prompt_in_folder():
+    langfuse = Langfuse()
+    prompt_name = f"some-folder/{create_uuid()}"
+
+    # Create initial prompt
+    langfuse.create_prompt(
+        name=prompt_name,
+        prompt="test prompt",
+        labels=["production"],
+    )
+
+    old_prompt_obj = langfuse.get_prompt(prompt_name)
+
+    updated_prompt = langfuse.update_prompt(
+        name=old_prompt_obj.name,
+        version=old_prompt_obj.version,
+        new_labels=["john", "doe"],
+    )
+
+    # Fetch prompt after update (should be invalidated)
+    fetched_prompt = langfuse.get_prompt(prompt_name)
+
+    # Verify the fetched prompt matches the updated values
+    assert fetched_prompt.name == prompt_name
+    assert fetched_prompt.version == 1
+    print(f"Fetched prompt labels: {fetched_prompt.labels}")
+    print(f"Updated prompt labels: {updated_prompt.labels}")
+
+    # production was set by the first call, latest is managed and set by Langfuse
+    expected_labels = sorted(["latest", "doe", "production", "john"])
+    assert sorted(fetched_prompt.labels) == expected_labels
+    assert sorted(updated_prompt.labels) == expected_labels


### PR DESCRIPTION
The httpx module encodes some special characters like "/", so this behaviour can bring some issues when managing prompts in folders.

Without parsing these characters on the prompt name, the `update_prompt` method would return an error.
```
Traceback (most recent call last):
  File "/Users/xxx/Projects/langfuse-python/temp.py", line 9, in <module>
    lf.update_prompt(
  File "/Users/xxx/Projects/langfuse-python/langfuse/_client/client.py", line 2976, in update_prompt
    updated_prompt = self.api.prompt_version.update(
  File "/Users/xxx/Projects/langfuse-python/langfuse/api/resources/prompt_version/client.py", line 103, in update
    raise ApiError(status_code=_response.status_code, body=_response.text)
langfuse.api.core.api_error.ApiError: status_code: 404, body: <!DOCTYPE html><html lang="en"><head><meta charSet="utf-8" data-next-head=""/><meta name="viewport" content="width=device-width" data-next-head=""/><link rel="preload" href="/_next/static/css/4f61577301da82fe.css" as="style"/><link rel="stylesheet" href="/_next/static/css/4f61577301da82fe.css" data-n-g=""/><noscript data-n-css=""></noscript><script defer="" noModule="" src="/_next/static/chunks/polyfills-42372ed130431b0a.js"></script><script src="/_next/static/chunks/webpack-48446a2f46277bf5.js" defer=""></script><script src="/_next/static/chunks/framework-39e74fc25319e84b.js" defer=""></script><script src="/_next/static/chunks/main-52f0abb496765ba2.js" defer=""></script><script src="/_next/static/chunks/pages/_app-394ef6f5ffa66063.js" defer=""></script><script src="/_next/static/chunks/pages/_error-f8e5d23f5659a71d.js" defer=""></script><script src="/_next/static/WLAoST7iIb6seR22m02hS/_buildManifest.js" defer=""></script><script src="/_next/static/WLAoST7iIb6seR22m02hS/_ssgManifest.js" defer=""></script></head><body><link rel="preload" as="image" href="/icon.svg"/><div id="__next"><script>((e,i,s,u,m,a,l,h)=>{let d=document.documentElement,w=["light","dark"];function p(n){(Array.isArray(e)?e:[e]).forEach(y=>{let k=y==="class",S=k&&a?m.map(f=>a[f]||f):m;k?(d.classList.remove(...S),d.classList.add(a&&a[n]?a[n]:n)):d.setAttribute(y,n)}),R(n)}function R(n){h&&w.includes(n)&&(d.style.colorScheme=n)}function c(){return window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"}if(u)p(u);else try{let n=localStorage.getItem(i)||s,y=l&&n==="system"?c():n;p(y)}catch(n){}})("class","theme","system",null,["light","dark"],null,true,true)</script><div class="flex min-h-full flex-1 flex-col justify-center py-12 sm:px-6 lg:px-8" data-sentry-component="Spinner" data-sentry-source-file="spinner.tsx"><div class="sm:mx-auto sm:w-full sm:max-w-md"><img src="/icon.svg" width="42" height="42" alt="Langfuse Icon" class="mx-auto motion-safe:animate-spin" data-sentry-component="LangfuseIcon" data-sentry-source-file="LangfuseLogo.tsx"/><h2 class="mt-5 text-center text-2xl font-bold leading-9 tracking-tight text-primary">Loading<!-- --> ...</h2></div></div></div><script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"statusCode":404}},"page":"/_error","query":{},"buildId":"WLAoST7iIb6seR22m02hS","nextExport":true,"isFallback":false,"gip":true,"locale":"en","locales":["en"],"defaultLocale":"en","scriptLoader":[]}</script></body></html>
```

I have updated the method to parse the name so that the prompt name, if containing a "/" would be handled correctly in the API, and added an additional test to the prompt tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `update_prompt` in `client.py` to handle prompt names with slashes by URL encoding them, and add a test for prompts in folders.
> 
>   - **Behavior**:
>     - Fix `update_prompt` in `client.py` to handle prompt names with slashes by URL encoding them using `_url_encode()`.
>     - Adds test `test_update_prompt_in_folder` in `test_prompt.py` to verify correct handling of prompts in folders.
>   - **Misc**:
>     - No changes to constants or other configurations.
>     - No new dependencies added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for b66eef963c0caef7f9a79b3aac5548395cc81082. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-11 20:56:18 UTC

This PR fixes a critical bug in the `update_prompt` method where prompts organized in folder structures (with names containing forward slashes like `folder/prompt-name`) would fail with 404 errors. The issue stemmed from the httpx library automatically URL-encoding special characters like `/` to `%2F`, causing the API to look for a prompt with the encoded name rather than the original name.

The fix applies the existing `_url_encode` method to the prompt name parameter before making the API call, ensuring consistent behavior with other prompt-related methods like `get_prompt` that already handle URL encoding. The solution leverages the existing `_url_encode` utility method (lines 2987-2998 in client.py) that properly handles httpx version compatibility and character escaping.

A comprehensive test case `test_update_prompt_in_folder` was added to verify that prompts with folder-like names can be successfully created, retrieved, and updated. This test follows the same pattern as existing prompt tests but specifically validates the URL encoding fix by using a prompt name containing a forward slash.

The change integrates seamlessly with the existing codebase by following established patterns for URL encoding in other API methods, ensuring consistency across the Langfuse client's prompt management functionality.

## Confidence score: 4/5

- This PR addresses a specific, well-documented bug with a targeted fix that follows existing patterns
- Score reflects the straightforward nature of the fix and comprehensive test coverage, though minor risk exists around URL encoding edge cases
- Pay close attention to the `_url_encode` method implementation and the new test case validation

<!-- /greptile_comment -->