### PR TITLE
Add dataset serialization to support distributed eval runs

### DIFF
--- a/langfuse/_client/datasets.py
+++ b/langfuse/_client/datasets.py
@@ -225,7 +225,7 @@ class DatasetClient:
             # Worker function (runs in separate process/container)
             def process_item(item_json: str, run_name: str) -> dict:
                 client = get_client()
-                dataset_item = DatasetItem(**item_dict)
+                dataset_item = DatasetItem(**json.loads(item_json))
                 item_client = DatasetItemClient(dataset_item, client)
 
                 with item_client.run(run_name=run_name) as span:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -418,3 +418,135 @@ def test_observe_dataset_run():
         assert "args" in trace.input
         assert trace.input["args"][0] == expected_input
         assert trace.output == expected_input
+
+
+def test_items_to_dict_basic():
+    """Test that items_to_dict returns a list of dictionaries with correct structure."""
+    langfuse = Langfuse(debug=False)
+    dataset_name = create_uuid()
+    langfuse.create_dataset(name=dataset_name)
+
+    input_data = {"input": "Hello World"}
+    expected_output = {"output": "Expected response"}
+    metadata = {"key": "value"}
+
+    langfuse.create_dataset_item(
+        dataset_name=dataset_name,
+        input=input_data,
+        expected_output=expected_output,
+        metadata=metadata,
+    )
+
+    dataset = langfuse.get_dataset(dataset_name)
+    items_dicts = dataset.items_to_dict()
+
+    assert len(items_dicts) == 1
+    item_dict = items_dicts[0]
+
+    assert "id" in item_dict
+    assert "status" in item_dict
+    assert item_dict["input"] == input_data
+    assert item_dict["expectedOutput"] == expected_output
+    assert item_dict["metadata"] == metadata
+    assert "datasetId" in item_dict
+    assert "datasetName" in item_dict
+    assert item_dict["datasetName"] == dataset_name
+    assert "createdAt" in item_dict
+    assert "updatedAt" in item_dict
+
+
+def test_items_to_dict_multiple_items():
+    """Test that items_to_dict handles multiple items correctly."""
+    langfuse = Langfuse(debug=False)
+    dataset_name = create_uuid()
+    langfuse.create_dataset(name=dataset_name)
+
+    num_items = 5
+    for i in range(num_items):
+        langfuse.create_dataset_item(
+            dataset_name=dataset_name,
+            input={"index": i},
+            expected_output={"result": i * 2},
+        )
+
+    dataset = langfuse.get_dataset(dataset_name)
+    items_dicts = dataset.items_to_dict()
+
+    assert len(items_dicts) == num_items
+
+    # Check all items have unique IDs
+    ids = [item["id"] for item in items_dicts]
+    assert len(set(ids)) == num_items
+
+
+def test_items_to_dict_reconstruct_item():
+    """Test that items can be reconstructed from dict and used with DatasetItemClient."""
+    from langfuse._client.datasets import DatasetItemClient
+    from langfuse.model import DatasetItem
+
+    langfuse = Langfuse(debug=False)
+    dataset_name = create_uuid()
+    langfuse.create_dataset(name=dataset_name)
+
+    input_data = {"input": "Test reconstruction"}
+    expected_output = {"output": "Expected"}
+    metadata = {"meta_key": "meta_value"}
+
+    langfuse.create_dataset_item(
+        dataset_name=dataset_name,
+        input=input_data,
+        expected_output=expected_output,
+        metadata=metadata,
+    )
+
+    dataset = langfuse.get_dataset(dataset_name)
+    items_dicts = dataset.items_to_dict()
+
+    item_dict = items_dicts[0]
+    reconstructed_item = DatasetItem(**item_dict)
+    item_client = DatasetItemClient(reconstructed_item, langfuse)
+
+    assert item_client.input == input_data
+    assert item_client.expected_output == expected_output
+    assert item_client.metadata == metadata
+    assert item_client.dataset_name == dataset_name
+    assert item_client.id == dataset.items[0].id
+
+
+def test_items_to_dict_with_run():
+    """Test that reconstructed items can be used with the run() context manager."""
+    from langfuse._client.datasets import DatasetItemClient
+    from langfuse.model import DatasetItem
+
+    langfuse = Langfuse(debug=False)
+    dataset_name = create_uuid()
+    langfuse.create_dataset(name=dataset_name)
+
+    input_data = {"input": "Test with run"}
+    langfuse.create_dataset_item(dataset_name=dataset_name, input=input_data)
+
+    dataset = langfuse.get_dataset(dataset_name)
+    items_dicts = dataset.items_to_dict()
+
+    run_name = create_uuid()
+    trace_id = None
+
+    # Simulate distributed processing by reconstructing item from dict
+    item_dict = items_dicts[0]
+    reconstructed_item = DatasetItem(**item_dict)
+    item_client = DatasetItemClient(reconstructed_item, langfuse)
+
+    with item_client.run(run_name=run_name) as span:
+        trace_id = span.trace_id
+        span.update_trace(name="reconstructed_item_run", output="test_output")
+
+    langfuse.flush()
+    time.sleep(1)
+
+    # Verify the trace was created
+    assert trace_id is not None
+    trace = langfuse.api.trace.get(trace_id)
+
+    assert trace is not None
+    assert trace.name == "reconstructed_item_run"
+    assert trace.output == "test_output"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -9,6 +9,8 @@ from langchain_openai import OpenAI
 from langfuse import Langfuse, observe
 from langfuse.api.resources.commons.types.dataset_status import DatasetStatus
 from langfuse.api.resources.commons.types.observation import Observation
+from langfuse._client.datasets import DatasetItemClient
+from langfuse.model import DatasetItem
 from langfuse.langchain import CallbackHandler
 from tests.utils import create_uuid, get_api
 
@@ -481,8 +483,6 @@ def test_items_to_dict_multiple_items():
 
 def test_items_to_dict_reconstruct_item():
     """Test that items can be reconstructed from dict and used with DatasetItemClient."""
-    from langfuse._client.datasets import DatasetItemClient
-    from langfuse.model import DatasetItem
 
     langfuse = Langfuse(debug=False)
     dataset_name = create_uuid()
@@ -515,8 +515,6 @@ def test_items_to_dict_reconstruct_item():
 
 def test_items_to_dict_with_run():
     """Test that reconstructed items can be used with the run() context manager."""
-    from langfuse._client.datasets import DatasetItemClient
-    from langfuse.model import DatasetItem
 
     langfuse = Langfuse(debug=False)
     dataset_name = create_uuid()


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `items_to_dict()` in `DatasetClient` for dataset item serialization, with tests for distributed processing support.
> 
>   - **Behavior**:
>     - Add `items_to_dict()` method in `DatasetClient` to serialize dataset items into dictionaries for distributed processing.
>     - Example usage provided for distributed systems like AWS Step Functions and Prefect.
>   - **Tests**:
>     - Add `test_items_to_dict_basic()` in `test_datasets.py` to verify basic serialization structure.
>     - Add `test_items_to_dict_multiple_items()` to check handling of multiple items.
>     - Add `test_items_to_dict_reconstruct_item()` to ensure items can be reconstructed from dicts.
>     - Add `test_items_to_dict_with_run()` to verify reconstructed items work with `run()` context manager.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for de4c08b81cf6502579d2144f56ae492c2bd9362b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds dataset serialization capabilities to the `langfuse-python` client to support distributed evaluation workflows. The main changes include a new `items_to_dict()` method in `DatasetClient` that converts dataset items into serializable dictionaries, and modifications to `DatasetItemClient` to store a reference to the original `DatasetItem` Pydantic model. This enables dataset items to be passed between distributed processing systems like AWS Step Functions, Azure Functions, or Prefect tasks where objects need to be JSON-serialized and reconstructed in separate processes.

The implementation stores the original `DatasetItem` model in a new `dataset_item` attribute on `DatasetItemClient` and provides a straightforward serialization method that calls `.dict()` on each item. The `DatasetClient` constructor also now accepts an optional `langfuse` parameter for more flexible client management in distributed scenarios. This change integrates seamlessly with the existing codebase architecture by leveraging the existing Pydantic models and maintaining backward compatibility.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/datasets.py | 4/5 | Adds `items_to_dict()` method and stores `dataset_item` reference for serialization support |
| tests/test_datasets.py | 5/5 | Comprehensive test coverage for the new serialization functionality with proper validation |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it adds new functionality without breaking existing APIs
- Score reflects well-structured implementation with comprehensive test coverage, but slight concern about imports within test functions rather than at module level
- Pay close attention to the import statements in test functions which violate typical Python import conventions

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DatasetClient
    participant DatasetItem
    participant DistributedWorker
    participant DatasetItemClient
    participant LangfuseSpan
    participant LangfuseAPI

    User->>DatasetClient: "items_to_dict()"
    DatasetClient->>DatasetItem: "dict()"
    DatasetItem-->>DatasetClient: "serialized_dict"
    DatasetClient-->>User: "List[Dict[str, Any]]"
    
    User->>DistributedWorker: "send serialized items"
    DistributedWorker->>DatasetItem: "DatasetItem(**item_dict)"
    DatasetItem-->>DistributedWorker: "reconstructed_item"
    DistributedWorker->>DatasetItemClient: "DatasetItemClient(item, langfuse)"
    DatasetItemClient-->>DistributedWorker: "client_instance"
    
    DistributedWorker->>DatasetItemClient: "run(run_name=name)"
    DatasetItemClient->>LangfuseSpan: "start_as_current_span()"
    LangfuseSpan-->>DatasetItemClient: "span_context"
    DatasetItemClient->>LangfuseAPI: "create dataset_run_item"
    LangfuseAPI-->>DatasetItemClient: "run_item_created"
    DatasetItemClient-->>DistributedWorker: "yield span"
    
    DistributedWorker->>LangfuseSpan: "update_trace()"
    DistributedWorker->>LangfuseSpan: "score_trace()"
    DistributedWorker->>DatasetItemClient: "flush()"
    DatasetItemClient->>LangfuseAPI: "flush traces and scores"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Move imports to the top of the module instead of placing them within functions or methods. ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

<!-- /greptile_comment -->