### PR TITLE
fix: ensure ingestion and media queues are always flushed

### DIFF
--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -398,11 +398,9 @@ class LangfuseResourceManager:
 
     def flush(self) -> None:
         tracer_provider = cast(TracerProvider, otel_trace_api.get_tracer_provider())
-        if isinstance(tracer_provider, otel_trace_api.ProxyTracerProvider):
-            return
-
-        tracer_provider.force_flush()
-        langfuse_logger.debug("Successfully flushed OTEL tracer provider")
+        if not isinstance(tracer_provider, otel_trace_api.ProxyTracerProvider):
+            tracer_provider.force_flush()
+            langfuse_logger.debug("Successfully flushed OTEL tracer provider")
 
         self._score_ingestion_queue.join()
         langfuse_logger.debug("Successfully flushed score ingestion queue")
@@ -415,10 +413,8 @@ class LangfuseResourceManager:
         atexit.unregister(self.shutdown)
 
         tracer_provider = cast(TracerProvider, otel_trace_api.get_tracer_provider())
-        if isinstance(tracer_provider, otel_trace_api.ProxyTracerProvider):
-            return
-
-        tracer_provider.force_flush()
+        if not isinstance(tracer_provider, otel_trace_api.ProxyTracerProvider):
+            tracer_provider.force_flush()
 
         self._stop_and_join_consumer_threads()
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure ingestion and media queues are always flushed in `resource_manager.py`, even with `ProxyTracerProvider`.
> 
>   - **Behavior**:
>     - Modify `flush()` and `shutdown()` in `resource_manager.py` to ensure ingestion and media queues are always flushed.
>     - Change condition to check for `ProxyTracerProvider` instances, ensuring flush operations are not skipped.
>   - **Logging**:
>     - Add debug log in `flush()` to confirm successful flushing of OTEL tracer provider, score ingestion queue, and media upload queue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 2479a83a2db599a13934c8e128080e967ff074d5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-09 20:05:52 UTC

<h3>Summary</h3>
This PR fixes a critical data loss bug in the `LangfuseResourceManager`'s flush and shutdown operations. The issue occurred when the OpenTelemetry tracer provider was a `ProxyTracerProvider` (OpenTelemetry's default provider when no explicit configuration is set), which is common in many deployment scenarios.

Previously, both the `flush()` and `shutdown()` methods would return early when encountering a `ProxyTracerProvider`, skipping the essential queue flushing operations for score ingestion and media upload queues. This meant that pending scores and media uploads could be lost during application shutdown or manual flush operations.

The fix inverts the conditional logic to ensure that the Langfuse-specific queues (score ingestion and media upload) are always flushed, while only making the OpenTelemetry tracer provider flush conditional on having a real (non-proxy) tracer provider. This change maintains thread safety and resource cleanup guarantees that are critical for the `LangfuseResourceManager`'s design as a singleton managing background threads and queues.

The change integrates well with the existing codebase architecture, where the `LangfuseResourceManager` serves as the central coordinator for background processing tasks. The fix preserves the existing OpenTelemetry integration while ensuring Langfuse's internal queue management remains robust regardless of OpenTelemetry configuration state.
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/resource_manager.py | 5/5 | Fixed critical data loss bug by ensuring ingestion and media queues are always flushed regardless of OpenTelemetry tracer provider type |

</details>
<h3>Confidence score: 5/5</h3>

- This PR is safe to merge with minimal risk as it fixes a clear data loss bug with a straightforward solution
- Score reflects the critical nature of the fix and the simple, well-targeted changes that address the root cause without introducing complexity
- No files require special attention as the change is isolated and the logic is clear

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LRM as "LangfuseResourceManager"
    participant TP as "TracerProvider"
    participant SIQ as "Score Ingestion Queue"
    participant MUQ as "Media Upload Queue"
    participant SIC as "ScoreIngestionConsumer"
    participant MUC as "MediaUploadConsumer"

    User->>LRM: "flush()"
    LRM->>TP: "force_flush()"
    TP-->>LRM: "flush complete"
    LRM->>LRM: "log 'Successfully flushed OTEL tracer provider'"
    
    LRM->>SIQ: "join()"
    Note over SIQ: "Wait for all score ingestion tasks to complete"
    SIQ-->>LRM: "all tasks complete"
    LRM->>LRM: "log 'Successfully flushed score ingestion queue'"
    
    LRM->>MUQ: "join()"
    Note over MUQ: "Wait for all media upload tasks to complete"
    MUQ-->>LRM: "all tasks complete"
    LRM->>LRM: "log 'Successfully flushed media upload queue'"
    
    LRM-->>User: "flush complete"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->