### PR TITLE
fix: ensure ingestion queues are flushed in flush and shutdown

### DIFF
--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -398,11 +398,9 @@ class LangfuseResourceManager:
 
     def flush(self) -> None:
         tracer_provider = cast(TracerProvider, otel_trace_api.get_tracer_provider())
-        if isinstance(tracer_provider, otel_trace_api.ProxyTracerProvider):
-            return
-
-        tracer_provider.force_flush()
-        langfuse_logger.debug("Successfully flushed OTEL tracer provider")
+        if not isinstance(tracer_provider, otel_trace_api.ProxyTracerProvider):
+            tracer_provider.force_flush()
+            langfuse_logger.debug("Successfully flushed OTEL tracer provider")
 
         self._score_ingestion_queue.join()
         langfuse_logger.debug("Successfully flushed score ingestion queue")
@@ -415,10 +413,8 @@ class LangfuseResourceManager:
         atexit.unregister(self.shutdown)
 
         tracer_provider = cast(TracerProvider, otel_trace_api.get_tracer_provider())
-        if isinstance(tracer_provider, otel_trace_api.ProxyTracerProvider):
-            return
-
-        tracer_provider.force_flush()
+        if not isinstance(tracer_provider, otel_trace_api.ProxyTracerProvider):
+            tracer_provider.force_flush()
 
         self._stop_and_join_consumer_threads()
 


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-09 19:27:11 UTC

<h3>Summary</h3>
This PR fixes a critical bug in the Langfuse Python SDK's resource management system where ingestion queues were not being properly flushed during `flush()` and `shutdown()` operations in certain environments.

**What Changed:**
The PR modifies the control flow in the `ResourceManager` class's `flush()` and `shutdown()` methods in `langfuse/_client/resource_manager.py`. Previously, both methods would return early if they detected a `ProxyTracerProvider` from OpenTelemetry, completely skipping all queue flushing operations. The fix inverts this logic - now the methods always execute queue flushing operations for score ingestion and media upload queues, while only conditionally handling OpenTelemetry tracer provider flushing.

**Why This Matters:**
A `ProxyTracerProvider` typically indicates that OpenTelemetry tracing hasn't been fully initialized or configured, which is common in development environments or when OTEL is not properly set up. However, the Langfuse client can still have important queued data (scores, media uploads) that needs to be processed regardless of OTEL status. The previous implementation meant that in these environments, calling `flush()` or `shutdown()` would silently skip queue processing, potentially causing data loss.

**Integration with Codebase:**
This change fits into Langfuse's broader architecture where the `ResourceManager` handles background processing through various queues (`_score_ingestion_queue`, `_media_upload_queue`) and integrates with OpenTelemetry for distributed tracing. The fix ensures that the core ingestion functionality remains reliable even when the optional OTEL integration is not fully operational. This is particularly important for the SDK's testing infrastructure, as evidenced by the test case that expects `langfuse.task_manager._ingestion_queue.empty()` to be true after shutdown.
<h3>Important Files Changed</h3>

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/resource_manager.py | 5/5 | Fixed queue flushing logic to ensure ingestion queues are always processed regardless of OTEL tracer provider status |

</details>
<h3>Confidence score: 5/5</h3>

- This PR is safe to merge with minimal risk as it fixes a clear bug without introducing breaking changes
- Score reflects a straightforward logic fix that improves reliability by ensuring queue flushing always occurs
- No files require special attention - the change is isolated and well-targeted

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LangfuseResourceManager
    participant TracerProvider
    participant ScoreIngestionQueue
    participant MediaUploadQueue
    participant IngestionConsumers
    participant MediaConsumers

    User->>LangfuseResourceManager: "flush()"
    
    LangfuseResourceManager->>TracerProvider: "force_flush()"
    TracerProvider-->>LangfuseResourceManager: "flush complete"
    LangfuseResourceManager->>LangfuseResourceManager: "log: Successfully flushed OTEL tracer provider"
    
    LangfuseResourceManager->>ScoreIngestionQueue: "join()"
    Note over ScoreIngestionQueue: Wait for all score ingestion tasks to complete
    ScoreIngestionQueue-->>LangfuseResourceManager: "all tasks complete"
    LangfuseResourceManager->>LangfuseResourceManager: "log: Successfully flushed score ingestion queue"
    
    LangfuseResourceManager->>MediaUploadQueue: "join()"
    Note over MediaUploadQueue: Wait for all media upload tasks to complete
    MediaUploadQueue-->>LangfuseResourceManager: "all tasks complete"
    LangfuseResourceManager->>LangfuseResourceManager: "log: Successfully flushed media upload queue"
    
    LangfuseResourceManager-->>User: "flush complete"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes flushing behavior in `LangfuseResourceManager` to ensure ingestion queues are flushed during `flush()` and `shutdown()` unless `TracerProvider` is a `ProxyTracerProvider`.
> 
>   - **Behavior**:
>     - In `LangfuseResourceManager`, `flush()` and `shutdown()` now flush `TracerProvider` unless it is a `ProxyTracerProvider`.
>     - Ensures ingestion queues are flushed during `flush()` and `shutdown()` operations.
>   - **Logging**:
>     - Debug logs added for successful flushing of OTEL tracer provider, score ingestion queue, and media upload queue in `flush()`.
>   - **Misc**:
>     - Minor refactoring of conditionals in `flush()` and `shutdown()` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 04276a2b7d872b7e473988ac01863c4b1b95a560. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->