### PR TITLE
fix(experiments): remove evals from main execution span

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -2858,56 +2858,56 @@ class Langfuse:
                     metadata=final_observation_metadata,
                 )
 
-                # Run evaluators
-                evaluations = []
-
-                for evaluator in evaluators:
-                    try:
-                        eval_metadata: Optional[Dict[str, Any]] = None
-
-                        if isinstance(item, dict):
-                            eval_metadata = item.get("metadata")
-                        elif hasattr(item, "metadata"):
-                            eval_metadata = item.metadata
-
-                        eval_results = await _run_evaluator(
-                            evaluator,
-                            input=input_data,
-                            output=output,
-                            expected_output=expected_output,
-                            metadata=eval_metadata,
-                        )
-                        evaluations.extend(eval_results)
-
-                        # Store evaluations as scores
-                        for evaluation in eval_results:
-                            self.create_score(
-                                trace_id=trace_id,
-                                observation_id=span.id,
-                                name=evaluation.name,
-                                value=evaluation.value,  # type: ignore
-                                comment=evaluation.comment,
-                                metadata=evaluation.metadata,
-                                config_id=evaluation.config_id,
-                                data_type=evaluation.data_type,  # type: ignore
-                            )
-
-                    except Exception as e:
-                        langfuse_logger.error(f"Evaluator failed: {e}")
-
-                return ExperimentItemResult(
-                    item=item,
-                    output=output,
-                    evaluations=evaluations,
-                    trace_id=trace_id,
-                    dataset_run_id=dataset_run_id,
-                )
-
             except Exception as e:
                 span.update(
                     output=f"Error: {str(e)}", level="ERROR", status_message=str(e)
                 )
                 raise e
+
+            # Run evaluators
+            evaluations = []
+
+            for evaluator in evaluators:
+                try:
+                    eval_metadata: Optional[Dict[str, Any]] = None
+
+                    if isinstance(item, dict):
+                        eval_metadata = item.get("metadata")
+                    elif hasattr(item, "metadata"):
+                        eval_metadata = item.metadata
+
+                    eval_results = await _run_evaluator(
+                        evaluator,
+                        input=input_data,
+                        output=output,
+                        expected_output=expected_output,
+                        metadata=eval_metadata,
+                    )
+                    evaluations.extend(eval_results)
+
+                    # Store evaluations as scores
+                    for evaluation in eval_results:
+                        self.create_score(
+                            trace_id=trace_id,
+                            observation_id=span.id,
+                            name=evaluation.name,
+                            value=evaluation.value,  # type: ignore
+                            comment=evaluation.comment,
+                            metadata=evaluation.metadata,
+                            config_id=evaluation.config_id,
+                            data_type=evaluation.data_type,  # type: ignore
+                        )
+
+                except Exception as e:
+                    langfuse_logger.error(f"Evaluator failed: {e}")
+
+            return ExperimentItemResult(
+                item=item,
+                output=output,
+                evaluations=evaluations,
+                trace_id=trace_id,
+                dataset_run_id=dataset_run_id,
+            )
 
     def _create_experiment_run_name(
         self, *, name: Optional[str] = None, run_name: Optional[str] = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move evaluator execution outside the main execution span in `_process_experiment_item()` to improve error handling and separation of concerns.
> 
>   - **Behavior**:
>     - Move evaluator execution outside the main execution span in `_process_experiment_item()` in `client.py`.
>     - Evaluators are now run after the main task execution, improving error handling and separation of concerns.
>   - **Error Handling**:
>     - Errors during task execution update the span with error details and re-raise the exception.
>     - Errors during evaluator execution are logged but do not affect the main task execution.
>   - **Misc**:
>     - Minor restructuring of try-except blocks for clarity and separation of task and evaluator logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 65a9523caf5f71bf68ae2f9db3ea2ebe9c4f4900. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Refactored `_process_experiment_item` to move evaluator execution outside the main try-block, separating evaluation logic from the primary task execution within the span.

- The evaluators now run after the main task completes successfully, but still within the span context manager
- If the main task throws an exception, evaluators are skipped entirely (exception is raised immediately)
- All variables (`output`, `input_data`, `trace_id`, etc.) remain accessible since they're initialized before the try-block ends
- The span object remains valid throughout since the code is still within the `with` statement scope

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a clean code reorganization that correctly moves evaluator logic outside the try-block while maintaining all necessary variable scopes. The refactoring properly handles error cases by skipping evaluators when exceptions occur, and all references remain valid within the context manager scope.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/client.py | 5/5 | Moved evaluator execution from inside try-block to after it, separating evaluation from main task execution while keeping them in the span context. Clean refactor with no logical issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Span as Experiment Item Span
    participant Task as Main Task
    participant Evaluators
    
    Client->>Span: start_as_current_span("experiment-item-run")
    activate Span
    
    Note over Span: Try Block Start
    Span->>Span: Initialize variables (input_data, expected_output, etc.)
    Span->>Task: await _run_task(task, item)
    Task-->>Span: output
    Span->>Span: update(input, output, metadata)
    Note over Span: Try Block End
    
    alt Exception in try block
        Span->>Span: update(level=ERROR, status_message)
        Span-->>Client: raise exception
        Note over Evaluators: Evaluators NOT executed
    else Success
        Note over Span,Evaluators: NEW: Evaluators run AFTER try block
        loop For each evaluator
            Span->>Evaluators: await _run_evaluator()
            Evaluators-->>Span: eval_results
            Span->>Span: create_score()
        end
        Span-->>Client: return ExperimentItemResult
    end
    
    deactivate Span
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->