### PR TITLE
fix: add option to force keep_trace_attributes in langfuse

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -1191,6 +1191,10 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                         current_parent_run_id
                     )
 
+            # Keep trace attributes if llm runs isolated outside chain, or caller forces it via metadata
+            keep_langfuse_trace_attributes = bool(
+                (metadata or {}).get("keep_trace_attributes") or parent_run_id is None
+            )
             content = {
                 "name": self.get_langchain_run_name(serialized, **kwargs),
                 "input": prompts,
@@ -1198,10 +1202,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                     parent_run_id=parent_run_id,
                     tags=tags,
                     metadata=metadata,
-                    # If llm is run isolated and outside chain, keep trace attributes
-                    keep_langfuse_trace_attributes=True
-                    if parent_run_id is None
-                    else False,
+                    keep_langfuse_trace_attributes=keep_langfuse_trace_attributes,
                 ),
                 "model": model_name,
                 "model_parameters": self._parse_model_parameters(kwargs),


### PR DESCRIPTION
Fix of the bug, when langfuse trace attributes was not passed to Langfuse UI, if call was inside of LLM chain

https://github.com/langfuse/langfuse/issues/10380
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix bug in `CallbackHandler.py` to ensure trace attributes are passed to Langfuse UI when LLM is run inside a chain.
> 
>   - **Bug Fix**:
>     - In `CallbackHandler.py`, fix bug in `__on_llm_action` where trace attributes were not passed to Langfuse UI if call was inside LLM chain.
>     - Introduce `keep_trace_attributes` to determine if trace attributes should be kept based on `metadata` or if `parent_run_id` is `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 3d36dfc28e2e950fc4a7b7382da0c1109e68538e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds `keep_trace_attributes` option to force preservation of Langfuse trace attributes (session ID, user ID, tags) when LLM calls occur inside chains

- Previously, trace attributes were only preserved for isolated LLM calls (`parent_run_id is None`)
- Now allows explicit override via `metadata['keep_trace_attributes']` to preserve attributes in chain contexts
- Critical bug: Line 796 will raise `AttributeError` when `metadata` is `None` since `.get()` is called on optional parameter

<h3>Confidence Score: 2/5</h3>


- This PR contains a critical bug that will cause runtime errors when `metadata` is `None`
- The implementation adds the requested feature but introduces an `AttributeError` on line 796 when `metadata` is `None` (calling `.get()` on `None`). This is a guaranteed runtime error that must be fixed before merging.
- langfuse/langchain/CallbackHandler.py line 796 requires immediate fix for the `None` handling bug

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/langchain/CallbackHandler.py | 2/5 | Added `keep_trace_attributes` flag to allow forcing trace attributes in LLM chains, but contains `AttributeError` bug when `metadata` is `None` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LangchainCallbackHandler
    participant __on_llm_action
    participant __join_tags_and_metadata
    participant _strip_langfuse_keys_from_dict
    participant LangfuseObservation

    User->>LangchainCallbackHandler: on_llm_start(metadata={keep_trace_attributes: true})
    LangchainCallbackHandler->>__on_llm_action: Process LLM start event
    
    alt metadata.keep_trace_attributes == true
        __on_llm_action->>__on_llm_action: keep_trace_attributes = True
    else parent_run_id is None (isolated LLM call)
        __on_llm_action->>__on_llm_action: keep_trace_attributes = True
    else inside chain
        __on_llm_action->>__on_llm_action: keep_trace_attributes = False
    end
    
    __on_llm_action->>__join_tags_and_metadata: Join metadata with keep flag
    __join_tags_and_metadata->>_strip_langfuse_keys_from_dict: Strip keys conditionally
    
    alt keep_trace_attributes == True
        _strip_langfuse_keys_from_dict->>_strip_langfuse_keys_from_dict: Keep langfuse_session_id, langfuse_user_id, langfuse_tags
    else keep_trace_attributes == False
        _strip_langfuse_keys_from_dict->>_strip_langfuse_keys_from_dict: Strip langfuse_session_id, langfuse_user_id, langfuse_tags
    end
    
    _strip_langfuse_keys_from_dict-->>__on_llm_action: Return processed metadata
    __on_llm_action->>LangfuseObservation: start_observation(metadata=processed_metadata)
    LangfuseObservation-->>User: Trace created with/without attributes
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->