### PR TITLE
fix: ensure raw_stream.response is httpx.Response in langfuse streaming adapter

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -845,7 +845,7 @@ def _wrap(
         if _is_streaming_response(openai_response):
             return LangfuseResponseGeneratorSync(
                 resource=open_ai_resource,
-                response=openai_response,
+                stream=openai_response,
                 generation=generation,
             )
 
@@ -916,7 +916,7 @@ async def _wrap_async(
         if _is_streaming_response(openai_response):
             return LangfuseResponseGeneratorAsync(
                 resource=open_ai_resource,
-                response=openai_response,
+                stream=openai_response,
                 generation=generation,
             )
 
@@ -980,19 +980,20 @@ class LangfuseResponseGeneratorSync:
         self,
         *,
         resource: Any,
-        response: Any,
+        stream: Any,
         generation: Any,
     ) -> None:
         self.items: list[Any] = []
 
         self.resource = resource
-        self.response = response
+        self.stream = stream
+        self.response = stream.response
         self.generation = generation
         self.completion_start_time: Optional[datetime] = None
 
     def __iter__(self) -> Any:
         try:
-            for i in self.response:
+            for i in self.stream:
                 self.items.append(i)
 
                 if self.completion_start_time is None:
@@ -1004,7 +1005,7 @@ class LangfuseResponseGeneratorSync:
 
     def __next__(self) -> Any:
         try:
-            item = self.response.__next__()
+            item = self.stream.__next__()
             self.items.append(item)
 
             if self.completion_start_time is None:
@@ -1051,19 +1052,20 @@ class LangfuseResponseGeneratorAsync:
         self,
         *,
         resource: Any,
-        response: Any,
+        stream: Any,
         generation: Any,
     ) -> None:
         self.items: list[Any] = []
 
         self.resource = resource
-        self.response = response
+        self.stream = stream
+        self.response = stream.response
         self.generation = generation
         self.completion_start_time: Optional[datetime] = None
 
     async def __aiter__(self) -> Any:
         try:
-            async for i in self.response:
+            async for i in self.stream:
                 self.items.append(i)
 
                 if self.completion_start_time is None:
@@ -1075,7 +1077,7 @@ class LangfuseResponseGeneratorAsync:
 
     async def __anext__(self) -> Any:
         try:
-            item = await self.response.__anext__()
+            item = await self.stream.__anext__()
             self.items.append(item)
 
             if self.completion_start_time is None:


### PR DESCRIPTION
When Langfuse is enabled, the object passed to OpenAI’s stream manager as `raw_stream` is adapter LangfuseResponseGeneratorAsync. The OpenAI manager sets `self._response = raw_stream.response` and then calls `await self._response.aclose()`. `LangfuseResponseGeneratorAsync` previously set `response` to the `AsyncStream` itself (not to `httpx.Response`), so the manager tried to call `aclose()` on an `AsyncStream`, causing:

```python
AttributeError: 'AsyncStream' object has no attribute 'aclose'
```

## Steps to reproduce

- openai == 2.4.0
- langfuse == 3.7.0

```python
from langfuse.openai import AsyncOpenAI

request_options = {
    "model": "...",
    "messages": [{"role": "user", "content": "Hello"}],
    "n": 1,
}

async with AsyncOpenAI().chat.completions.stream(**request_options) as stream:
    async for event in stream:
        print(event)
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `raw_stream.response` is `httpx.Response` by renaming `response` to `stream` and setting `self.response` to `stream.response` in relevant classes and functions.
> 
>   - **Behavior**:
>     - Ensure `raw_stream.response` is `httpx.Response` in async adapter by renaming `response` to `stream` in `_wrap` and `_wrap_async` functions.
>     - Set `self.response` to `stream.response` in `LangfuseResponseGeneratorSync` and `LangfuseResponseGeneratorAsync` classes.
>   - **Classes**:
>     - `LangfuseResponseGeneratorSync`: Renamed `response` to `stream` and set `self.response` to `stream.response`.
>     - `LangfuseResponseGeneratorAsync`: Renamed `response` to `stream` and set `self.response` to `stream.response`.
>   - **Functions**:
>     - `_wrap`: Renamed `response` to `stream`.
>     - `_wrap_async`: Renamed `response` to `stream`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 816c68a7d57abb8363f929dcb0aded68c8e4c3e2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->