### PR TITLE
feat: propagate trace attributes onto all child spans on update

### DIFF
--- a/langfuse/_client/attributes.py
+++ b/langfuse/_client/attributes.py
@@ -18,7 +18,6 @@ from langfuse._client.constants import (
     ObservationTypeGenerationLike,
     ObservationTypeSpanLike,
 )
-
 from langfuse._utils.serializer import EventSerializer
 from langfuse.model import PromptClient
 from langfuse.types import MapValue, SpanLevel

--- a/langfuse/_client/constants.py
+++ b/langfuse/_client/constants.py
@@ -3,15 +3,13 @@
 This module defines constants used throughout the Langfuse OpenTelemetry integration.
 """
 
-from typing import Literal, List, get_args, Union, Any
+from typing import Any, List, Literal, Union, get_args
+
 from typing_extensions import TypeAlias
 
 LANGFUSE_TRACER_NAME = "langfuse-sdk"
 
-# Context key constants for Langfuse context propagation
-LANGFUSE_CTX_USER_ID = "langfuse.ctx.user.id"
-LANGFUSE_CTX_SESSION_ID = "langfuse.ctx.session.id"
-LANGFUSE_CTX_METADATA = "langfuse.ctx.metadata"
+LANGFUSE_CORRELATION_CONTEXT_KEY = "langfuse.ctx.correlation"
 
 
 """Note: this type is used with .__args__ / get_args in some cases and therefore must remain flat"""

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -13,9 +13,9 @@ All span classes provide methods for media processing, attribute management,
 and scoring integration specific to Langfuse's observability platform.
 """
 
+import warnings
 from datetime import datetime
 from time import time_ns
-import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -44,10 +44,10 @@ from langfuse._client.attributes import (
     create_trace_attributes,
 )
 from langfuse._client.constants import (
-    ObservationTypeLiteral,
     ObservationTypeGenerationLike,
-    ObservationTypeSpanLike,
+    ObservationTypeLiteral,
     ObservationTypeLiteralNoEvent,
+    ObservationTypeSpanLike,
     get_observation_types_list,
 )
 from langfuse.logger import langfuse_logger

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -234,7 +234,7 @@ class LangfuseObservationWrapper:
             public: Whether the trace should be publicly accessible
         """
         warnings.warn(
-            "update_trace is deprecated and will be removed in a future version. Use `with langfuse.with_attributes(...)` instead. ",
+            "update_trace is deprecated and will be removed in a future version. Use `with langfuse.correlation_context(...)` instead. ",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/langfuse/_client/utils.py
+++ b/langfuse/_client/utils.py
@@ -13,6 +13,8 @@ from opentelemetry import trace as otel_trace_api
 from opentelemetry.sdk import util
 from opentelemetry.sdk.trace import ReadableSpan
 
+from langfuse._client.attributes import LangfuseOtelSpanAttributes
+
 
 def span_formatter(span: ReadableSpan) -> str:
     parent_id = (
@@ -125,3 +127,16 @@ def run_async_safely(coro: Coroutine[Any, Any, Any]) -> Any:
     else:
         # Loop exists but not running, safe to use asyncio.run()
         return asyncio.run(coro)
+
+
+correlation_context_to_attribute_map = {
+    "session_id": LangfuseOtelSpanAttributes.TRACE_SESSION_ID,
+    "user_id": LangfuseOtelSpanAttributes.TRACE_USER_ID,
+}
+
+
+def get_attribute_key_from_correlation_context(correlation_context_key: str) -> str:
+    return (
+        correlation_context_to_attribute_map.get(correlation_context_key)
+        or f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.{correlation_context_key}"
+    )

--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -2071,7 +2071,7 @@ def test_context_manager_user_propagation():
     user_id = "test_user_123"
 
     with langfuse.start_as_current_span(name="parent-span") as parent_span:
-        with langfuse.with_attributes(user_id=user_id):
+        with langfuse.correlation_context({"user_id": user_id}):
             trace_id = parent_span.trace_id
 
             # Create child spans that should inherit user_id
@@ -2107,7 +2107,7 @@ def test_context_manager_session_propagation():
     session_id = "test_session_456"
 
     with langfuse.start_as_current_span(name="parent-span") as parent_span:
-        with langfuse.with_attributes(session_id=session_id):
+        with langfuse.correlation_context({"session_id": session_id}):
             trace_id = parent_span.trace_id
 
             # Create child spans that should inherit session_id
@@ -2142,8 +2142,8 @@ def test_context_manager_metadata_propagation():
     langfuse = Langfuse()
 
     with langfuse.start_as_current_span(name="parent-span") as parent_span:
-        with langfuse.with_attributes(
-            metadata={
+        with langfuse.correlation_context(
+            {
                 "experiment": "A/B",
                 "version": "1.2.3",
                 "feature_flag": "enabled",
@@ -2189,10 +2189,10 @@ def test_context_manager_nested_contexts():
     langfuse = Langfuse()
 
     with langfuse.start_as_current_span(name="outer-span") as outer_span:
-        with langfuse.with_attributes(user_id="user_1", session_id="session_1"):
-            with langfuse.with_attributes(
-                metadata={"env": "prod", "region": "us-east"}
-            ):
+        with langfuse.correlation_context(
+            {"user_id": "user_1", "session_id": "session_1"}
+        ):
+            with langfuse.correlation_context({"env": "prod", "region": "us-east"}):
                 outer_trace_id = outer_span.trace_id
 
                 # Create span in outer context
@@ -2234,9 +2234,11 @@ def test_context_manager_baggage_propagation():
 
     # Test with baggage enabled (careful with sensitive data)
     with langfuse.start_as_current_span(name="service-span") as span:
-        with langfuse.with_attributes(session_id="public_session_789", as_baggage=True):
-            with langfuse.with_attributes(
-                as_baggage=True, metadata={"service": "api", "version": "v1.0"}
+        with langfuse.correlation_context(
+            {"session_id": "public_session_789"}, as_baggage=True
+        ):
+            with langfuse.correlation_context(
+                {"service": "api", "version": "v1.0"}, as_baggage=True
             ):
                 trace_id = span.trace_id
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `correlation_context` for trace attribute propagation to child spans, deprecating `update_current_trace` and `update_trace`.
> 
>   - **Behavior**:
>     - Adds `correlation_context()` in `client.py` to propagate trace attributes to child spans.
>     - Deprecates `update_current_trace()` in `client.py` and `update_trace()` in `span.py`.
>   - **Span Processing**:
>     - Updates `LangfuseSpanProcessor` in `span_processor.py` to propagate correlation context to spans.
>   - **Utilities**:
>     - Adds `get_attribute_key_from_correlation_context()` in `utils.py` for attribute key mapping.
>   - **Tests**:
>     - Adds tests in `test_core_sdk.py` for `correlation_context()` propagation of `user_id`, `session_id`, and metadata.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for cf3ec39bf8396bdd04472400a58143cb21123f83. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-07 17:24:05 UTC

<h3>Summary</h3>
This PR introduces a new `correlation_context` feature that enables automatic propagation of trace-level attributes (user_id, session_id, metadata) to all child spans within a given scope, replacing the manual approach of calling `update_trace()` on each span individually.

### Key Changes Made:

**New Context Manager API**: A new `langfuse.correlation_context()` context manager allows developers to set trace attributes once and have them automatically applied to all nested spans and generations within that scope.

**OpenTelemetry Integration**: The implementation leverages OpenTelemetry's context propagation mechanisms, supporting both local context and baggage propagation modes. The baggage mode enables cross-service attribute propagation in distributed tracing scenarios.

**Automatic Span Processing**: The `LangfuseSpanProcessor` now includes an `on_start()` method that automatically reads correlation context from both OpenTelemetry baggage and local context, then applies relevant attributes to new spans as they're created.

**Deprecation Path**: The existing `update_current_trace()` and `span.update_trace()` methods are deprecated with clear warnings directing users to the new correlation context approach.

**Support Infrastructure**: New utility functions and constants support the attribute mapping between correlation context keys and OpenTelemetry span attributes, with special handling for well-known attributes like user_id and session_id.

This change addresses a common pain point in complex AI application tracing where maintaining consistent context across nested operations (like agent workflows, tool calls, etc.) was previously manual and error-prone. The new API follows OpenTelemetry best practices and provides a more ergonomic developer experience.
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/client.py | 4/5 | Implements the new `correlation_context` context manager with OpenTelemetry integration and deprecates `update_current_trace` |
| langfuse/_client/span_processor.py | 4/5 | Adds automatic attribute propagation in `on_start` method to inherit correlation context on child spans |
| tests/test_core_sdk.py | 4/5 | Adds comprehensive test coverage for correlation context functionality including nested contexts and baggage propagation |
| langfuse/_client/utils.py | 4/5 | Introduces mapping utilities for correlation context to span attribute conversion |
| langfuse/_client/span.py | 5/5 | Adds deprecation warning for `update_trace` method with minor import reorganization |
| langfuse/_client/constants.py | 5/5 | Adds correlation context key constant for OpenTelemetry context storage |
| langfuse/_client/attributes.py | 5/5 | Minor formatting improvement removing unnecessary blank line in imports |

</details>
<h3>Confidence score: 4/5</h3>

- This PR introduces a significant new feature with proper OpenTelemetry integration and comprehensive test coverage
- Score reflects the complexity of context propagation logic and potential edge cases in distributed tracing scenarios
- Pay close attention to the span processor implementation and baggage propagation behavior in production environments

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse as Langfuse Client
    participant SpanProcessor as LangfuseSpanProcessor
    participant CorrelationContext as Correlation Context
    participant OTELSpan as OpenTelemetry Span
    participant API as Langfuse API

    User->>Langfuse: start_as_current_span(name="parent")
    Langfuse->>OTELSpan: create parent span
    
    User->>Langfuse: correlation_context({"user_id": "123", "session_id": "456"})
    Langfuse->>CorrelationContext: set context values
    CorrelationContext->>CorrelationContext: store in OTEL context
    
    User->>Langfuse: start_span(name="child")
    Langfuse->>OTELSpan: create child span
    SpanProcessor->>SpanProcessor: on_start()
    SpanProcessor->>CorrelationContext: get_value(LANGFUSE_CORRELATION_CONTEXT_KEY)
    CorrelationContext-->>SpanProcessor: return correlation context
    SpanProcessor->>SpanProcessor: process correlation context
    loop For each context key-value pair
        SpanProcessor->>SpanProcessor: get_attribute_key_from_correlation_context(key)
        SpanProcessor->>OTELSpan: set_attribute(attribute_key, value)
    end
    SpanProcessor->>SpanProcessor: propagate baggage attributes
    
    User->>Langfuse: flush()
    Langfuse->>SpanProcessor: export spans
    SpanProcessor->>API: send span data with propagated attributes
    
    Note over SpanProcessor: All child spans automatically inherit<br/>trace attributes from correlation context
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->