### PR TITLE
feat(client): Add optional timestamp parameter to score creation

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1972,6 +1972,7 @@ class Langfuse:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         metadata: Optional[Any] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None: ...
 
     @overload
@@ -1989,6 +1990,7 @@ class Langfuse:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         metadata: Optional[Any] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None: ...
 
     def create_score(
@@ -2005,6 +2007,7 @@ class Langfuse:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         metadata: Optional[Any] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None:
         """Create a score for a specific trace or observation.
 
@@ -2023,6 +2026,7 @@ class Langfuse:
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
             metadata: Optional metadata to be attached to the score
+            timestamp: Optional timestamp for the score (defaults to current UTC time)
 
         Example:
             ```python
@@ -2069,7 +2073,7 @@ class Langfuse:
             event = {
                 "id": self.create_trace_id(),
                 "type": "score-create",
-                "timestamp": _get_timestamp(),
+                "timestamp": timestamp or _get_timestamp(),
                 "body": new_body,
             }
 

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -276,6 +276,7 @@ class LangfuseObservationWrapper:
         data_type: Optional[Literal["NUMERIC", "BOOLEAN"]] = None,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None: ...
 
     @overload
@@ -288,6 +289,7 @@ class LangfuseObservationWrapper:
         data_type: Optional[Literal["CATEGORICAL"]] = "CATEGORICAL",
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None: ...
 
     def score(
@@ -299,6 +301,7 @@ class LangfuseObservationWrapper:
         data_type: Optional[ScoreDataType] = None,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None:
         """Create a score for this specific span.
 
@@ -312,6 +315,7 @@ class LangfuseObservationWrapper:
             data_type: Type of score (NUMERIC, BOOLEAN, or CATEGORICAL)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
+            timestamp: Optional timestamp for the score (defaults to current UTC time)
 
         Example:
             ```python
@@ -337,6 +341,7 @@ class LangfuseObservationWrapper:
             data_type=cast(Literal["CATEGORICAL"], data_type),
             comment=comment,
             config_id=config_id,
+            timestamp=timestamp,
         )
 
     @overload
@@ -349,6 +354,7 @@ class LangfuseObservationWrapper:
         data_type: Optional[Literal["NUMERIC", "BOOLEAN"]] = None,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None: ...
 
     @overload
@@ -361,6 +367,7 @@ class LangfuseObservationWrapper:
         data_type: Optional[Literal["CATEGORICAL"]] = "CATEGORICAL",
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None: ...
 
     def score_trace(
@@ -372,6 +379,7 @@ class LangfuseObservationWrapper:
         data_type: Optional[ScoreDataType] = None,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None:
         """Create a score for the entire trace that this span belongs to.
 
@@ -386,6 +394,7 @@ class LangfuseObservationWrapper:
             data_type: Type of score (NUMERIC, BOOLEAN, or CATEGORICAL)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
+            timestamp: Optional timestamp for the score (defaults to current UTC time)
 
         Example:
             ```python
@@ -410,6 +419,7 @@ class LangfuseObservationWrapper:
             data_type=cast(Literal["CATEGORICAL"], data_type),
             comment=comment,
             config_id=config_id,
+            timestamp=timestamp,
         )
 
     def _set_processed_span_attributes(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add optional `timestamp` parameter to score creation functions in `client.py` and `span.py`, allowing custom timestamps for scores.
> 
>   - **Behavior**:
>     - Add `timestamp` parameter to `create_score()` in `client.py` and `score()` in `span.py` to allow custom timestamps for scores.
>     - Defaults to current UTC time if `timestamp` is not provided.
>   - **Tests**:
>     - Add `test_create_score_with_custom_timestamp()` in `test_core_sdk.py` to verify scores with custom timestamps are created correctly.
>     - Ensure timestamps are within 1 second of the expected custom timestamp.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for b29756ccceaaa24fc3381b7bd016da786727dc0f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added optional `timestamp` parameter to score creation methods across the SDK, allowing users to specify custom timestamps for scores instead of always using the current UTC time. The change is implemented consistently across `create_score`, `score`, and `score_trace` methods.

- Added `timestamp: Optional[datetime] = None` parameter to all score creation method signatures and overloads
- Updated implementation to use `timestamp or _get_timestamp()` pattern for fallback behavior
- Added comprehensive test coverage verifying custom timestamps are properly persisted
- All imports remain at module level, complying with custom instructions

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified risks
- The implementation is clean, consistent, and well-tested. The change follows existing patterns (using the `or` operator for optional parameter defaults), maintains backward compatibility (timestamp is optional with proper default), and includes comprehensive test coverage. No breaking changes, no security issues, and no logical errors detected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/client.py | 5/5 | Added optional `timestamp` parameter to `create_score` method and all its overloads, allowing custom timestamps for score creation |
| langfuse/_client/span.py | 5/5 | Added optional `timestamp` parameter to `score` and `score_trace` methods and their overloads, properly forwarding it to the underlying `create_score` call |
| tests/test_core_sdk.py | 5/5 | Added comprehensive test for custom timestamp functionality, verifying that scores are created with the specified timestamp value |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse
    participant Span
    participant ScoreBody
    participant ResourceManager

    User->>Langfuse: create_score(name, value, timestamp=custom_time)
    Langfuse->>Langfuse: timestamp or _get_timestamp()
    Langfuse->>ScoreBody: Create score body
    Langfuse->>ResourceManager: add_score_task(event)
    ResourceManager-->>User: Score created

    Note over User,Span: Alternative: Score via Span

    User->>Span: score(name, value, timestamp=custom_time)
    Span->>Langfuse: create_score(..., timestamp=timestamp)
    Langfuse->>Langfuse: timestamp or _get_timestamp()
    Langfuse->>ScoreBody: Create score body
    Langfuse->>ResourceManager: add_score_task(event)
    ResourceManager-->>User: Score created
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->