### PR TITLE
Handle starlette.StreamingResponse

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -312,6 +312,16 @@ class LangfuseDecorator:
                                     transform_to_string,
                                 )
 
+                            # handle starlette.StreamingResponse
+                            if type(result).__name__ == "StreamingResponse" and hasattr(result, "body_iterator"):
+                                is_return_type_generator = True
+
+                                result.body_iterator = self._wrap_async_generator_result(
+                                    langfuse_span_or_generation,
+                                    result.body_iterator,
+                                    transform_to_string,
+                                )
+
                             langfuse_span_or_generation.update(output=result)
 
                         return result
@@ -413,6 +423,16 @@ class LangfuseDecorator:
                                 return self._wrap_async_generator_result(
                                     langfuse_span_or_generation,
                                     result,
+                                    transform_to_string,
+                                )
+
+                            # handle starlette.StreamingResponse
+                            if type(result).__name__ == "StreamingResponse" and hasattr(result, "body_iterator"):
+                                is_return_type_generator = True
+
+                                result.body_iterator = self._wrap_async_generator_result(
+                                    langfuse_span_or_generation,
+                                    result.body_iterator,
                                     transform_to_string,
                                 )
 


### PR DESCRIPTION
Starlette has a StreamingResponse type that wraps an AsyncGenerator, which is often used in fastapi http calls.
By wrapping the result inside of it, we can get the correct timings and outputs for these generators in the resulting trace.

This also keeps the span open until the response is finished.

- https://github.com/langfuse/langfuse/issues/3876
- https://github.com/langfuse/langfuse/issues/7892
- Related: https://github.com/langfuse/langfuse/issues/8216