### PR TITLE
fix: avoid empty status message when capturing exception in observe decorator

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -441,7 +441,7 @@ class LangfuseDecorator:
                         return result
                     except Exception as e:
                         langfuse_span_or_generation.update(
-                            level="ERROR", status_message=str(e)
+                            level="ERROR", status_message=str(e) or type(e).__name__
                         )
 
                         raise e
@@ -581,7 +581,7 @@ class _ContextPreservedSyncGeneratorWrapper:
             raise  # Re-raise StopIteration
 
         except Exception as e:
-            self.span.update(level="ERROR", status_message=str(e)).end()
+            self.span.update(level="ERROR", status_message=str(e) or type(e).__name__).end()
 
             raise
 
@@ -646,6 +646,6 @@ class _ContextPreservedAsyncGeneratorWrapper:
 
             raise  # Re-raise StopAsyncIteration
         except Exception as e:
-            self.span.update(level="ERROR", status_message=str(e)).end()
+            self.span.update(level="ERROR", status_message=str(e) or type(e).__name__).end()
 
             raise


### PR DESCRIPTION
```python
try:
    raise ValueError
except Exception as e:
    print(str(e))
```

Results in empty string. Nothing is shown in Langfuse web.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-22 10:40:32 UTC

<h3>Summary</h3>

This PR fixes empty status messages when exceptions with empty `str()` representations are captured in the `@observe` decorator by falling back to the exception class name.

**Key Changes:**
- Modified async decorator exception handler to use `str(e) or type(e).__name__` for status messages

**Issues Found:**
- The fix was only applied to the async decorator (`_async_observe` at langfuse/_client/observe.py:330)
- Three other exception handlers still use `str(e)` without the fallback:
  - Sync decorator (`_sync_observe` at langfuse/_client/observe.py:444)
  - Sync generator wrapper (`_ContextPreservedSyncGeneratorWrapper.__next__` at langfuse/_client/observe.py:584)
  - Async generator wrapper (`_ContextPreservedAsyncGeneratorWrapper.__anext__` at langfuse/_client/observe.py:649)
- This inconsistency means the bug still exists for synchronous decorated functions and generator-returning functions

<h3>Confidence Score: 2/5</h3>

- This PR is incomplete - the fix only covers one of four exception handlers
- The PR correctly identifies and fixes the issue for async decorators, but fails to apply the same fix to sync decorators and generator wrappers, leaving the original bug present in 75% of exception handling paths
- langfuse/_client/observe.py requires the same fix to be applied at lines 444, 584, and 649

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/observe.py | 2/5 | Fixed empty status messages for exceptions in async decorator only; sync decorator and both generator wrappers still have the issue |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Decorator as @observe Decorator
    participant Function as Decorated Function
    participant Langfuse as Langfuse API

    User->>Decorator: Call decorated function
    Decorator->>Langfuse: Create span/generation
    Decorator->>Function: Execute function
    
    alt Function succeeds
        Function->>Decorator: Return result
        Decorator->>Langfuse: Update with output
        Decorator->>Langfuse: End span
        Decorator->>User: Return result
    else Function raises exception
        Function->>Decorator: Raise exception
        Decorator->>Decorator: Get status_message: str(e) or type(e).__name__
        Decorator->>Langfuse: Update with level=ERROR, status_message
        Decorator->>Langfuse: End span
        Decorator->>User: Re-raise exception
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->