### PR TITLE
feat(client): allow fallback prompt to be supplied by a callable

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -3411,7 +3411,10 @@ class Langfuse:
         label: Optional[str] = None,
         type: Literal["chat"],
         cache_ttl_seconds: Optional[int] = None,
-        fallback: Optional[List[ChatMessageDict]] = None,
+        fallback: Union[
+            Optional[List[ChatMessageDict]],
+            Optional[Callable[[], List[ChatMessageDict]]],
+        ] = None,
         max_retries: Optional[int] = None,
         fetch_timeout_seconds: Optional[int] = None,
     ) -> ChatPromptClient: ...
@@ -3425,7 +3428,7 @@ class Langfuse:
         label: Optional[str] = None,
         type: Literal["text"] = "text",
         cache_ttl_seconds: Optional[int] = None,
-        fallback: Optional[str] = None,
+        fallback: Union[Optional[str], Optional[Callable[[], str]]] = None,
         max_retries: Optional[int] = None,
         fetch_timeout_seconds: Optional[int] = None,
     ) -> TextPromptClient: ...
@@ -3438,7 +3441,12 @@ class Langfuse:
         label: Optional[str] = None,
         type: Literal["chat", "text"] = "text",
         cache_ttl_seconds: Optional[int] = None,
-        fallback: Union[Optional[List[ChatMessageDict]], Optional[str]] = None,
+        fallback: Union[
+            Optional[List[ChatMessageDict]],
+            Optional[str],
+            Optional[Callable[[], str]],
+            Optional[Callable[[], List[ChatMessageDict]]],
+        ] = None,
         max_retries: Optional[int] = None,
         fetch_timeout_seconds: Optional[int] = None,
     ) -> PromptClient:
@@ -3458,7 +3466,7 @@ class Langfuse:
             cache_ttl_seconds: Optional[int]: Time-to-live in seconds for caching the prompt. Must be specified as a
             keyword argument. If not set, defaults to 60 seconds. Disables caching if set to 0.
             type: Literal["chat", "text"]: The type of the prompt to retrieve. Defaults to "text".
-            fallback: Union[Optional[List[ChatMessageDict]], Optional[str]]: The prompt string to return if fetching the prompt fails. Important on the first call where no cached prompt is available. Follows Langfuse prompt formatting with double curly braces for variables. Defaults to None.
+            fallback: Union[Optional[List[ChatMessageDict]], Optional[str], Optional[Callable[[], str]], Optional[Callable[[], List[ChatMessageDict]]]]: The prompt string to return if fetching the prompt fails. Important on the first call where no cached prompt is available. Follows Langfuse prompt formatting with double curly braces for variables. Defaults to None.
             max_retries: Optional[int]: The maximum number of retries in case of API/network errors. Defaults to 2. The maximum value is 4. Retries have an exponential backoff with a maximum delay of 10 seconds.
             fetch_timeout_seconds: Optional[int]: The timeout in milliseconds for fetching the prompt. Defaults to the default timeout set on the SDK, which is 5 seconds per default.
 
@@ -3510,7 +3518,7 @@ class Langfuse:
 
                     fallback_client_args: Dict[str, Any] = {
                         "name": name,
-                        "prompt": fallback,
+                        "prompt": fallback() if callable(fallback) else fallback,
                         "type": type,
                         "version": version or 0,
                         "config": {},

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1303,6 +1303,25 @@ def test_fallback_text_prompt():
     )
 
 
+def test_fallback_text_prompt_via_callable():
+    langfuse = Langfuse()
+    fallback_text_prompt = "this is a fallback text prompt with {{variable}}"
+
+    def fallback_provider():
+        return fallback_text_prompt
+
+    # Should throw an error if prompt not found and no fallback provided
+    with pytest.raises(Exception):
+        langfuse.get_prompt("nonexistent_prompt")
+
+    prompt = langfuse.get_prompt("nonexistent_prompt", fallback=fallback_provider)
+
+    assert prompt.prompt == fallback_text_prompt
+    assert (
+        prompt.compile(variable="value") == "this is a fallback text prompt with value"
+    )
+
+
 def test_fallback_chat_prompt():
     langfuse = Langfuse()
     fallback_chat_prompt = [


### PR DESCRIPTION
This PR adds the ability to pass a callable to the `fallback` argument of the `get_prompt` function.
It makes it easier to e.g. fetch a fallback prompt from an external location, such as a database or a file.

E.g. since the recent Cloudflare outage we store fallback prompts as JSON files in our deployed artifacts.
Right now we have the choice of either _always_ loading them to pass them as the `fallback` argument, or introduce our own try-catch logic and only load them once an error occurs. A better/more ergonomic solution would be to pass a function that will load the fallback prompt in case of a failure, which is exactly what this PR enables.

## Examples

Before this MR:

```python
from utils import get_fallback_prompt_from_db

# Unnecessarily issues a DB query on every call
prompt = client.get_prompt("my_prompt", fallback=get_fallback_prompt_from_db("my_prompt"))

# Alternative: awkward try-catch and trying twice
prompt = None
try:
    prompt = client.get_prompt("my_prompt")
except Exception:
    prompt = client.get_prompt("my_prompt", fallback=get_fallback_prompt_from_db("my_prompt"))
```

After this MR:

```python
from utils import get_fallback_prompt_from_db

# Only called when necessary, no awkward try-catch
prompt = client.get_prompt("my_prompt", fallback=lambda: get_fallback_prompt_from_db("my_prompt"))
```

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR extends the `get_prompt` fallback functionality to accept callable functions that return prompt values, allowing lazy evaluation of fallback prompts. The implementation cleanly adds callable support by updating type hints and adding a runtime check using `callable()` before invoking the fallback.

Key changes:
- Updated type signatures for all three `get_prompt` overloads to accept `Callable[[], str]` or `Callable[[], List[ChatMessageDict]]`
- Added runtime check `fallback() if callable(fallback) else fallback` in langfuse/_client/client.py:3517
- Added test coverage for callable text prompt fallback

The change is well-implemented with minimal risk. Test coverage could be enhanced with a callable chat prompt fallback test.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is straightforward and well-typed. It adds a simple runtime check using Python's built-in `callable()` function to support lazy evaluation of fallback prompts. The change is backward compatible (static fallbacks still work), properly typed with Union types across all overloads, and includes test coverage for the new functionality. No security concerns or edge cases that would cause runtime errors.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/client.py | 5/5 | Updated type hints to allow callable fallback arguments and added callable check in fallback prompt construction. Implementation is clean and safe. |
| tests/test_prompt.py | 4/5 | Added test for callable text prompt fallback. Test coverage is good but missing test for callable chat prompt fallback. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse
    participant PromptCache
    participant FallbackCallable
    participant PromptClient

    User->>Langfuse: get_prompt(name, fallback=callable_fn)
    Langfuse->>PromptCache: get(cache_key)
    PromptCache-->>Langfuse: None (not cached)
    
    Langfuse->>Langfuse: _fetch_prompt_and_update_cache()
    Note over Langfuse: Fetch fails (Exception)
    
    Langfuse->>Langfuse: Check if fallback exists
    Langfuse->>Langfuse: callable(fallback)?
    
    alt Fallback is callable
        Langfuse->>FallbackCallable: fallback()
        FallbackCallable-->>Langfuse: prompt value
    else Fallback is static
        Note over Langfuse: Use fallback directly
    end
    
    Langfuse->>PromptClient: Create client with fallback prompt
    PromptClient-->>User: Return prompt client (is_fallback=True)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->