### PR TITLE
feat(openai): add openai embeddings api support (#1345)

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -558,6 +558,14 @@ def _parse_usage(usage: Optional[Any] = None) -> Any:
                 k: v for k, v in tokens_details_dict.items() if v is not None
             }
 
+    if (
+        len(usage_dict) == 2
+        and "prompt_tokens" in usage_dict
+        and "total_tokens" in usage_dict
+    ):
+        # handle embedding usage
+        return {"input": usage_dict["prompt_tokens"]}
+
     return usage_dict
 
 
@@ -683,7 +691,7 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                             curr[-1]["arguments"] = ""
 
                         curr[-1]["arguments"] += getattr(
-                            tool_call_chunk, "arguments", None
+                            tool_call_chunk, "arguments", ""
                         )
 
             if resource.type == "completion":
@@ -813,7 +821,7 @@ def _wrap(
     )
 
     generation = langfuse_client.start_observation(
-        as_type=observation_type,
+        as_type=observation_type,  # type: ignore
         name=langfuse_data["name"],
         input=langfuse_data.get("input", None),
         metadata=langfuse_data.get("metadata", None),
@@ -884,7 +892,7 @@ async def _wrap_async(
     )
 
     generation = langfuse_client.start_observation(
-        as_type=observation_type,
+        as_type=observation_type,  # type: ignore
         name=langfuse_data["name"],
         input=langfuse_data.get("input", None),
         metadata=langfuse_data.get("metadata", None),

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -177,6 +177,20 @@ OPENAI_METHODS_V1 = [
         sync=False,
         min_version="1.66.0",
     ),
+    OpenAiDefinition(
+        module="openai.resources.embeddings",
+        object="Embeddings",
+        method="create",
+        type="embedding",
+        sync=True,
+    ),
+    OpenAiDefinition(
+        module="openai.resources.embeddings",
+        object="AsyncEmbeddings",
+        method="create",
+        type="embedding",
+        sync=False,
+    ),
 ]
 
 
@@ -340,10 +354,13 @@ def _extract_chat_response(kwargs: Any) -> Any:
 
 
 def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> Any:
-    name = kwargs.get("name", "OpenAI-generation")
+    default_name = (
+        "OpenAI-embedding" if resource.type == "embedding" else "OpenAI-generation"
+    )
+    name = kwargs.get("name", default_name)
 
     if name is None:
-        name = "OpenAI-generation"
+        name = default_name
 
     if name is not None and not isinstance(name, str):
         raise TypeError("name must be a string")
@@ -395,6 +412,8 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
         prompt = kwargs.get("input", None)
     elif resource.type == "chat":
         prompt = _extract_chat_prompt(kwargs)
+    elif resource.type == "embedding":
+        prompt = kwargs.get("input", None)
 
     parsed_temperature = (
         kwargs.get("temperature", 1)
@@ -440,23 +459,41 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
 
     parsed_n = kwargs.get("n", 1) if not isinstance(kwargs.get("n", 1), NotGiven) else 1
 
-    modelParameters = {
-        "temperature": parsed_temperature,
-        "max_tokens": parsed_max_tokens,  # casing?
-        "top_p": parsed_top_p,
-        "frequency_penalty": parsed_frequency_penalty,
-        "presence_penalty": parsed_presence_penalty,
-    }
+    if resource.type == "embedding":
+        parsed_dimensions = (
+            kwargs.get("dimensions", None)
+            if not isinstance(kwargs.get("dimensions", None), NotGiven)
+            else None
+        )
+        parsed_encoding_format = (
+            kwargs.get("encoding_format", "float")
+            if not isinstance(kwargs.get("encoding_format", "float"), NotGiven)
+            else "float"
+        )
 
-    if parsed_max_completion_tokens is not None:
-        modelParameters.pop("max_tokens", None)
-        modelParameters["max_completion_tokens"] = parsed_max_completion_tokens
+        modelParameters = {}
+        if parsed_dimensions is not None:
+            modelParameters["dimensions"] = parsed_dimensions
+        if parsed_encoding_format != "float":
+            modelParameters["encoding_format"] = parsed_encoding_format
+    else:
+        modelParameters = {
+            "temperature": parsed_temperature,
+            "max_tokens": parsed_max_tokens,
+            "top_p": parsed_top_p,
+            "frequency_penalty": parsed_frequency_penalty,
+            "presence_penalty": parsed_presence_penalty,
+        }
 
-    if parsed_n is not None and parsed_n > 1:
-        modelParameters["n"] = parsed_n
+        if parsed_max_completion_tokens is not None:
+            modelParameters.pop("max_tokens", None)
+            modelParameters["max_completion_tokens"] = parsed_max_completion_tokens
 
-    if parsed_seed is not None:
-        modelParameters["seed"] = parsed_seed
+        if parsed_n is not None and parsed_n > 1:
+            modelParameters["n"] = parsed_n
+
+        if parsed_seed is not None:
+            modelParameters["seed"] = parsed_seed
 
     langfuse_prompt = kwargs.get("langfuse_prompt", None)
 
@@ -729,6 +766,20 @@ def _get_langfuse_data_from_default_response(
                     else choice.get("message", None)
                 )
 
+    elif resource.type == "embedding":
+        data = response.get("data", [])
+        if len(data) > 0:
+            first_embedding = data[0]
+            embedding_vector = (
+                first_embedding.embedding
+                if hasattr(first_embedding, "embedding")
+                else first_embedding.get("embedding", [])
+            )
+            completion = {
+                "dimensions": len(embedding_vector) if embedding_vector else 0,
+                "count": len(data),
+            }
+
     usage = _parse_usage(response.get("usage", None))
 
     return (model, completion, usage)
@@ -757,8 +808,12 @@ def _wrap(
     langfuse_data = _get_langfuse_data_from_kwargs(open_ai_resource, langfuse_args)
     langfuse_client = get_client(public_key=langfuse_args["langfuse_public_key"])
 
+    observation_type = (
+        "embedding" if open_ai_resource.type == "embedding" else "generation"
+    )
+
     generation = langfuse_client.start_observation(
-        as_type="generation",
+        as_type=observation_type,
         name=langfuse_data["name"],
         input=langfuse_data.get("input", None),
         metadata=langfuse_data.get("metadata", None),
@@ -824,8 +879,12 @@ async def _wrap_async(
     langfuse_data = _get_langfuse_data_from_kwargs(open_ai_resource, langfuse_args)
     langfuse_client = get_client(public_key=langfuse_args["langfuse_public_key"])
 
+    observation_type = (
+        "embedding" if open_ai_resource.type == "embedding" else "generation"
+    )
+
     generation = langfuse_client.start_observation(
-        as_type="generation",
+        as_type=observation_type,
         name=langfuse_data["name"],
         input=langfuse_data.get("input", None),
         metadata=langfuse_data.get("metadata", None),

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1579,13 +1579,16 @@ def test_openai_embeddings_multiple_inputs(openai):
 async def test_async_openai_embeddings(openai):
     client = openai.AsyncOpenAI()
     embedding_name = create_uuid()
+    print(embedding_name)
 
-    await client.embeddings.create(
+    result = await client.embeddings.create(
         name=embedding_name,
         model="text-embedding-ada-002",
         input="Async embedding test",
         metadata={"async": True},
     )
+
+    print("result:", result.usage)
 
     langfuse.flush()
     sleep(1)

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1536,7 +1536,7 @@ def test_openai_embeddings(openai):
     assert embedding_data.metadata["test_key"] == "test_value"
     assert embedding_data.input == "The quick brown fox jumps over the lazy dog"
     assert embedding_data.type == "EMBEDDING"
-    assert embedding_data.model == "text-embedding-ada-002"
+    assert "text-embedding-ada-002" in embedding_data.model
     assert embedding_data.start_time is not None
     assert embedding_data.end_time is not None
     assert embedding_data.start_time < embedding_data.end_time
@@ -1569,7 +1569,7 @@ def test_openai_embeddings_multiple_inputs(openai):
     assert embedding_data.name == embedding_name
     assert embedding_data.input == inputs
     assert embedding_data.type == "EMBEDDING"
-    assert embedding_data.model == "text-embedding-ada-002"
+    assert "text-embedding-ada-002" in embedding_data.model
     assert embedding_data.usage.input is not None
     assert embedding_data.usage.total is not None
     assert embedding_data.output["count"] == len(inputs)
@@ -1597,7 +1597,7 @@ async def test_async_openai_embeddings(openai):
     assert embedding_data.name == embedding_name
     assert embedding_data.input == "Async embedding test"
     assert embedding_data.type == "EMBEDDING"
-    assert embedding_data.model == "text-embedding-ada-002"
+    assert "text-embedding-ada-002" in embedding_data.model
     assert embedding_data.metadata["async"] is True
     assert embedding_data.usage.input is not None
     assert embedding_data.usage.total is not None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for OpenAI's embeddings API to Langfuse, including synchronous and asynchronous operations, with comprehensive test coverage.
> 
>   - **Behavior**:
>     - Adds `OpenAiDefinition` entries for synchronous and asynchronous embedding operations in `langfuse/openai.py`.
>     - Uses `"OpenAI-embedding"` as default operation name for embeddings.
>     - Extracts prompts from `input` parameter for embeddings.
>     - Parses embedding-specific parameters like `dimensions` and `encoding_format`.
>     - Creates observations with type `"embedding"`.
>     - Extracts embedding-specific response data (dimensions and count).
>   - **Test Coverage**:
>     - Adds `test_openai_embeddings`, `test_openai_embeddings_multiple_inputs`, and `test_async_openai_embeddings` in `tests/test_openai.py`.
>     - Tests validate observation type, input/output handling, usage statistics, and metadata preservation for embeddings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for b65d6024308b287744a3e1412ebf7bdf3d01dc46. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-18 15:43:55 UTC

This PR adds comprehensive support for OpenAI's embeddings API to the Langfuse integration. The changes span both the core integration logic and test coverage to handle embeddings as a distinct type of operation alongside existing chat completions and text completions.

**Core Integration Changes:**
The implementation adds two new `OpenAiDefinition` entries for synchronous and asynchronous embedding operations, following the established pattern used for other OpenAI APIs. The wrapper logic has been extended with conditional handling based on `resource.type == "embedding"` throughout the codebase to accommodate the different input/output structure of embeddings compared to chat/completion APIs.

Key behavioral differences for embeddings include:
- Uses `"OpenAI-embedding"` as the default operation name instead of `"OpenAI-generation"`
- Extracts prompts from the `input` parameter rather than `messages` or `prompt`
- Parses embedding-specific model parameters like `dimensions` and `encoding_format` instead of chat parameters like `temperature`
- Creates observations with type `"embedding"` rather than `"generation"`
- Extracts embedding-specific response data (dimensions and count) rather than text completion data

**Test Coverage:**
Three comprehensive test functions validate the integration: `test_openai_embeddings` for basic single-input operations, `test_openai_embeddings_multiple_inputs` for batch processing, and `test_async_openai_embeddings` for asynchronous operations. The tests verify proper observation type tracking, input/output handling, usage statistics, and metadata preservation.

The implementation maintains backward compatibility with existing functionality while extending the Langfuse integration to cover embeddings, which are essential for vector search, semantic similarity, and RAG applications.

## Confidence score: 4/5

- This PR appears safe to merge with good architectural consistency
- Score reflects well-structured conditional logic and comprehensive test coverage
- Pay close attention to the conditional branching logic in `langfuse/openai.py`

<!-- /greptile_comment -->