### PR TITLE
feat(client): allow propagating trace name

### DIFF
--- a/langfuse/_client/propagation.py
+++ b/langfuse/_client/propagation.py
@@ -32,6 +32,7 @@ PropagatedKeys = Literal[
     "metadata",
     "version",
     "tags",
+    "trace_name",
 ]
 
 InternalPropagatedKeys = Literal[
@@ -50,6 +51,7 @@ propagated_keys: List[Union[PropagatedKeys, InternalPropagatedKeys]] = [
     "metadata",
     "version",
     "tags",
+    "trace_name",
     "experiment_id",
     "experiment_name",
     "experiment_metadata",
@@ -77,6 +79,7 @@ def propagate_attributes(
     metadata: Optional[Dict[str, str]] = None,
     version: Optional[str] = None,
     tags: Optional[List[str]] = None,
+    trace_name: Optional[str] = None,
     as_baggage: bool = False,
 ) -> _AgnosticContextManager[Any]:
     """Propagate trace-level attributes to all spans created within this context.
@@ -109,6 +112,8 @@ def propagate_attributes(
             - AVOID: large payloads, sensitive data, non-string values (will be dropped with warning)
         version: Version identfier for parts of your application that are independently versioned, e.g. agents
         tags: List of tags to categorize the group of observations
+        trace_name: Name to assign to the trace. Must be US-ASCII string, ≤200 characters.
+            Use this to set a consistent trace name for all spans created within this context.
         as_baggage: If True, propagates attributes using OpenTelemetry baggage for
             cross-process/service propagation. **Security warning**: When enabled,
             attribute values are added to HTTP headers on ALL outbound requests.
@@ -195,6 +200,7 @@ def propagate_attributes(
         metadata=metadata,
         version=version,
         tags=tags,
+        trace_name=trace_name,
         as_baggage=as_baggage,
     )
 
@@ -207,6 +213,7 @@ def _propagate_attributes(
     metadata: Optional[Dict[str, str]] = None,
     version: Optional[str] = None,
     tags: Optional[List[str]] = None,
+    trace_name: Optional[str] = None,
     as_baggage: bool = False,
     experiment: Optional[PropagatedExperimentAttributes] = None,
 ) -> Generator[Any, Any, Any]:
@@ -218,6 +225,7 @@ def _propagate_attributes(
         "session_id": session_id,
         "version": version,
         "tags": tags,
+        "trace_name": trace_name,
     }
 
     propagated_string_attributes = propagated_string_attributes | (
@@ -456,6 +464,7 @@ def _get_propagated_span_key(key: str) -> str:
         "user_id": LangfuseOtelSpanAttributes.TRACE_USER_ID,
         "version": LangfuseOtelSpanAttributes.VERSION,
         "tags": LangfuseOtelSpanAttributes.TRACE_TAGS,
+        "trace_name": LangfuseOtelSpanAttributes.TRACE_NAME,
         "experiment_id": LangfuseOtelSpanAttributes.EXPERIMENT_ID,
         "experiment_name": LangfuseOtelSpanAttributes.EXPERIMENT_NAME,
         "experiment_metadata": LangfuseOtelSpanAttributes.EXPERIMENT_METADATA,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for propagating `trace_name` in `propagate_attributes()` with validation and comprehensive tests.
> 
>   - **Behavior**:
>     - Add `trace_name` to `propagate_attributes()` in `propagation.py` to propagate trace names to all child spans.
>     - `trace_name` must be a US-ASCII string, ≤200 characters. Non-string or overly long values are dropped with a warning.
>     - Supports propagation through OpenTelemetry baggage when `as_baggage=True`.
>   - **Tests**:
>     - Add `TestPropagateAttributesTraceName` in `test_propagate_attributes.py` to verify `trace_name` propagation to child and grandchild spans.
>     - Test `trace_name` with other attributes like `user_id`, `session_id`, `version`, and `metadata`.
>     - Validate behavior for nested contexts, baggage propagation, and invalid `trace_name` values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 439b33d4e4a02b7e1c9ced52730aa60989c70d0c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>


Added `trace_name` parameter to the `propagate_attributes()` context manager, enabling users to set a consistent trace name for all spans created within a context.

**Key Changes:**
- Added `trace_name` to `PropagatedKeys` literal type and `propagated_keys` list
- Added `trace_name` parameter to `propagate_attributes()` and `_propagate_attributes()` functions with proper documentation
- Mapped `trace_name` to `LangfuseOtelSpanAttributes.TRACE_NAME` in `_get_propagated_span_key()`
- Validation automatically enforces: string type, ≤200 characters (matches existing attribute validation)
- Comprehensive test suite (11 tests) covering: propagation to children/grandchildren, combination with other attributes (`user_id`, `session_id`, `version`, `metadata`), validation edge cases, nested contexts, baggage propagation

**Implementation Quality:**
- Follows established patterns exactly (mirroring `user_id`, `session_id`, `version`, `tags`)
- All imports properly placed at module top
- No code duplication or unnecessary complexity
- Maintains backward compatibility (new optional parameter)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects high-quality implementation following established patterns exactly, comprehensive test coverage (11 tests covering all edge cases), proper validation and documentation, no breaking changes, and adherence to all coding standards
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_client/propagation.py | Added `trace_name` parameter to propagation system following existing patterns for `user_id`, `session_id`, `version`, and `tags`. Includes validation, documentation, and proper integration with OpenTelemetry context. |
| tests/test_propagate_attributes.py | Comprehensive test suite for `trace_name` propagation covering all edge cases: child/grandchild propagation, combination with other attributes, validation (200 char limit, non-string), nested contexts, and baggage propagation. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PropagateAttrs as propagate_attributes
    participant Context as OpenTelemetry Context
    participant Validation as _validate_propagated_value
    participant CurrentSpan as Current Span
    participant ChildSpan as Child Spans

    User->>PropagateAttrs: propagate_attributes(trace_name="my-trace")
    PropagateAttrs->>Context: get_current()
    PropagateAttrs->>CurrentSpan: get_current_span()
    
    PropagateAttrs->>Validation: validate trace_name
    alt valid (≤200 chars, string)
        Validation-->>PropagateAttrs: validated value
        PropagateAttrs->>Context: set_value("langfuse.propagated.trace_name")
        PropagateAttrs->>CurrentSpan: set_attribute("langfuse.trace.name")
        PropagateAttrs->>Context: attach(context)
        
        loop for each child span
            User->>ChildSpan: start_span()
            ChildSpan->>Context: get_propagated_attributes()
            Context-->>ChildSpan: trace_name="my-trace"
            ChildSpan->>ChildSpan: set_attribute("langfuse.trace.name")
        end
        
        PropagateAttrs->>Context: detach(token)
    else invalid (>200 chars or non-string)
        Validation-->>PropagateAttrs: None (dropped with warning)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->