### PR TITLE
chore: set `ensure_ascii=False` for json serialization to preserve unicode chars

### DIFF
--- a/langfuse/_client/attributes.py
+++ b/langfuse/_client/attributes.py
@@ -164,7 +164,7 @@ def _serialize(obj: Any) -> Optional[str]:
     if obj is None or isinstance(obj, str):
         return obj
 
-    return json.dumps(obj, cls=EventSerializer)
+    return json.dumps(obj, cls=EventSerializer, ensure_ascii=False)
 
 
 def _flatten_and_serialize_metadata(

--- a/langfuse/_task_manager/score_ingestion_consumer.py
+++ b/langfuse/_task_manager/score_ingestion_consumer.py
@@ -85,7 +85,7 @@ class ScoreIngestionConsumer(threading.Thread):
 
                 # check for serialization errors
                 try:
-                    json.dumps(event, cls=EventSerializer)
+                    json.dumps(event, cls=EventSerializer, ensure_ascii=False)
                 except Exception as e:
                     self._log.error(
                         f"Data error: Failed to serialize score object for ingestion. Score will be dropped. Error: {e}"
@@ -117,7 +117,7 @@ class ScoreIngestionConsumer(threading.Thread):
 
     def _get_item_size(self, item: Any) -> int:
         """Return the size of the item in bytes."""
-        return len(json.dumps(item, cls=EventSerializer).encode())
+        return len(json.dumps(item, cls=EventSerializer, ensure_ascii=False).encode())
 
     def run(self) -> None:
         """Run the consumer."""

--- a/langfuse/_utils/request.py
+++ b/langfuse/_utils/request.py
@@ -60,7 +60,7 @@ class LangfuseClient:
         """Post the `kwargs` to the API"""
         log = logging.getLogger("langfuse")
         url = self._remove_trailing_slash(self._base_url) + "/api/public/ingestion"
-        data = json.dumps(kwargs, cls=EventSerializer)
+        data = json.dumps(kwargs, cls=EventSerializer, ensure_ascii=False)
         log.debug("making request: %s to %s", data, url)
         headers = self.generate_headers()
         res = self._session.post(

--- a/tests/test_unicode_serialization.py
+++ b/tests/test_unicode_serialization.py
@@ -1,0 +1,20 @@
+"""Test Unicode character handling in serialization."""
+
+from langfuse._client.attributes import _serialize
+
+def test_mixed_unicode_preserved():
+    """Test that mixed Unicode content is preserved."""
+    data = {
+        "japanese": "こんにちは",
+        "chinese": "你好",
+        "korean": "안녕하세요",
+        "arabic": "مرحبا",
+        "russian": "Привет",
+        "emoji": "Hello, 🌍!",
+    }
+    serialized = _serialize(data)
+    assert serialized is not None
+
+    assert "\\u" not in serialized, "Should not contain Unicode escapes"
+    for value in data.values():
+        assert value in serialized, f"Should contain {value}"


### PR DESCRIPTION
In the langfuse web UI, `output` is encoded in unicode escape sequence (`\uXXX`). This is the default behavior of the python's `json.dumps()`. 

It's annoying for non-English poeple like me, so set `ensure_ascii=False` for `json.dumps()`. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `ensure_ascii=False` in JSON serialization to preserve Unicode characters and added tests to verify this behavior.
> 
>   - **Behavior**:
>     - Set `ensure_ascii=False` in `json.dumps()` in `_serialize()` in `attributes.py`, `_next()` and `_get_item_size()` in `score_ingestion_consumer.py`, and `post()` in `request.py` to preserve Unicode characters.
>   - **Testing**:
>     - Added `test_unicode_serialization.py` to verify Unicode characters are preserved in serialized output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 500db8d956991af46223a2bb6fb4d92bfd09d71b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 04:39:28 UTC

<h3>Summary</h3>
This pull request improves Unicode character handling in the Langfuse Python SDK by adding `ensure_ascii=False` to all `json.dumps()` calls throughout the codebase. The change affects three critical serialization points: the OpenTelemetry attributes serializer (`_serialize` function in `attributes.py`), the HTTP client for API requests (`request.py`), and the score ingestion consumer for batch processing (`score_ingestion_consumer.py`). 

By default, Python's `json.dumps()` escapes non-ASCII characters as Unicode sequences (e.g., `\u3053\u3093\u306b\u3061\u306f` instead of `こんにちは`), making output unreadable for non-English users in the Langfuse web UI. This change preserves Unicode characters in their native form, significantly improving the user experience for international users working with Japanese, Chinese, Korean, Arabic, Russian, and other non-Latin scripts.

The PR includes a comprehensive test file (`test_unicode_serialization.py`) that validates Unicode preservation across multiple writing systems and emoji. The change is backward-compatible as the resulting JSON remains valid, and the modification is applied consistently across all serialization points to ensure uniform behavior throughout the SDK.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `langfuse/_client/attributes.py` | 5/5 | Added `ensure_ascii=False` to `json.dumps()` in the `_serialize` function used for OpenTelemetry span attributes |
| `langfuse/_utils/request.py` | 5/5 | Added `ensure_ascii=False` to `json.dumps()` in the HTTP client used for all API requests to Langfuse |
| `langfuse/_task_manager/score_ingestion_consumer.py` | 5/5 | Added `ensure_ascii=False` to two `json.dumps()` calls in the score ingestion batch processing pipeline |
| `tests/test_unicode_serialization.py` | 5/5 | New comprehensive test file validating Unicode character preservation across multiple languages and emoji |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only changes JSON serialization format without affecting data structures or API contracts
- Score reflects the backward-compatible nature of the change and comprehensive test coverage for Unicode handling
- No files require special attention as all changes are straightforward serialization parameter additions

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LangfuseClient as "Langfuse Client"
    participant EventSerializer as "Event Serializer"
    participant JSONEncoder as "JSON Encoder"
    participant APIEndpoint as "API Endpoint"

    User->>LangfuseClient: "serialize data with unicode content"
    LangfuseClient->>EventSerializer: "_serialize(data)"
    EventSerializer->>JSONEncoder: "json.dumps(obj, cls=EventSerializer, ensure_ascii=False)"
    JSONEncoder-->>EventSerializer: "serialized json string with preserved unicode"
    EventSerializer-->>LangfuseClient: "unicode-preserved json string"
    
    User->>LangfuseClient: "batch_post(**kwargs)"
    LangfuseClient->>EventSerializer: "json.dumps(kwargs, cls=EventSerializer, ensure_ascii=False)"
    EventSerializer-->>LangfuseClient: "serialized data with unicode preserved"
    LangfuseClient->>APIEndpoint: "POST request with unicode content"
    APIEndpoint-->>LangfuseClient: "response"
    LangfuseClient-->>User: "response"

    User->>LangfuseClient: "upload score events"
    LangfuseClient->>EventSerializer: "serialize events with unicode"
    EventSerializer->>JSONEncoder: "json.dumps(event, cls=EventSerializer, ensure_ascii=False)"
    JSONEncoder-->>EventSerializer: "unicode-preserved serialization"
    EventSerializer-->>LangfuseClient: "serialized events"
    LangfuseClient->>APIEndpoint: "upload batch with unicode content"
    APIEndpoint-->>LangfuseClient: "upload response"
    LangfuseClient-->>User: "upload complete"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->