### PR TITLE
docs(experiments): evaluation value cannot be None

### DIFF
--- a/langfuse/experiment.py
+++ b/langfuse/experiment.py
@@ -107,7 +107,6 @@ class Evaluation:
             - Numeric (int/float): For quantitative metrics like accuracy (0.85), BLEU (0.42)
             - String: For categorical results like "positive", "negative", "neutral"
             - Boolean: For binary assessments like "passes_safety_check"
-            - None: When evaluation cannot be computed (missing data, API errors, etc.)
         comment: Optional human-readable explanation of the evaluation result.
             Useful for providing context, explaining scoring rationale, or noting
             special conditions. Displayed in Langfuse UI for interpretability.
@@ -186,7 +185,7 @@ class Evaluation:
         self,
         *,
         name: str,
-        value: Union[int, float, str, bool, None],
+        value: Union[int, float, str, bool],
         comment: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         data_type: Optional[ScoreDataType] = None,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `None` as a valid type for `value` in `Evaluation` class in `experiment.py`, updating the `__init__` method and class docstring accordingly.
> 
>   - **Behavior**:
>     - Removes `None` as a valid type for `value` in `Evaluation` class in `experiment.py`.
>     - Updates `__init__` method to enforce `value` as `Union[int, float, str, bool]`.
>     - Updates class docstring to reflect removal of `None` as a valid `value` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 306529c079c0d8db92e7c0aedb6ce6e33eef7538. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR removes `None` as a valid value for `Evaluation.value` by updating the type hint from `Union[int, float, str, bool, None]` to `Union[int, float, str, bool]` and removing the corresponding documentation line.

**Issue Found:**
The PR incompletely updates the documentation. While the type hint and the main documentation list are updated, two code examples in the docstring (lines 127 and 173) still show `value=None` being used in error handling scenarios. These examples now contradict the new type constraint and will cause type errors if users follow them.

**Impact:**
- Users following the examples will encounter type errors
- The documentation is inconsistent, which may confuse developers
- The examples need to be updated to show alternative error handling patterns (e.g., returning `None` from the evaluator function to skip the evaluation, or using sentinel values)

<h3>Confidence Score: 2/5</h3>


- This PR has critical documentation inconsistencies that will mislead users
- The type hint change is correct, but the documentation examples contradict it. This creates a breaking inconsistency where examples demonstrate invalid usage that will fail at runtime or with type checkers.
- langfuse/experiment.py requires attention - the docstring examples at lines 127 and 173 need to be updated to align with the new type constraint

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/experiment.py | 2/5 | Removes `None` from `Evaluation.value` type hint and docs, but examples still use `value=None`, creating contradictions |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Evaluator
    participant Evaluation
    participant LangfuseAPI
    
    User->>Evaluator: Call evaluator function
    Evaluator->>Evaluator: Process output
    alt Has expected_output
        Evaluator->>Evaluation: Create with value (int/float/str/bool)
        Note right of Evaluation: value cannot be None (after PR)
    else No expected_output
        Evaluator->>Evaluation: Previously: value=None
        Note right of Evaluation: Issue: Examples still use None<br/>but type hint now rejects it
    end
    Evaluation->>LangfuseAPI: Submit score
    LangfuseAPI-->>User: Result recorded
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->