### PR TITLE
feat: support custom export path to export spans

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -180,6 +180,7 @@ class Langfuse:
         public_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         host: Optional[str] = None,
+        traces_export_path: Optional[str] = None,
         timeout: Optional[int] = None,
         httpx_client: Optional[httpx.Client] = None,
         debug: bool = False,
@@ -197,6 +198,9 @@ class Langfuse:
     ):
         self._host = host or cast(
             str, os.environ.get(LANGFUSE_HOST, "https://cloud.langfuse.com")
+        )
+        self._traces_export_path = traces_export_path or cast(
+            str, os.environ.get(LANGFUSE_TRACES_EXPORT_PATH)
         )
         self._environment = environment or cast(
             str, os.environ.get(LANGFUSE_TRACING_ENVIRONMENT)
@@ -256,6 +260,7 @@ class Langfuse:
             public_key=public_key,
             secret_key=secret_key,
             host=self._host,
+            traces_export_path=self._traces_export_path,
             timeout=timeout,
             environment=self._environment,
             release=release,

--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -47,6 +47,7 @@ from langfuse._client.datasets import DatasetClient, DatasetItemClient
 from langfuse._client.environment_variables import (
     LANGFUSE_DEBUG,
     LANGFUSE_HOST,
+    LANGFUSE_TRACES_EXPORT_PATH,
     LANGFUSE_PUBLIC_KEY,
     LANGFUSE_SAMPLE_RATE,
     LANGFUSE_SECRET_KEY,

--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -47,7 +47,7 @@ from langfuse._client.datasets import DatasetClient, DatasetItemClient
 from langfuse._client.environment_variables import (
     LANGFUSE_DEBUG,
     LANGFUSE_HOST,
-    LANGFUSE_TRACES_EXPORT_PATH,
+    LANGFUSE_OTEL_TRACES_EXPORT_PATH,
     LANGFUSE_PUBLIC_KEY,
     LANGFUSE_SAMPLE_RATE,
     LANGFUSE_SECRET_KEY,

--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -181,7 +181,6 @@ class Langfuse:
         public_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         host: Optional[str] = None,
-        traces_export_path: Optional[str] = None,
         timeout: Optional[int] = None,
         httpx_client: Optional[httpx.Client] = None,
         debug: bool = False,
@@ -199,9 +198,6 @@ class Langfuse:
     ):
         self._host = host or cast(
             str, os.environ.get(LANGFUSE_HOST, "https://cloud.langfuse.com")
-        )
-        self._traces_export_path = traces_export_path or cast(
-            str, os.environ.get(LANGFUSE_TRACES_EXPORT_PATH)
         )
         self._environment = environment or cast(
             str, os.environ.get(LANGFUSE_TRACING_ENVIRONMENT)
@@ -261,7 +257,6 @@ class Langfuse:
             public_key=public_key,
             secret_key=secret_key,
             host=self._host,
-            traces_export_path=self._traces_export_path,
             timeout=timeout,
             environment=self._environment,
             release=release,

--- a/langfuse/_client/environment_variables.py
+++ b/langfuse/_client/environment_variables.py
@@ -44,13 +44,13 @@ Host of Langfuse API. Can be set via `LANGFUSE_HOST` environment variable.
 **Default value:** ``"https://cloud.langfuse.com"``
 """
 
-LANGFUSE_TRACES_EXPORT_PATH = "LANGFUSE_TRACES_EXPORT_PATH"
+LANGFUSE_OTEL_TRACES_EXPORT_PATH = "LANGFUSE_OTEL_TRACES_EXPORT_PATH"
 """
-.. envvar:: LANGFUSE_TRACES_EXPORT_PATH
+.. envvar:: LANGFUSE_OTEL_TRACES_EXPORT_PATH
 
-Path to export traces to. Can be set via `LANGFUSE_TRACES_EXPORT_PATH` environment variable.
+URL path on the configured host to export traces to.
 
-**Default value:** ``None``
+**Default value:** ``/api/public/otel/v1/traces``
 """
 
 LANGFUSE_DEBUG = "LANGFUSE_DEBUG"

--- a/langfuse/_client/environment_variables.py
+++ b/langfuse/_client/environment_variables.py
@@ -44,6 +44,15 @@ Host of Langfuse API. Can be set via `LANGFUSE_HOST` environment variable.
 **Default value:** ``"https://cloud.langfuse.com"``
 """
 
+LANGFUSE_TRACES_EXPORT_PATH = "LANGFUSE_TRACES_EXPORT_PATH"
+"""
+.. envvar:: LANGFUSE_TRACES_EXPORT_PATH
+
+Path to export traces to. Can be set via `LANGFUSE_TRACES_EXPORT_PATH` environment variable.
+
+**Default value:** ``None``
+"""
+
 LANGFUSE_DEBUG = "LANGFUSE_DEBUG"
 """
 .. envvar:: LANGFUSE_DEBUG

--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -84,6 +84,7 @@ class LangfuseResourceManager:
         public_key: str,
         secret_key: str,
         host: str,
+        traces_export_path: Optional[str] = None,
         environment: Optional[str] = None,
         release: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -116,6 +117,7 @@ class LangfuseResourceManager:
                     public_key=public_key,
                     secret_key=secret_key,
                     host=host,
+                    traces_export_path=traces_export_path,
                     timeout=timeout,
                     environment=environment,
                     release=release,
@@ -143,6 +145,7 @@ class LangfuseResourceManager:
         public_key: str,
         secret_key: str,
         host: str,
+        traces_export_path: Optional[str] = None,
         environment: Optional[str] = None,
         release: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -161,6 +164,7 @@ class LangfuseResourceManager:
         self.secret_key = secret_key
         self.tracing_enabled = tracing_enabled
         self.host = host
+        self.traces_export_path = traces_export_path
         self.mask = mask
         self.environment = environment
 
@@ -184,6 +188,7 @@ class LangfuseResourceManager:
                 public_key=self.public_key,
                 secret_key=secret_key,
                 host=host,
+                traces_export_path=traces_export_path,
                 timeout=timeout,
                 flush_at=flush_at,
                 flush_interval=flush_interval,

--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -84,7 +84,6 @@ class LangfuseResourceManager:
         public_key: str,
         secret_key: str,
         host: str,
-        traces_export_path: Optional[str] = None,
         environment: Optional[str] = None,
         release: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -117,7 +116,6 @@ class LangfuseResourceManager:
                     public_key=public_key,
                     secret_key=secret_key,
                     host=host,
-                    traces_export_path=traces_export_path,
                     timeout=timeout,
                     environment=environment,
                     release=release,
@@ -145,7 +143,6 @@ class LangfuseResourceManager:
         public_key: str,
         secret_key: str,
         host: str,
-        traces_export_path: Optional[str] = None,
         environment: Optional[str] = None,
         release: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -164,7 +161,6 @@ class LangfuseResourceManager:
         self.secret_key = secret_key
         self.tracing_enabled = tracing_enabled
         self.host = host
-        self.traces_export_path = traces_export_path
         self.mask = mask
         self.environment = environment
 
@@ -188,7 +184,6 @@ class LangfuseResourceManager:
                 public_key=self.public_key,
                 secret_key=secret_key,
                 host=host,
-                traces_export_path=traces_export_path,
                 timeout=timeout,
                 flush_at=flush_at,
                 flush_interval=flush_interval,

--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -52,6 +52,7 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         public_key: str,
         secret_key: str,
         host: str,
+        traces_export_path: Optional[str] = None,
         timeout: Optional[int] = None,
         flush_at: Optional[int] = None,
         flush_interval: Optional[float] = None,
@@ -90,8 +91,14 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         # Merge additional headers if provided
         headers = {**default_headers, **(additional_headers or {})}
 
+        endpoint = (
+            f"{host}/{traces_export_path}"
+            if traces_export_path
+            else f"{host}/api/public/otel/v1/traces"
+        )
+
         langfuse_span_exporter = OTLPSpanExporter(
-            endpoint=f"{host}/api/public/otel/v1/traces",
+            endpoint=endpoint,
             headers=headers,
             timeout=timeout,
         )

--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -23,6 +23,7 @@ from langfuse._client.constants import LANGFUSE_TRACER_NAME
 from langfuse._client.environment_variables import (
     LANGFUSE_FLUSH_AT,
     LANGFUSE_FLUSH_INTERVAL,
+    LANGFUSE_TRACES_EXPORT_PATH,
 )
 from langfuse._client.utils import span_formatter
 from langfuse.logger import langfuse_logger
@@ -52,7 +53,6 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         public_key: str,
         secret_key: str,
         host: str,
-        traces_export_path: Optional[str] = None,
         timeout: Optional[int] = None,
         flush_at: Optional[int] = None,
         flush_interval: Optional[float] = None,
@@ -90,6 +90,8 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
 
         # Merge additional headers if provided
         headers = {**default_headers, **(additional_headers or {})}
+
+        traces_export_path = os.environ.get(LANGFUSE_TRACES_EXPORT_PATH, None)
 
         endpoint = (
             f"{host}/{traces_export_path}"

--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -23,7 +23,7 @@ from langfuse._client.constants import LANGFUSE_TRACER_NAME
 from langfuse._client.environment_variables import (
     LANGFUSE_FLUSH_AT,
     LANGFUSE_FLUSH_INTERVAL,
-    LANGFUSE_TRACES_EXPORT_PATH,
+    LANGFUSE_OTEL_TRACES_EXPORT_PATH,
 )
 from langfuse._client.utils import span_formatter
 from langfuse.logger import langfuse_logger
@@ -91,7 +91,7 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         # Merge additional headers if provided
         headers = {**default_headers, **(additional_headers or {})}
 
-        traces_export_path = os.environ.get(LANGFUSE_TRACES_EXPORT_PATH, None)
+        traces_export_path = os.environ.get(LANGFUSE_OTEL_TRACES_EXPORT_PATH, None)
 
         endpoint = (
             f"{host}/{traces_export_path}"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for custom span export path in Langfuse OpenTelemetry integration by introducing `traces_export_path` parameter.
> 
>   - **Behavior**:
>     - Add `traces_export_path` parameter to `Langfuse` constructor in `client.py` for custom span export path.
>     - Update `LangfuseResourceManager` and `LangfuseSpanProcessor` to use `traces_export_path` if provided.
>     - Default to `LANGFUSE_TRACES_EXPORT_PATH` environment variable if `traces_export_path` is not specified.
>   - **Span Export**:
>     - Modify `LangfuseSpanProcessor` to construct endpoint using `traces_export_path` in `span_processor.py`.
>     - Update `LangfuseResourceManager` to pass `traces_export_path` to `LangfuseSpanProcessor` in `resource_manager.py`.
>   - **Misc**:
>     - Ensure backward compatibility by defaulting to existing endpoint if `traces_export_path` is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for a25507f291c33b22643c781a0d2587c65ad17894. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-17 04:00:48 UTC

This PR introduces support for customizing the OTLP traces export endpoint path in the Langfuse Python client. The change adds a new optional `traces_export_path` parameter that allows users to override the default `/api/public/otel/v1/traces` endpoint with a custom path.

The implementation flows through the entire client initialization chain:
1. **Langfuse client** (`client.py`) - Accepts the new parameter and reads from `LANGFUSE_TRACES_EXPORT_PATH` environment variable
2. **LangfuseResourceManager** (`resource_manager.py`) - Passes the parameter through the initialization process
3. **LangfuseSpanProcessor** (`span_processor.py`) - Uses the custom path to construct the final OTLP endpoint URL

The feature maintains backward compatibility by defaulting to the existing behavior when no custom path is provided. This change integrates with the existing OpenTelemetry Protocol (OTLP) infrastructure already present in the codebase, specifically enhancing the span export functionality that feeds into Langfuse's trace collection system.

PR Description Notes:
- The pull request description is empty (`null`), which makes it difficult to understand the specific use case or rationale for this change

## Confidence score: 3/5

- This PR introduces useful functionality but has implementation gaps that could cause runtime issues
- Score reflects missing environment variable constant definition and lack of input validation for the custom path parameter
- Pay close attention to `client.py` where `LANGFUSE_TRACES_EXPORT_PATH` constant is referenced but not defined in the environment variables module

### Context used:
**Rule -** Open a GitHub issue or discussion first before submitting PRs to explain the rationale and necessity of the proposed changes, as required by the contributing guide. ([link](https://app.greptile.com/review/custom-context?memory=f66422d7-e71a-47d4-928b-df849c888300))

<!-- /greptile_comment -->