### PR TITLE
fix: Assume naive datetime as UTC in serialize_datetime

### DIFF
--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -1,0 +1,132 @@
+"""Test suite for datetime_utils module - UTC timestamp serialization."""
+
+import datetime as dt
+from datetime import timezone
+
+import pytest
+
+from langfuse.api.core.datetime_utils import serialize_datetime
+
+
+class TestSerializeDatetime:
+    """Test suite for the serialize_datetime function."""
+
+    def test_utc_datetime_ends_with_z(self):
+        """Test that UTC datetime is serialized with 'Z' suffix."""
+        utc_dt = dt.datetime(2025, 12, 10, 13, 30, 45, 123456, tzinfo=timezone.utc)
+        result = serialize_datetime(utc_dt)
+        
+        assert result.endswith("Z")
+        assert "+00:00" not in result
+        assert result == "2025-12-10T13:30:45.123456Z"
+
+    def test_utc_datetime_without_microseconds(self):
+        """Test UTC datetime without microseconds."""
+        utc_dt = dt.datetime(2025, 12, 10, 13, 30, 45, tzinfo=timezone.utc)
+        result = serialize_datetime(utc_dt)
+        
+        assert result.endswith("Z")
+        assert result == "2025-12-10T13:30:45Z"
+
+    def test_naive_datetime_assumed_utc(self):
+        """Test that naive datetime (no tzinfo) is assumed to be UTC.
+        
+        This is the key fix: naive datetime should be treated as UTC,
+        not local time, to prevent duplicate trace records in ClickHouse
+        when the SDK runs in non-UTC timezones.
+        """
+        naive_dt = dt.datetime(2025, 12, 10, 13, 30, 45, 123456)
+        result = serialize_datetime(naive_dt)
+        
+        # Should end with 'Z' (UTC), not a local timezone offset like +08:00
+        assert result.endswith("Z"), f"Expected UTC suffix 'Z', got: {result}"
+        assert result == "2025-12-10T13:30:45.123456Z"
+
+    def test_naive_datetime_without_microseconds(self):
+        """Test naive datetime without microseconds is assumed UTC."""
+        naive_dt = dt.datetime(2025, 12, 10, 13, 30, 45)
+        result = serialize_datetime(naive_dt)
+        
+        assert result.endswith("Z")
+        assert result == "2025-12-10T13:30:45Z"
+
+    def test_non_utc_timezone_uses_offset(self):
+        """Test that non-UTC timezones use offset format."""
+        # Create datetime with +08:00 timezone
+        tz_plus_8 = timezone(dt.timedelta(hours=8))
+        dt_plus_8 = dt.datetime(2025, 12, 10, 21, 30, 45, tzinfo=tz_plus_8)
+        result = serialize_datetime(dt_plus_8)
+        
+        # Should use offset format, not 'Z'
+        assert result.endswith("+08:00")
+        assert result == "2025-12-10T21:30:45+08:00"
+
+    def test_negative_timezone_offset(self):
+        """Test negative timezone offset format."""
+        tz_minus_5 = timezone(dt.timedelta(hours=-5))
+        dt_minus_5 = dt.datetime(2025, 12, 10, 8, 30, 45, tzinfo=tz_minus_5)
+        result = serialize_datetime(dt_minus_5)
+        
+        assert result.endswith("-05:00")
+        assert result == "2025-12-10T08:30:45-05:00"
+
+    def test_consistency_with_internal_timestamp_function(self):
+        """Test that serialize_datetime is consistent with _get_timestamp.
+        
+        The _get_timestamp function returns datetime.now(timezone.utc),
+        which should serialize correctly with 'Z' suffix.
+        """
+        from langfuse._utils import _get_timestamp
+        
+        timestamp = _get_timestamp()
+        result = serialize_datetime(timestamp)
+        
+        # Should always end with 'Z' since _get_timestamp uses UTC
+        assert result.endswith("Z"), f"Expected UTC suffix 'Z', got: {result}"
+
+    def test_multiple_naive_datetimes_serialize_consistently(self):
+        """Test that multiple naive datetimes serialize consistently.
+        
+        This prevents the issue where different events in the same trace
+        could get different timezone treatments.
+        """
+        dt1 = dt.datetime(2025, 12, 10, 13, 30, 45)
+        dt2 = dt.datetime(2025, 12, 10, 13, 30, 46)
+        dt3 = dt.datetime(2025, 12, 10, 13, 30, 47)
+        
+        results = [serialize_datetime(d) for d in [dt1, dt2, dt3]]
+        
+        # All should have 'Z' suffix (UTC)
+        for result in results:
+            assert result.endswith("Z"), f"Expected UTC suffix 'Z', got: {result}"
+        
+        # All should have the same date (no timezone shift causing date change)
+        for result in results:
+            assert result.startswith("2025-12-10")
+
+    def test_edge_case_midnight_utc(self):
+        """Test midnight UTC serialization."""
+        midnight = dt.datetime(2025, 12, 10, 0, 0, 0, tzinfo=timezone.utc)
+        result = serialize_datetime(midnight)
+        
+        assert result == "2025-12-10T00:00:00Z"
+
+    def test_edge_case_end_of_day_utc(self):
+        """Test end of day UTC serialization."""
+        end_of_day = dt.datetime(2025, 12, 10, 23, 59, 59, 999999, tzinfo=timezone.utc)
+        result = serialize_datetime(end_of_day)
+        
+        assert result == "2025-12-10T23:59:59.999999Z"
+
+    def test_iso8601_format_compliance(self):
+        """Test that output complies with ISO 8601 format."""
+        naive_dt = dt.datetime(2025, 12, 10, 13, 30, 45, 123456)
+        result = serialize_datetime(naive_dt)
+        
+        # ISO 8601 format: YYYY-MM-DDTHH:MM:SS.ffffff[Z|+HH:MM|-HH:MM]
+        assert "T" in result
+        assert result.count(":") >= 2
+        # Should be parseable
+        parsed = dt.datetime.fromisoformat(result.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None
+


### PR DESCRIPTION
```markdown
## Summary

Fix timestamp inconsistency that causes duplicate trace records in ClickHouse when the SDK runs in non-UTC timezones.

Closes https://github.com/langfuse/langfuse/issues/11026

## Problem

When a datetime object without timezone info (naive datetime) is passed to `serialize_datetime()`, 
it was previously interpreted using the **local timezone**. In UTC+8 environments, this caused:

1. **Duplicate trace records** - Same trace ID gets different `toDate(timestamp)` values
2. **ReplacingMergeTree merge failures** - ClickHouse can't merge records with different dates
3. **Inconsistent trace rendering** - Traces appear fragmented in the UI

### Example

```
id: 2e0e8e5f811849f5106dc38a584cce27
Row 1: timestamp=2025-12-10 (UTC),   name=NULL
Row 2: timestamp=2025-12-11 (local), name=LangGraph  ← Different date!
```

## Root Cause

In `langfuse/api/core/datetime_utils.py`:

```python
# Before (problematic)
local_tz = dt.datetime.now().astimezone().tzinfo
localized_dt = v.replace(tzinfo=local_tz)
```

## Solution

Assume naive datetime is UTC, consistent with:
- Langfuse infrastructure requirements (all timestamps should be UTC)
- Internal `_get_timestamp()` which already uses `datetime.now(timezone.utc)`

```python
# After (fixed)
utc_dt = v.replace(tzinfo=dt.timezone.utc)
```

## Testing

Added 11 test cases in `tests/test_datetime_utils.py`:
- ✅ UTC datetime serialization (ends with 'Z')
- ✅ Non-UTC timezone handling (uses offset format)  
- ✅ Naive datetime assumed as UTC
- ✅ Consistency with `_get_timestamp()`
- ✅ Edge cases (midnight, end of day)
- ✅ ISO 8601 compliance

All tests pass.

## Checklist

- [x] Code follows project conventions
- [x] Tests added for the fix
- [x] All tests pass locally
- [x] Linked to issue #11026
```

---

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `serialize_datetime()` to assume naive datetimes as UTC, preventing duplicate trace records in ClickHouse.
> 
>   - **Behavior**:
>     - `serialize_datetime()` in `datetime_utils.py` now assumes naive datetimes are UTC, preventing duplicate trace records in ClickHouse.
>     - Aligns with Langfuse infrastructure requirements for UTC timestamps.
>   - **Testing**:
>     - Adds 11 test cases in `test_datetime_utils.py` to verify correct serialization of UTC, naive, and non-UTC datetimes.
>     - Tests include edge cases like midnight, end of day, and ISO 8601 compliance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 02587ef3a9ed726d4960df1698c387240761bc56. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed timestamp inconsistency causing duplicate trace records in ClickHouse when the SDK runs in non-UTC timezones by changing `serialize_datetime()` to assume naive datetimes are UTC instead of local time.

- Changed naive datetime handling in `langfuse/api/core/datetime_utils.py` from local timezone to UTC assumption
- This aligns with Langfuse infrastructure requirements where all timestamps should be UTC
- Consistent with internal `_get_timestamp()` which uses `datetime.now(timezone.utc)`
- Added 11 comprehensive test cases covering UTC, non-UTC timezones, naive datetime handling, and edge cases
- **Note:** This is a behavioral change - naive datetimes will now serialize differently in non-UTC environments

<h3>Confidence Score: 4/5</h3>


- Safe to merge - targeted bug fix with comprehensive test coverage.
- The change is well-documented, addresses a real issue (duplicate trace records), and includes thorough test coverage. Minor deduction for the in-method import style issue in tests.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/api/core/datetime_utils.py | 5/5 | Changed naive datetime handling from local timezone to UTC assumption, fixing duplicate trace records in ClickHouse for non-UTC environments. |
| tests/test_datetime_utils.py | 4/5 | Added 11 comprehensive test cases for datetime serialization; contains one in-method import that should be moved to module top. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SDK as Langfuse SDK
    participant DT as serialize_datetime()
    participant CH as ClickHouse

    Note over SDK,CH: Before Fix (Non-UTC timezone)
    SDK->>DT: naive datetime (e.g., 2025-12-10 21:00)
    DT->>DT: Apply local timezone (+08:00)
    DT->>CH: 2025-12-11T05:00:00+08:00
    Note over CH: Stored as 2025-12-11

    Note over SDK,CH: After Fix (Any timezone)
    SDK->>DT: naive datetime (e.g., 2025-12-10 21:00)
    DT->>DT: Assume UTC
    DT->>CH: 2025-12-10T21:00:00Z
    Note over CH: Stored as 2025-12-10 (consistent)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->