### PR TITLE
feat: add LANGFUSE_SPAN_PROCESSOR_ENABLED environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Environment variables (defined in `_client/environment_variables.py`):
 - `LANGFUSE_HOST`: API endpoint (defaults to https://cloud.langfuse.com)
 - `LANGFUSE_DEBUG`: Enable debug logging
 - `LANGFUSE_TRACING_ENABLED`: Enable/disable tracing
+- `LANGFUSE_SPAN_PROCESSOR_ENABLED`: Enable/disable span processor registration (defaults to True)
 - `LANGFUSE_SAMPLE_RATE`: Sampling rate for traces
 
 ## Testing Notes

--- a/langfuse/_client/environment_variables.py
+++ b/langfuse/_client/environment_variables.py
@@ -156,3 +156,15 @@ This setting determines how long prompt responses are cached before they expire.
 
 **Default value**: ``60``
 """
+
+LANGFUSE_SPAN_PROCESSOR_ENABLED = "LANGFUSE_SPAN_PROCESSOR_ENABLED"
+"""
+.. envvar: LANGFUSE_SPAN_PROCESSOR_ENABLED
+
+Controls whether the Langfuse span processor is registered with the tracer provider.
+When disabled, spans will not be exported to the Langfuse API even if tracing is enabled.
+This is useful when you want to use your own custom span processor to avoid duplicate
+span processing and export.
+
+**Default value**: ``True``
+"""


### PR DESCRIPTION
Add environment variable to control whether the Langfuse span processor is registered with the tracer provider. This allows users to use their own custom span processors without duplicate processing.

- Add LANGFUSE_SPAN_PROCESSOR_ENABLED environment variable (default: True)
- Update resource_manager.py to check env var before registering processor
- Add test_disabled_span_processor test to verify behavior
- Update CLAUDE.md documentation
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `LANGFUSE_SPAN_PROCESSOR_ENABLED` environment variable to control span processor registration, with updates to `resource_manager.py`, tests, and documentation.
> 
>   - **Behavior**:
>     - Add `LANGFUSE_SPAN_PROCESSOR_ENABLED` environment variable to control span processor registration (default: True).
>     - Update `resource_manager.py` to check this variable before registering the span processor.
>   - **Testing**:
>     - Add `test_disabled_span_processor` in `test_otel.py` to verify behavior when the span processor is disabled.
>   - **Documentation**:
>     - Update `CLAUDE.md` to include the new environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for f5e761c314b94ea5ec750c1ea8349f53e2f917ee. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-11-10 05:50:09 UTC

<h3>Greptile Summary</h3>


This PR introduces a new environment variable `LANGFUSE_SPAN_PROCESSOR_ENABLED` (defaults to True) that controls whether the Langfuse span processor is registered with the tracer provider. This allows users to disable the default span processor when they want to use their own custom processors, avoiding duplicate span processing and export.

**Key changes:**
- Added `LANGFUSE_SPAN_PROCESSOR_ENABLED` environment variable definition with documentation
- Updated `resource_manager.py` to conditionally register the span processor based on the env var
- Added comprehensive test to verify the processor is not created when disabled
- Updated documentation in CLAUDE.md

The implementation is straightforward and follows existing patterns in the codebase for checking environment variables. The tracer provider is still created when tracing is enabled, but the Langfuse-specific span processor is only added if the env var is not set to "false" or "0".

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are simple, well-tested, and follow existing patterns in the codebase. The only minor style issue is imports inside a test function, which doesn't affect functionality.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/resource_manager.py | 5/5 | Conditionally registers span processor based on env var, allows custom processors |
| tests/test_otel.py | 4/5 | Test verifies span processor is not created when disabled; imports should be moved to top |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse
    participant ResourceManager
    participant TracerProvider
    participant SpanProcessor

    User->>Langfuse: Initialize client with tracing_enabled=True
    Langfuse->>ResourceManager: Create/get singleton instance
    ResourceManager->>ResourceManager: Check LANGFUSE_SPAN_PROCESSOR_ENABLED env var
    
    alt LANGFUSE_SPAN_PROCESSOR_ENABLED = "True" (default)
        ResourceManager->>TracerProvider: Initialize tracer provider
        ResourceManager->>SpanProcessor: Create LangfuseSpanProcessor
        ResourceManager->>TracerProvider: add_span_processor(langfuse_processor)
        TracerProvider-->>ResourceManager: Span processor registered
        ResourceManager-->>Langfuse: Tracer with Langfuse processor
    else LANGFUSE_SPAN_PROCESSOR_ENABLED = "false"
        ResourceManager->>TracerProvider: Initialize tracer provider
        Note right of ResourceManager: Skip span processor creation
        ResourceManager-->>Langfuse: Tracer without Langfuse processor
    end
    
    Langfuse-->>User: Client ready
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->