### PR TITLE
fix(openai): handle None arguments in tool calls

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -641,6 +641,10 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                         curr[-1]["name"] = curr[-1]["name"] or getattr(
                             tool_call_chunk, "name", None
                         )
+
+                        if curr[-1]["arguments"] is None:
+                            curr[-1]["arguments"] = ""
+
                         curr[-1]["arguments"] += getattr(
                             tool_call_chunk, "arguments", None
                         )


### PR DESCRIPTION
**Problem:**

An error occurs when using langfuse-python with `OpenRouter` as the base_url and `deepseek/deepseek-r1-0528` as the model in a function calling scenario.

**Error:**
<img width="2564" height="581" alt="error" src="https://github.com/user-attachments/assets/1191841a-ea07-4de6-b079-ad68883c1c1e" />

**Root Cause:**

1. At Time A, the first chunk received from the streaming API contains tool_calls.function.arguments with a value of None.
`Chunk: {'id': 'gen-1757583928-Bk8WIfqQDQprOXBvlnP4', 'choices': [Choice(delta=ChoiceDelta(content=None, function_call=None, refusal=None, role='assistant', tool_calls=[ChoiceDeltaToolCall(index=0, id='chatcmpl-tool-005b7a71760046f3aa3205fc354342f9', function=ChoiceDeltaToolCallFunction(arguments=None, name='builtin_search_web'), type='function')]), finish_reason=None, index=0, logprobs=None, native_finish_reason=None)], 'created': 1757583931, 'model': 'deepseek/deepseek-r1-0528', 'object': 'chat.completion.chunk', 'service_tier': None, 'system_fingerprint': '', 'usage': None}`

2. The `_extract_streamed_openai_response `function processes this chunk, and the curr variable is set to:
`curr: [{'name': 'builtin_search_web', 'arguments': None}]
`

3. At Time B, a subsequent chunk is received.
`Chunk: {'id': 'gen-1757583928-Bk8WIfqQDQprOXBvlnP4', 'choices': [Choice(delta=ChoiceDelta(content=None, function_call=None, refusal=None, role='assistant', tool_calls=[ChoiceDeltaToolCall(index=0, id=None, function=ChoiceDeltaToolCallFunction(arguments='{"', name=None), type='function')]), finish_reason=None, index=0, logprobs=None, native_finish_reason=None)], 'created': 1757583931, 'model': 'deepseek/deepseek-r1-0528', 'object': 'chat.completion.chunk', 'service_tier': None, 'system_fingerprint': '', 'usage': None}`

4. The `_extract_streamed_openai_response `function attempts to append the new arguments chunk to `curr[-1]["arguments"]`. Since `curr[-1]["arguments"]` is None, a type error occurs when trying to concatenate a string ('{"') to None.

**Fix:**
Before performing the string concatenation, check if the current value of `curr[-1]["arguments"]` is None. If it is, initialize it as an empty string ("") to prevent the error.
