### PR TITLE
fix(langchain): update docstring for trace_context

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -104,6 +104,19 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
         Args:
             public_key: Optional Langfuse public key. If not provided, will use the default client configuration.
             update_trace: Whether to update the Langfuse trace with the chains input / output / metadata / name. Defaults to False.
+            trace_context: Optional context for connecting to an existing trace (distributed tracing) or
+                setting a custom trace id for the root LangChain run. Pass a `TraceContext` dict, e.g.
+                `{"trace_id": "<trace_id>"}` (and optionally `{"parent_span_id": "<span_id>"}`) to link
+                the trace to an upstream system.
+
+        Example:
+            Use a custom trace id without context managers:
+
+            ```python
+            from langfuse.langchain import CallbackHandler
+
+            handler = CallbackHandler(trace_context={"trace_id": "my-trace-id"})
+            ```
         """
         self.client = get_client(public_key=public_key)
         self.run_inline = True


### PR DESCRIPTION
Update `LangchainCallbackHandler` docstring to document `trace_context` and provide an example for setting a custom trace ID.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd7f8c66-3930-467a-804b-bd52366fc66a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd7f8c66-3930-467a-804b-bd52366fc66a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `LangchainCallbackHandler` docstring to document `trace_context` and provide an example for setting a custom trace ID.
> 
>   - **Documentation**:
>     - Update `LangchainCallbackHandler` docstring to include `trace_context` parameter.
>     - Provide example for setting a custom trace ID in `LangchainCallbackHandler`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for cf63a7918997e6d4d65568cc469ee8d988c484fd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Enhanced documentation for `LangchainCallbackHandler` by adding the missing `trace_context` parameter description and usage example. The docstring now clearly explains how to set custom trace IDs for distributed tracing or linking LangChain runs to upstream systems.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a documentation-only change that adds missing parameter documentation and a usage example. No code logic was modified, only docstrings were enhanced. The documentation accurately reflects the existing functionality.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/langchain/CallbackHandler.py | 5/5 | Added comprehensive documentation for `trace_context` parameter with clear example showing custom trace ID usage |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CallbackHandler
    participant Langfuse Client
    participant Trace

    User->>CallbackHandler: Initialize with trace_context={"trace_id": "custom-id"}
    Note over CallbackHandler: Store trace_context parameter
    
    User->>CallbackHandler: Execute LangChain chain
    CallbackHandler->>Langfuse Client: start_observation(trace_context=trace_context)
    Langfuse Client->>Trace: Create/link to trace with custom ID
    Note over Trace: Trace uses custom trace_id<br/>from trace_context
    Trace-->>Langfuse Client: Trace created/linked
    Langfuse Client-->>CallbackHandler: Observation started
    CallbackHandler-->>User: Chain execution continues
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->