### PR TITLE
fix: setting OTEL span status as error on Langfuse error

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -20,7 +20,6 @@ from typing import (
     overload,
 )
 
-from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util._decorator import _AgnosticContextManager
 from typing_extensions import ParamSpec
 

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -31,6 +31,7 @@ from typing import (
 
 from opentelemetry import trace as otel_trace_api
 from opentelemetry.util._decorator import _AgnosticContextManager
+from opentelemetry.trace.status import Status, StatusCode
 
 from langfuse.model import PromptClient
 
@@ -557,7 +558,6 @@ class LangfuseObservationWrapper:
         """
         if level == "ERROR" and self._otel_span.is_recording():
             try:
-                from opentelemetry.trace.status import Status, StatusCode
                 self._otel_span.set_status(
                     status=Status(StatusCode.ERROR),
                     description=status_message


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets OTEL span status to ERROR when Langfuse span level is ERROR, ensuring consistency between Langfuse and OTEL error states.
> 
>   - **Behavior**:
>     - Sets OTEL span status to ERROR if Langfuse span level is ERROR in `LangfuseObservationWrapper`.
>     - Adds `_set_otel_span_status_if_error()` to handle setting OTEL status in `span.py`.
>   - **Tests**:
>     - Adds tests in `test_otel.py` for ERROR level handling in span creation and updates.
>     - Tests cover span creation, updates, and different observation types (e.g., `generation`, `agent`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 0c6dfbec94fdd75dc59c5fd7b64780439be26c66. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 07:24:14 UTC

<h3>Summary</h3>
This PR enhances the integration between Langfuse and OpenTelemetry by automatically setting OTEL span status to ERROR when a Langfuse observation has `level='ERROR'`. The implementation ensures consistency between Langfuse's error tracking and OpenTelemetry's span status system, which is crucial for downstream observability tools that rely on OTEL span status for error detection and alerting.

The changes span three files: adding comprehensive test coverage in `test_otel.py`, importing required OTEL status classes in `observe.py`, and implementing the core functionality in `span.py`. The implementation includes a new private method `_set_otel_span_status_if_error()` that safely sets the underlying OTEL span status to ERROR when appropriate, with defensive error handling to prevent disruption of existing workflows.

The feature works during both span creation and updates, supports all observation types (spans, generations, events), and includes proper validation to ensure only ERROR-level observations trigger the status change. This enhancement improves observability for users who rely on OpenTelemetry-compatible monitoring systems while maintaining backward compatibility.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tests/test_otel.py | 5/5 | Adds comprehensive test coverage for OTEL span status ERROR setting functionality |
| langfuse/_client/observe.py | 5/5 | Adds OpenTelemetry Status and StatusCode imports needed for error status setting |
| langfuse/_client/span.py | 4/5 | Implements core functionality to set OTEL span status to ERROR when Langfuse level is ERROR |

</details>

## Confidence score: 4/5

- This PR is safe to merge with good test coverage and defensive implementation
- Score reflects solid implementation with comprehensive testing, though the core logic in span.py has some complexity
- Pay close attention to the span.py file to ensure the error handling logic is appropriate for your use case

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LangfuseObservationWrapper
    participant OpenTelemetrySpan as "OTEL Span"

    Note over User, OpenTelemetrySpan: Scenario 1: Creating span with ERROR level

    User->>LangfuseObservationWrapper: "__init__(level='ERROR', status_message='Error occurred')"
    LangfuseObservationWrapper->>LangfuseObservationWrapper: "Process attributes and media"
    LangfuseObservationWrapper->>OpenTelemetrySpan: "set_attributes(processed_attributes)"
    LangfuseObservationWrapper->>LangfuseObservationWrapper: "_set_otel_span_status_if_error(level='ERROR', status_message='Error occurred')"
    
    alt level == "ERROR" and span is recording
        LangfuseObservationWrapper->>OpenTelemetrySpan: "set_status(Status(StatusCode.ERROR), description='Error occurred')"
    end

    Note over User, OpenTelemetrySpan: Scenario 2: Updating existing span to ERROR level

    User->>LangfuseObservationWrapper: "update(level='ERROR', status_message='Updated error')"
    
    alt span is recording
        LangfuseObservationWrapper->>LangfuseObservationWrapper: "Process media and create attributes"
        LangfuseObservationWrapper->>OpenTelemetrySpan: "set_attributes(processed_attributes)"
        LangfuseObservationWrapper->>LangfuseObservationWrapper: "_set_otel_span_status_if_error(level='ERROR', status_message='Updated error')"
        
        alt level == "ERROR" and span is recording
            LangfuseObservationWrapper->>OpenTelemetrySpan: "set_status(Status(StatusCode.ERROR), description='Updated error')"
        end
    end

    Note over User, OpenTelemetrySpan: Scenario 3: Non-ERROR level (no OTEL status change)

    User->>LangfuseObservationWrapper: "update(level='INFO', status_message='Info message')"
    
    alt span is recording
        LangfuseObservationWrapper->>LangfuseObservationWrapper: "Process media and create attributes" 
        LangfuseObservationWrapper->>OpenTelemetrySpan: "set_attributes(processed_attributes)"
        LangfuseObservationWrapper->>LangfuseObservationWrapper: "_set_otel_span_status_if_error(level='INFO', status_message='Info message')"
        
        Note over LangfuseObservationWrapper: "level != 'ERROR', so no OTEL status change"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->