### PR TITLE
fix(client): reuse httpx client in get_client

### DIFF
--- a/langfuse/_client/get_client.py
+++ b/langfuse/_client/get_client.py
@@ -53,6 +53,7 @@ def _create_client_from_instance(
         blocked_instrumentation_scopes=instance.blocked_instrumentation_scopes,
         additional_headers=instance.additional_headers,
         tracer_provider=instance.tracer_provider,
+        httpx_client=instance.httpx_client,
     )
 
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reuse existing `httpx_client` in `_create_client_from_instance()` in `get_client.py` to improve performance.
> 
>   - **Behavior**:
>     - Reuse existing `httpx_client` in `_create_client_from_instance()` in `get_client.py` to improve performance by avoiding new client creation.
>   - **Functions**:
>     - Add `httpx_client=instance.httpx_client` parameter to `_create_client_from_instance()` in `get_client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for ce6c6c5b721fe72cd2478dc4b66cccaa6573dcf7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>


This PR fixes a bug in `_create_client_from_instance` where the `httpx_client` was not being passed when creating a new `Langfuse` client from an existing `LangfuseResourceManager` instance. This ensures proper reuse of the httpx connection pool, preventing potential TCP socket exhaustion issues as documented in the codebase.

- Added `httpx_client=instance.httpx_client` parameter to the `Langfuse` constructor call in `_create_client_from_instance`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a minimal, targeted fix that adds a missing parameter to ensure proper resource reuse.
- Single-line change that correctly propagates an existing parameter. The change aligns with the documented design pattern in the codebase (httpx client singleton for connection pool management). No risk of regression.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_client/get_client.py | Added `httpx_client` parameter to `_create_client_from_instance` to reuse the existing httpx client from the resource manager instance, preventing potential connection pool exhaustion. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant get_client
    participant _create_client_from_instance
    participant Langfuse
    participant LangfuseResourceManager

    User->>get_client: get_client()
    get_client->>LangfuseResourceManager: Check _instances
    alt Instance exists
        get_client->>_create_client_from_instance: Create client from instance
        _create_client_from_instance->>Langfuse: new Langfuse(httpx_client=instance.httpx_client)
        Langfuse->>LangfuseResourceManager: Get singleton (reuses existing)
        Note right of LangfuseResourceManager: Reuses existing httpx_client<br/>from connection pool
        Langfuse-->>_create_client_from_instance: Return client
        _create_client_from_instance-->>get_client: Return client
    end
    get_client-->>User: Return Langfuse client
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->