### PR TITLE
fix(langchain): allow prompt linking with langchain v1 create_agent

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from contextvars import Token
 from typing import (
     Any,
@@ -133,7 +132,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                 LangfuseRetriever,
             ],
         ] = {}
-        self._child_to_parent_run_id_map: Dict[UUID, Optional[UUID]] = defaultdict(None)
+        self._child_to_parent_run_id_map: Dict[UUID, Optional[UUID]] = {}
         self.context_tokens: Dict[UUID, Token] = {}
         self.prompt_to_parent_run_map: Dict[UUID, Any] = {}
         self.updated_completion_start_time_memo: Set[UUID] = set()
@@ -852,7 +851,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                     break
                 else:
                     current_parent_run_id = self._child_to_parent_run_id_map.get(
-                        current_parent_run_id
+                        current_parent_run_id, None
                     )
 
             content = {
@@ -1013,7 +1012,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
             langfuse_logger.exception(e)
 
     def _reset(self) -> None:
-        self._child_to_parent_run_id_map = defaultdict(None)
+        self._child_to_parent_run_id_map = {}
 
     def __join_tags_and_metadata(
         self,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes prompt linking in LangChain v1 by adding parent-child run ID mapping and modifying prompt search logic in `CallbackHandler.py`, and fixes a `defaultdict` syntax error.
> 
>   - **Behavior**:
>     - Adds `_child_to_parent_run_id_map` in `CallbackHandler.py` to track parent-child run ID relationships.
>     - Modifies `__on_llm_action` in `CallbackHandler.py` to walk up the parent chain for registered prompts.
>     - Adds `_reset()` in `CallbackHandler.py` to clear mappings when top-level runs complete.
>   - **Imports**:
>     - Moves `collections.defaultdict` import to the top of `CallbackHandler.py`.
>   - **Logging**:
>     - Improves debug logging in `CallbackHandler.py` by removing UUID truncation.
>   - **Bug Fix**:
>     - Fixes `defaultdict(None)` syntax error in `CallbackHandler.py` by replacing it with `lambda: None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for e61d204fb8a43dd925a87d741953226426389d31. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>


This PR fixes prompt linking for LangChain v1's `create_agent` function by tracking parent-child relationships between runs and walking up the parent chain to find registered prompts.

**Key Changes:**
- Added `_child_to_parent_run_id_map` to track parent-child run ID relationships
- Modified `__on_llm_action` to walk up the parent chain when searching for registered prompts
- Added `_reset()` method to clear the mapping when top-level runs complete
- Moved `collections.defaultdict` import to top of module per project style
- Improved debug logging by removing UUID truncation

**Critical Issue Found:**
- `defaultdict(None)` on lines 136 and 1016 is incorrect syntax - `None` is not callable and will raise `TypeError` when the defaultdict tries to create default values for missing keys

<h3>Confidence Score: 2/5</h3>


- This PR contains a critical syntax error that will cause runtime failures
- The `defaultdict(None)` syntax error on lines 136 and 1016 will raise TypeError when the defaultdict attempts to create default values. This is currently masked by only using `.get()` which doesn't trigger the default factory, but accessing missing keys directly would fail. The logic for parent-chain traversal appears sound otherwise.
- langfuse/langchain/CallbackHandler.py requires immediate attention to fix defaultdict initialization

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/langchain/CallbackHandler.py | Adds parent-child run ID mapping and tree-walking logic for prompt linking; contains defaultdict(None) bug that should use lambda: None |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as LangChain Agent
    participant CH as CallbackHandler
    participant Map as _child_to_parent_run_id_map
    participant PromptMap as prompt_to_parent_run_map
    
    Note over Agent,PromptMap: Agent starts with prompt
    Agent->>CH: on_chain_start(run_id=A, parent_run_id=None)
    CH->>Map: Store A -> None
    CH->>PromptMap: Register prompt for A
    
    Note over Agent,PromptMap: Agent creates intermediate chain
    Agent->>CH: on_chain_start(run_id=B, parent_run_id=A)
    CH->>Map: Store B -> A
    CH->>PromptMap: Propagate prompt from A to B
    
    Note over Agent,PromptMap: LLM invocation happens
    Agent->>CH: __on_llm_action(run_id=C, parent_run_id=B)
    CH->>Map: Store C -> B
    
    Note over CH,PromptMap: Walk up parent chain
    CH->>PromptMap: Check B for prompt
    alt Prompt not found at B
        CH->>Map: Get parent of B (returns A)
        CH->>PromptMap: Check A for prompt
        PromptMap-->>CH: Found prompt!
    end
    
    CH->>PromptMap: Deregister prompt from A
    CH->>Agent: Link generation with prompt
    
    Note over Agent,CH: Top-level run completes
    Agent->>CH: on_chain_end(run_id=A, parent_run_id=None)
    CH->>Map: _reset() - Clear all mappings
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Move imports to the top of the module instead of placing them within functions or methods. ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

<!-- /greptile_comment -->