### PR TITLE
fix(openai): handle pydantic BaseModel as metadata

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -400,7 +400,10 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
         and not isinstance(metadata, NotGiven)
         and not isinstance(metadata, dict)
     ):
-        raise TypeError("metadata must be a dictionary")
+        if isinstance(metadata, BaseModel):
+            metadata = metadata.model_dump()
+        else:
+            metadata = {}
 
     model = kwargs.get("model", None) or None
 

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -607,16 +607,6 @@ def test_fails_wrong_name(openai):
         )
 
 
-def test_fails_wrong_metadata(openai):
-    with pytest.raises(TypeError, match="metadata must be a dictionary"):
-        openai.OpenAI().completions.create(
-            metadata="metadata",
-            model="gpt-3.5-turbo-instruct",
-            prompt="1 + 1 = ",
-            temperature=0,
-        )
-
-
 def test_fails_wrong_trace_id(openai):
     with pytest.raises(TypeError, match="trace_id must be a string"):
         openai.OpenAI().completions.create(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle `pydantic.BaseModel` as `metadata` in `langfuse/openai.py` by converting it to a dictionary, and update tests accordingly.
> 
>   - **Behavior**:
>     - In `_get_langfuse_data_from_kwargs()` in `langfuse/openai.py`, handle `metadata` as `pydantic.BaseModel` by converting it to a dictionary using `model_dump()`. If not a `BaseModel` or `dict`, set `metadata` to an empty dictionary.
>   - **Tests**:
>     - Remove `test_fails_wrong_metadata()` from `tests/test_openai.py` as `metadata` no longer raises `TypeError` for non-dict inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for fdc8a2b4fb1ca5d11e460f3408d9ec79585506d8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added support for Pydantic `BaseModel` as metadata by converting it to dict using `model_dump()`. However, the implementation has a critical flaw: invalid metadata types (strings, numbers, etc.) are now silently converted to empty dict `{}` instead of raising a `TypeError`.

**Key Issues:**
- The `else` branch in the metadata validation (line 406) catches all non-dict, non-BaseModel types and silently converts them to `{}`
- This breaks existing error handling behavior - the original code correctly raised `TypeError` for invalid metadata
- The removed test `test_fails_wrong_metadata` verified this error behavior, but no test was added to verify `BaseModel` handling works correctly

<h3>Confidence Score: 1/5</h3>


- This PR is not safe to merge due to a critical logic error in metadata validation
- Score reflects a logic bug that silently converts invalid metadata to empty dict instead of raising errors, breaking existing validation behavior and removing important error feedback for users
- `langfuse/openai.py` requires immediate attention to fix the metadata validation logic

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/openai.py | 1/5 | added `BaseModel` handling for metadata, but `else` branch silently converts invalid types to empty dict instead of raising error |
| tests/test_openai.py | 3/5 | removed test for invalid metadata, but no test added to verify `BaseModel` metadata handling works |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant OpenAI Client
    participant _get_langfuse_data_from_kwargs
    participant Langfuse

    User->>OpenAI Client: create(metadata=BaseModel())
    OpenAI Client->>_get_langfuse_data_from_kwargs: kwargs with metadata
    _get_langfuse_data_from_kwargs->>_get_langfuse_data_from_kwargs: Check if metadata is dict
    alt metadata is BaseModel
        _get_langfuse_data_from_kwargs->>_get_langfuse_data_from_kwargs: metadata.model_dump()
    else metadata is invalid type
        _get_langfuse_data_from_kwargs->>_get_langfuse_data_from_kwargs: metadata = {} (silent conversion)
    end
    _get_langfuse_data_from_kwargs->>Langfuse: return langfuse_data with metadata
    Langfuse-->>User: tracked generation
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->