### PR TITLE
fix: evict prompt cache on NotFound error

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -79,6 +79,7 @@ from langfuse._utils import _get_timestamp
 from langfuse._utils.parse_error import handle_fern_exception
 from langfuse._utils.prompt_cache import PromptCache
 from langfuse.api.resources.commons.errors.error import Error
+from langfuse.api.resources.commons.errors.not_found_error import NotFoundError
 from langfuse.api.resources.ingestion.types.score_body import ScoreBody
 from langfuse.api.resources.prompts.types import (
     CreatePromptRequest_Chat,
@@ -3596,6 +3597,14 @@ class Langfuse:
                 self._resources.prompt_cache.set(cache_key, prompt, ttl_seconds)
 
             return prompt
+
+        except NotFoundError as not_found_error:
+            langfuse_logger.warning(
+                f"Prompt '{cache_key}' not found during refresh, evicting from cache."
+            )
+            if self._resources is not None:
+                self._resources.prompt_cache.delete(cache_key)
+            raise not_found_error
 
         except Exception as e:
             langfuse_logger.error(

--- a/langfuse/_utils/prompt_cache.py
+++ b/langfuse/_utils/prompt_cache.py
@@ -158,6 +158,9 @@ class PromptCache:
 
         self._cache[key] = PromptCacheItem(value, ttl_seconds)
 
+    def delete(self, key: str) -> None:
+        self._cache.pop(key, None)
+
     def invalidate(self, prompt_name: str) -> None:
         """Invalidate all cached prompts with the given prompt name."""
         for key in list(self._cache):


### PR DESCRIPTION
### Problem

When a prompt label is removed in the Langfuse UI and the cached entry expires, `get_prompt` kept returning the stale prompt. The refresh worker logged a `404 NotFoundError` but left the cache entry intact, so the SDK never fell back to another label or the unlabeled version. This bug is described in the issue linked below.

### Technical details

- Catch `NotFoundError` in `_fetch_prompt_and_update_cache`, log a warning and delete the cache entry before re‑raising the error.
- Add `PromptCache.delete(key)` to remove a single cached entry and `PromptCache.invalidate(prompt_name)` to drop all entries for a prompt.
- Add `test_evict_prompt_cache_entry_when_refresh_returns_not_found` and update fixtures to initialise `_resources` with `PromptCache`.

Original issue: https://github.com/langfuse/langfuse/issues/10138
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes prompt cache eviction on `NotFoundError` by updating cache handling logic and adding tests for verification.
> 
>   - **Behavior**:
>     - In `client.py`, catch `NotFoundError` in `_fetch_prompt_and_update_cache`, log a warning, and delete the cache entry before re-raising the error.
>     - Add `PromptCache.delete(key)` to remove a single cached entry and `PromptCache.invalidate(prompt_name)` to drop all entries for a prompt.
>   - **Tests**:
>     - Add `test_evict_prompt_cache_entry_when_refresh_returns_not_found` in `test_prompt.py` to verify cache eviction on `NotFoundError`.
>     - Update fixtures in `test_prompt.py` to initialize `_resources` with `PromptCache`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 3c32bb0ee185c654c5bd32ab5c885e6281138d2d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>


- Fixes stale prompt cache bug by evicting cache entries when background refresh receives 404 `NotFoundError` from API
- Adds `PromptCache.delete()` method to remove single cache entries when prompts are deleted in Langfuse UI

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is well-targeted with proper exception handling, safe cache deletion logic using `dict.pop(key, None)`, and comprehensive test coverage verifying the cache eviction flow
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_client/client.py | Added `NotFoundError` exception handling to evict cache entries when prompts are deleted from Langfuse UI |
| tests/test_prompt.py | Added comprehensive test for cache eviction on `NotFoundError` and updated fixture with `_resources` initialization |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse as "Langfuse.get_prompt()"
    participant Cache as "PromptCache"
    participant Worker as "Background Worker"
    participant API as "Langfuse API"

    User->>Langfuse: "get_prompt(name)"
    Langfuse->>Cache: "get(cache_key)"
    Cache-->>Langfuse: "cached_prompt (expired)"
    Langfuse->>Cache: "add_refresh_prompt_task()"
    Langfuse-->>User: "return stale prompt"
    
    Cache->>Worker: "schedule refresh task"
    Worker->>Langfuse: "call _fetch_prompt_and_update_cache()"
    Langfuse->>API: "prompts.get(name, label)"
    API-->>Langfuse: "NotFoundError (404)"
    Langfuse->>Cache: "delete(cache_key)"
    
    User->>Langfuse: "get_prompt(name, fallback)"
    Langfuse->>Cache: "get(cache_key)"
    Cache-->>Langfuse: "None"
    Langfuse->>API: "prompts.get(name, label)"
    API-->>Langfuse: "NotFoundError (404)"
    Langfuse-->>User: "return fallback prompt"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->