### PR TITLE
feat(openai): add openai embeddings api support

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -177,6 +177,20 @@ OPENAI_METHODS_V1 = [
         sync=False,
         min_version="1.66.0",
     ),
+    OpenAiDefinition(
+        module="openai.resources.embeddings",
+        object="Embeddings",
+        method="create",
+        type="embedding",
+        sync=True,
+    ),
+    OpenAiDefinition(
+        module="openai.resources.embeddings",
+        object="AsyncEmbeddings",
+        method="create",
+        type="embedding",
+        sync=False,
+    ),
 ]
 
 
@@ -340,10 +354,13 @@ def _extract_chat_response(kwargs: Any) -> Any:
 
 
 def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> Any:
-    name = kwargs.get("name", "OpenAI-generation")
+    default_name = (
+        "OpenAI-embedding" if resource.type == "embedding" else "OpenAI-generation"
+    )
+    name = kwargs.get("name", default_name)
 
     if name is None:
-        name = "OpenAI-generation"
+        name = default_name
 
     if name is not None and not isinstance(name, str):
         raise TypeError("name must be a string")
@@ -395,6 +412,8 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
         prompt = kwargs.get("input", None)
     elif resource.type == "chat":
         prompt = _extract_chat_prompt(kwargs)
+    elif resource.type == "embedding":
+        prompt = kwargs.get("input", None)
 
     parsed_temperature = (
         kwargs.get("temperature", 1)
@@ -440,23 +459,41 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
 
     parsed_n = kwargs.get("n", 1) if not isinstance(kwargs.get("n", 1), NotGiven) else 1
 
-    modelParameters = {
-        "temperature": parsed_temperature,
-        "max_tokens": parsed_max_tokens,  # casing?
-        "top_p": parsed_top_p,
-        "frequency_penalty": parsed_frequency_penalty,
-        "presence_penalty": parsed_presence_penalty,
-    }
+    if resource.type == "embedding":
+        parsed_dimensions = (
+            kwargs.get("dimensions", None)
+            if not isinstance(kwargs.get("dimensions", None), NotGiven)
+            else None
+        )
+        parsed_encoding_format = (
+            kwargs.get("encoding_format", "float")
+            if not isinstance(kwargs.get("encoding_format", "float"), NotGiven)
+            else "float"
+        )
 
-    if parsed_max_completion_tokens is not None:
-        modelParameters.pop("max_tokens", None)
-        modelParameters["max_completion_tokens"] = parsed_max_completion_tokens
+        modelParameters = {}
+        if parsed_dimensions is not None:
+            modelParameters["dimensions"] = parsed_dimensions
+        if parsed_encoding_format != "float":
+            modelParameters["encoding_format"] = parsed_encoding_format
+    else:
+        modelParameters = {
+            "temperature": parsed_temperature,
+            "max_tokens": parsed_max_tokens,
+            "top_p": parsed_top_p,
+            "frequency_penalty": parsed_frequency_penalty,
+            "presence_penalty": parsed_presence_penalty,
+        }
 
-    if parsed_n is not None and parsed_n > 1:
-        modelParameters["n"] = parsed_n
+        if parsed_max_completion_tokens is not None:
+            modelParameters.pop("max_tokens", None)
+            modelParameters["max_completion_tokens"] = parsed_max_completion_tokens
 
-    if parsed_seed is not None:
-        modelParameters["seed"] = parsed_seed
+        if parsed_n is not None and parsed_n > 1:
+            modelParameters["n"] = parsed_n
+
+        if parsed_seed is not None:
+            modelParameters["seed"] = parsed_seed
 
     langfuse_prompt = kwargs.get("langfuse_prompt", None)
 
@@ -729,6 +766,20 @@ def _get_langfuse_data_from_default_response(
                     else choice.get("message", None)
                 )
 
+    elif resource.type == "embedding":
+        data = response.get("data", [])
+        if len(data) > 0:
+            first_embedding = data[0]
+            embedding_vector = (
+                first_embedding.embedding
+                if hasattr(first_embedding, "embedding")
+                else first_embedding.get("embedding", [])
+            )
+            completion = {
+                "dimensions": len(embedding_vector) if embedding_vector else 0,
+                "count": len(data),
+            }
+
     usage = _parse_usage(response.get("usage", None))
 
     return (model, completion, usage)
@@ -757,8 +808,12 @@ def _wrap(
     langfuse_data = _get_langfuse_data_from_kwargs(open_ai_resource, langfuse_args)
     langfuse_client = get_client(public_key=langfuse_args["langfuse_public_key"])
 
+    observation_type = (
+        "embedding" if open_ai_resource.type == "embedding" else "generation"
+    )
+
     generation = langfuse_client.start_observation(
-        as_type="generation",
+        as_type=observation_type,
         name=langfuse_data["name"],
         input=langfuse_data.get("input", None),
         metadata=langfuse_data.get("metadata", None),
@@ -824,8 +879,12 @@ async def _wrap_async(
     langfuse_data = _get_langfuse_data_from_kwargs(open_ai_resource, langfuse_args)
     langfuse_client = get_client(public_key=langfuse_args["langfuse_public_key"])
 
+    observation_type = (
+        "embedding" if open_ai_resource.type == "embedding" else "generation"
+    )
+
     generation = langfuse_client.start_observation(
-        as_type="generation",
+        as_type=observation_type,
         name=langfuse_data["name"],
         input=langfuse_data.get("input", None),
         metadata=langfuse_data.get("metadata", None),


### PR DESCRIPTION
Implement https://github.com/langfuse/langfuse/issues/9137
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for OpenAI embeddings API in Langfuse integration, including synchronous and asynchronous handling and corresponding tests.
> 
>   - **Behavior**:
>     - Add support for OpenAI embeddings API in `langfuse/openai.py` with `OpenAiDefinition` entries for `Embeddings` and `AsyncEmbeddings`.
>     - Update `_get_langfuse_data_from_kwargs()` to handle `embedding` type, extracting `input` and embedding-specific parameters.
>     - Modify `_get_langfuse_data_from_default_response()` to parse embedding responses, extracting dimensions and count.
>     - Adjust `_wrap()` and `_wrap_async()` to set observation type to `embedding` for embedding requests.
>   - **Tests**:
>     - Add `test_openai_embeddings()`, `test_openai_embeddings_multiple_inputs()`, and `test_async_openai_embeddings()` in `tests/test_openai.py` to validate embedding functionality, including multiple inputs and async support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for bb9f752d07248b2a36668fa1b3168d073beaacda. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-17 08:37:13 UTC

This PR adds comprehensive support for OpenAI's embeddings API to the Langfuse OpenAI integration. The implementation extends Langfuse's observability capabilities beyond chat/text completions to include embeddings, which are crucial for AI applications using retrieval-augmented generation (RAG) and semantic search.

The changes follow established patterns in the codebase by:
- Adding new `OpenAiDefinition` entries for both sync (`embeddings.create`) and async (`embeddings.acreate`) embedding operations in the `OPENAI_METHODS_V1` list
- Updating the default naming convention to distinguish embeddings ('OpenAI-embedding') from generations ('OpenAI-generation')
- Extending parameter extraction logic to handle embedding-specific parameters like `dimensions` and `encoding_format`
- Creating embedding-specific response parsing that extracts meaningful metadata (dimensions, count) from the embedding data
- Using 'embedding' as the observation type instead of 'generation' for proper categorization in Langfuse's tracking system

The test coverage includes three comprehensive test functions that validate synchronous single input, multiple inputs (batch processing), and asynchronous embedding scenarios. These tests verify proper tracking of embedding requests including input/output handling, metadata, usage statistics, and timing measurements, following the same validation patterns used for other OpenAI API integrations.

## Confidence score: 4/5

- This PR is safe to merge with low risk of breaking existing functionality
- Score reflects well-structured implementation following existing patterns, but embeddings are a new integration area that may need real-world validation
- Pay close attention to the response parsing logic in `langfuse/openai.py` lines 769-781 to ensure embedding data extraction works correctly across different models

<!-- /greptile_comment -->