### PR TITLE
fix(openai): handle parsed_n non integer

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -492,7 +492,7 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
             modelParameters.pop("max_tokens", None)
             modelParameters["max_completion_tokens"] = parsed_max_completion_tokens
 
-        if parsed_n is not None and parsed_n > 1:
+        if parsed_n is not None and isinstance(parsed_n, int) and parsed_n > 1:
             modelParameters["n"] = parsed_n
 
         if parsed_seed is not None:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes condition in `_get_langfuse_data_from_kwargs` to ensure `parsed_n` is an integer before comparison, preventing errors with non-integer values.
> 
>   - **Behavior**:
>     - Fixes condition in `_get_langfuse_data_from_kwargs` in `langfuse/openai.py` to check if `parsed_n` is an integer before comparing it to 1.
>     - Prevents errors when `parsed_n` is not an integer.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for b8de64b7c1b6f94403514818c6ad0cf436987781. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added type validation for the `n` parameter to prevent `TypeError` when comparing non-integer values.

- Added `isinstance(parsed_n, int)` check before comparing `parsed_n > 1` to handle edge cases where the OpenAI SDK passes non-integer values
- Prevents potential runtime errors when comparing non-numeric types with integers
- Follows defensive programming pattern by validating types before operations

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple defensive type check that prevents potential runtime errors. The logic is sound and follows best practices for type validation before comparison operations. The change is minimal, focused, and doesn't alter the core functionality.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/openai.py | 4/5 | Added type check to prevent comparison errors when `n` parameter is non-integer; defensive programming improvement |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant _get_langfuse_data_from_kwargs
    participant modelParameters
    
    Client->>_get_langfuse_data_from_kwargs: Call with kwargs containing 'n' parameter
    _get_langfuse_data_from_kwargs->>_get_langfuse_data_from_kwargs: Extract parsed_n from kwargs.get("n", 1)
    
    alt parsed_n is not None
        _get_langfuse_data_from_kwargs->>_get_langfuse_data_from_kwargs: Check isinstance(parsed_n, int)
        
        alt parsed_n is integer AND parsed_n > 1
            _get_langfuse_data_from_kwargs->>modelParameters: Add n parameter to modelParameters
        else parsed_n is not integer OR parsed_n <= 1
            _get_langfuse_data_from_kwargs->>_get_langfuse_data_from_kwargs: Skip adding n to modelParameters
        end
    end
    
    _get_langfuse_data_from_kwargs->>Client: Return langfuse data with modelParameters
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->