### PR TITLE
fix(resource-manager): reuse passed tracer provider for reinit

### DIFF
--- a/langfuse/_client/get_client.py
+++ b/langfuse/_client/get_client.py
@@ -52,6 +52,7 @@ def _create_client_from_instance(
         mask=instance.mask,
         blocked_instrumentation_scopes=instance.blocked_instrumentation_scopes,
         additional_headers=instance.additional_headers,
+        tracer_provider=instance.tracer_provider,
     )
 
 

--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -179,6 +179,7 @@ class LangfuseResourceManager:
             tracer_provider = tracer_provider or _init_tracer_provider(
                 environment=environment, release=release, sample_rate=sample_rate
             )
+            self.tracer_provider = tracer_provider
 
             langfuse_processor = LangfuseSpanProcessor(
                 public_key=self.public_key,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reuse `tracer_provider` during reinitialization in `LangfuseResourceManager` to maintain consistent tracing behavior.
> 
>   - **Behavior**:
>     - Reuse `tracer_provider` in `_create_client_from_instance()` in `get_client.py` by passing `instance.tracer_provider`.
>     - Set `self.tracer_provider` in `_initialize_instance()` in `resource_manager.py` to reuse existing `tracer_provider`.
>   - **Functions**:
>     - Modify `_create_client_from_instance()` to include `tracer_provider` parameter.
>     - Update `_initialize_instance()` to set `self.tracer_provider` with passed or initialized `tracer_provider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 57b2c3dd541525ab4f4e1fb42869599e92a953d1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Preserves custom `tracer_provider` when reinitializing Langfuse clients through `get_client()`.

- **Fixed bug**: The resource manager now stores the passed `tracer_provider` as an instance attribute (resource_manager.py:182)
- **Fixed propagation**: `_create_client_from_instance` now passes the stored `tracer_provider` when creating new client instances (get_client.py:55)
- **Impact**: Ensures custom OpenTelemetry tracer providers are reused across client reinitialization, maintaining consistent tracing configuration

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and directly address a bug where custom tracer providers weren't being preserved during client reinitialization. Both changes are simple attribute assignments that maintain existing behavior while fixing the missing propagation. No breaking changes or side effects expected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/resource_manager.py | 5/5 | Stores passed `tracer_provider` as instance attribute for later reuse during client reinitialization |
| langfuse/_client/get_client.py | 5/5 | Passes `tracer_provider` from resource manager when creating new client instances to preserve custom tracer configuration |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse
    participant ResourceManager
    participant get_client
    participant _create_client_from_instance
    
    User->>Langfuse: new Langfuse(tracer_provider=custom_provider)
    Langfuse->>ResourceManager: __new__(tracer_provider=custom_provider)
    ResourceManager->>ResourceManager: _initialize_instance()
    Note over ResourceManager: tracer_provider stored or initialized
    ResourceManager->>ResourceManager: self.tracer_provider = tracer_provider
    ResourceManager-->>Langfuse: singleton instance
    
    User->>get_client: get_client()
    get_client->>get_client: Look up instance in _instances
    get_client->>_create_client_from_instance: _create_client_from_instance(instance)
    _create_client_from_instance->>Langfuse: new Langfuse(tracer_provider=instance.tracer_provider)
    Note over _create_client_from_instance,Langfuse: Passes tracer_provider to preserve custom config
    Langfuse->>ResourceManager: __new__(tracer_provider=instance.tracer_provider)
    Note over ResourceManager: Reuses existing singleton with same tracer_provider
    ResourceManager-->>Langfuse: existing instance
    Langfuse-->>get_client: client with preserved tracer_provider
    get_client-->>User: client instance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->