### PR TITLE
fix(client): handle update_current_trace on non recorded spans gracefully

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1664,7 +1664,7 @@ class Langfuse:
 
         current_otel_span = self._get_current_otel_span()
 
-        if current_otel_span is not None:
+        if current_otel_span is not None and current_otel_span.is_recording():
             existing_observation_type = current_otel_span.attributes.get(  # type: ignore[attr-defined]
                 LangfuseOtelSpanAttributes.OBSERVATION_TYPE, "span"
             )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add check in `update_current_trace()` in `client.py` to ensure updates only occur on recording spans.
> 
>   - **Behavior**:
>     - In `update_current_trace()` in `client.py`, add check for `current_otel_span.is_recording()` to ensure updates only occur on recording spans.
>   - **Misc**:
>     - No changes to function signatures or additional functionality added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 04877ec014c8d4d3772c87f1f605a0b0cb83dcd3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added defensive check to prevent accessing attributes on non-recording OpenTelemetry spans in the `update_current_trace` method.

- Previously, the code would attempt to access `current_otel_span.attributes.get()` on line 1668 without checking if the span was recording
- In OpenTelemetry, non-recording spans (e.g., sampled-out spans) don't allow attribute access and would cause errors
- The fix adds `and current_otel_span.is_recording()` to the conditional check, consistent with similar patterns used elsewhere in the codebase (e.g., `langfuse/_client/span.py:240`, `langfuse/_client/propagation.py:358`)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple defensive check that follows established patterns in the codebase. It prevents a potential error when accessing attributes on non-recording spans, making the code more robust without changing any functional behavior for recording spans.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/client.py | 5/5 | Added `is_recording()` check to prevent attribute access on non-recording spans in `update_current_trace` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse
    participant OtelSpan
    participant SpanWrapper
    
    User->>Langfuse: update_current_trace()
    Langfuse->>Langfuse: Check _tracing_enabled
    alt Tracing disabled
        Langfuse-->>User: Return early
    end
    
    Langfuse->>Langfuse: _get_current_otel_span()
    Langfuse->>OtelSpan: Check is not None
    Langfuse->>OtelSpan: is_recording()
    
    alt Span is recording
        OtelSpan-->>Langfuse: true
        Langfuse->>OtelSpan: attributes.get()
        OtelSpan-->>Langfuse: observation_type
        Langfuse->>Langfuse: _get_span_class()
        Langfuse->>SpanWrapper: Create wrapper instance
        Langfuse->>SpanWrapper: update_trace()
        SpanWrapper-->>Langfuse: Success
    else Span not recording
        OtelSpan-->>Langfuse: false
        Note over Langfuse: Skip update (no error)
    end
    
    Langfuse-->>User: Return
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->