### PR TITLE
callbacks: langchain: Migrate to v1

### DIFF
--- a/langfuse/callback/langchain.py
+++ b/langfuse/callback/langchain.py
@@ -28,24 +28,44 @@ from langfuse.utils import _get_timestamp
 from langfuse.utils.base_callback_handler import LangfuseBaseCallbackHandler
 
 try:
-    from langchain.callbacks.base import (
-        BaseCallbackHandler as LangchainBaseCallbackHandler,
-    )
-    from langchain.schema.agent import AgentAction, AgentFinish
-    from langchain.schema.document import Document
-    from langchain_core.messages import (
-        AIMessage,
-        BaseMessage,
-        ChatMessage,
-        FunctionMessage,
-        HumanMessage,
-        SystemMessage,
-        ToolMessage,
-    )
-    from langchain_core.outputs import (
-        ChatGeneration,
-        LLMResult,
-    )
+    if langchain.__version__.startswith("1"):
+        # Langchain v1
+        from langchain_core.agents import AgentAction, AgentFinish
+        from langchain_core.callbacks import (
+            BaseCallbackHandler as LangchainBaseCallbackHandler,
+        )
+        from langchain_core.documents import Document
+        from langchain_core.messages import (
+            AIMessage,
+            BaseMessage,
+            ChatMessage,
+            FunctionMessage,
+            HumanMessage,
+            SystemMessage,
+            ToolMessage,
+        )
+        from langchain_core.outputs import ChatGeneration, LLMResult
+
+    else:
+        # Langchain v0
+        from langchain.callbacks.base import (  # type: ignore
+            BaseCallbackHandler as LangchainBaseCallbackHandler,
+        )
+        from langchain.schema.agent import AgentAction, AgentFinish  # type: ignore
+        from langchain.schema.document import Document  # type: ignore
+        from langchain_core.messages import (
+            AIMessage,
+            BaseMessage,
+            ChatMessage,
+            FunctionMessage,
+            HumanMessage,
+            SystemMessage,
+            ToolMessage,
+        )
+        from langchain_core.outputs import (
+            ChatGeneration,
+            LLMResult,
+        )
 except ImportError:
     raise ModuleNotFoundError(
         "Please install langchain to use the Langfuse langchain integration: 'pip install langchain'"


### PR DESCRIPTION
Update langchain imports for langchain v1

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-11-10 12:47:39 UTC

<h3>Greptile Summary</h3>


Added backward compatibility for langchain v0 while supporting v1 by implementing runtime version detection. The change wraps imports in a conditional block that checks `langchain.__version__` and imports from different modules depending on the version:

- **v1**: Imports from `langchain_core.agents`, `langchain_core.callbacks`, `langchain_core.documents`
- **v0**: Imports from legacy `langchain.callbacks.base`, `langchain.schema.agent`, `langchain.schema.document`

Both versions continue to use `langchain_core` for messages and outputs.

**Key findings:**
- Version check using `.startswith("1")` will incorrectly match future v10+ versions

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor logic issue that should be addressed for future-proofing
- The implementation correctly adds backward compatibility for langchain v0 while supporting v1. The approach is sound - using runtime version detection to conditionally import from appropriate modules. However, the version check uses `.startswith("1")` which will cause incorrect behavior if langchain ever reaches v10+. This is unlikely in the near term but should be fixed for proper version handling. All other aspects of the implementation look correct.
- langfuse/callback/langchain.py - fix version check logic at line 31

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/callback/langchain.py | 4/5 | Added version detection to support both langchain v0 and v1 by checking `langchain.__version__` and importing from appropriate modules. However, version check relies on runtime detection within the import block which could cause issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant LC as Langchain
    participant LF as Langfuse Callback
    participant Ver as Version Check
    
    App->>LC: Import langchain
    LC-->>Ver: Check langchain.__version__
    
    alt langchain v1
        Ver->>LC: Import from langchain_core.agents
        Ver->>LC: Import from langchain_core.callbacks
        Ver->>LC: Import from langchain_core.documents
        Ver->>LC: Import from langchain_core.messages
        Ver->>LC: Import from langchain_core.outputs
    else langchain v0
        Ver->>LC: Import from langchain.callbacks.base
        Ver->>LC: Import from langchain.schema.agent
        Ver->>LC: Import from langchain.schema.document
        Ver->>LC: Import from langchain_core.messages
        Ver->>LC: Import from langchain_core.outputs
    end
    
    App->>LC: Execute langchain operations
    LC->>LF: Trigger callbacks
    LF->>LF: Process with imported types
    LF-->>App: Return results
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `langfuse/callback/langchain.py` imports to support both langchain v0 and v1 by checking `langchain.__version__`.
> 
>   - **Imports**:
>     - Update imports in `langfuse/callback/langchain.py` to support langchain v1.
>     - Conditional imports based on `langchain` version to maintain compatibility with v0 and v1.
>   - **Version Check**:
>     - Check `langchain.__version__` to determine import paths for v0 and v1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 95dd3b0e5b5f9c9c8555ae5a228bd49521b341fb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->