### PR TITLE
fix(resource_manager): define tracer_provider if tracing_enabled=False

### DIFF
--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -173,6 +173,7 @@ class LangfuseResourceManager:
         self.sample_rate = sample_rate
         self.blocked_instrumentation_scopes = blocked_instrumentation_scopes
         self.additional_headers = additional_headers
+        self.tracer_provider = None
 
         # OTEL Tracer
         if tracing_enabled:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Define `tracer_provider` as `None` in `resource_manager.py` when `tracing_enabled=False` to prevent attribute errors.
> 
>   - **Behavior**:
>     - Define `self.tracer_provider` as `None` in `_initialize_instance()` in `resource_manager.py` when `tracing_enabled=False` to prevent attribute errors.
>   - **Misc**:
>     - No changes to existing logic or functionality beyond defining `tracer_provider` when tracing is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 502d112cd9915126443fcd1f8340f1dd7657127f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes an `AttributeError` that occurred when `tracing_enabled=False` by explicitly initializing `self.tracer_provider = None` before the conditional block. 

**Key Changes:**
- Added `self.tracer_provider = None` at line 176 in `_initialize_instance()` method
- Previously, when `tracing_enabled=False`, the `tracer_provider` attribute was never defined since it was only set inside the `if tracing_enabled:` block
- This caused an `AttributeError` when `get_client()` tried to access `instance.tracer_provider` (line 55 in `get_client.py`)

**Impact:**
- Ensures the attribute always exists regardless of the tracing configuration
- Allows safe access to `tracer_provider` attribute in multi-client scenarios where clients with different tracing settings may coexist
- No functional changes to the tracing behavior itself

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a minimal defensive fix that prevents AttributeError
- The change is a one-line defensive fix that explicitly initializes an attribute to None, preventing AttributeError when accessing it later. The fix follows Python best practices by ensuring all instance attributes are defined in __init__ regardless of conditional logic. No logical changes to existing behavior, only prevents potential runtime errors.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/resource_manager.py | 5/5 | Initializes `tracer_provider` to `None` before conditional assignment, preventing AttributeError when `tracing_enabled=False` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Langfuse Client
    participant RM as LangfuseResourceManager
    participant GC as get_client()
    
    Note over Client,RM: Initialization Flow
    Client->>RM: __new__(tracing_enabled=False)
    RM->>RM: _initialize_instance()
    RM->>RM: Set self.tracer_provider = None
    Note over RM: BEFORE FIX: AttributeError if<br/>tracing_enabled=False and<br/>tracer_provider accessed later
    Note over RM: AFTER FIX: Always defined,<br/>set to None initially
    alt tracing_enabled=True
        RM->>RM: Initialize tracer_provider
        RM->>RM: Set self.tracer_provider = tracer_provider
    else tracing_enabled=False
        Note over RM: tracer_provider remains None
    end
    
    Note over GC: Later Access
    GC->>RM: Access instance.tracer_provider
    RM-->>GC: Returns None (no AttributeError)
    GC->>Client: Create new client with tracer_provider=None
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->