### PR TITLE
fix(experiments): move evaluations to root experiment span

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -2866,17 +2866,17 @@ class Langfuse:
                     }
                 )
 
-                with _propagate_attributes(
-                    experiment=PropagatedExperimentAttributes(
-                        experiment_id=experiment_id,
-                        experiment_name=experiment_run_name,
-                        experiment_metadata=_serialize(experiment_metadata),
-                        experiment_dataset_id=dataset_id,
-                        experiment_item_id=experiment_item_id,
-                        experiment_item_metadata=_serialize(item_metadata),
-                        experiment_item_root_observation_id=span.id,
-                    )
-                ):
+                propagated_experiment_attributes = PropagatedExperimentAttributes(
+                    experiment_id=experiment_id,
+                    experiment_name=experiment_run_name,
+                    experiment_metadata=_serialize(experiment_metadata),
+                    experiment_dataset_id=dataset_id,
+                    experiment_item_id=experiment_item_id,
+                    experiment_item_metadata=_serialize(item_metadata),
+                    experiment_item_root_observation_id=span.id,
+                )
+
+                with _propagate_attributes(experiment=propagated_experiment_attributes):
                     output = await _run_task(task, item)
 
                 span.update(
@@ -2891,95 +2891,101 @@ class Langfuse:
                 )
                 raise e
 
-        # Run evaluators
-        evaluations = []
+            # Run evaluators
+            evaluations = []
 
-        for evaluator in evaluators:
-            try:
-                eval_metadata: Optional[Dict[str, Any]] = None
+            for evaluator in evaluators:
+                try:
+                    eval_metadata: Optional[Dict[str, Any]] = None
 
-                if isinstance(item, dict):
-                    eval_metadata = item.get("metadata")
-                elif hasattr(item, "metadata"):
-                    eval_metadata = item.metadata
+                    if isinstance(item, dict):
+                        eval_metadata = item.get("metadata")
+                    elif hasattr(item, "metadata"):
+                        eval_metadata = item.metadata
 
-                eval_results = await _run_evaluator(
-                    evaluator,
-                    input=input_data,
-                    output=output,
-                    expected_output=expected_output,
-                    metadata=eval_metadata,
-                )
-                evaluations.extend(eval_results)
+                    with _propagate_attributes(
+                        experiment=propagated_experiment_attributes
+                    ):
+                        eval_results = await _run_evaluator(
+                            evaluator,
+                            input=input_data,
+                            output=output,
+                            expected_output=expected_output,
+                            metadata=eval_metadata,
+                        )
+                        evaluations.extend(eval_results)
 
-                # Store evaluations as scores
-                for evaluation in eval_results:
-                    self.create_score(
-                        trace_id=trace_id,
-                        observation_id=span.id,
-                        name=evaluation.name,
-                        value=evaluation.value,  # type: ignore
-                        comment=evaluation.comment,
-                        metadata=evaluation.metadata,
-                        config_id=evaluation.config_id,
-                        data_type=evaluation.data_type,  # type: ignore
-                    )
+                        # Store evaluations as scores
+                        for evaluation in eval_results:
+                            self.create_score(
+                                trace_id=trace_id,
+                                observation_id=span.id,
+                                name=evaluation.name,
+                                value=evaluation.value,  # type: ignore
+                                comment=evaluation.comment,
+                                metadata=evaluation.metadata,
+                                config_id=evaluation.config_id,
+                                data_type=evaluation.data_type,  # type: ignore
+                            )
 
-            except Exception as e:
-                langfuse_logger.error(f"Evaluator failed: {e}")
+                except Exception as e:
+                    langfuse_logger.error(f"Evaluator failed: {e}")
 
-        # Run composite evaluator if provided and we have evaluations
-        if composite_evaluator and evaluations:
-            try:
-                composite_eval_metadata: Optional[Dict[str, Any]] = None
-                if isinstance(item, dict):
-                    composite_eval_metadata = item.get("metadata")
-                elif hasattr(item, "metadata"):
-                    composite_eval_metadata = item.metadata
+            # Run composite evaluator if provided and we have evaluations
+            if composite_evaluator and evaluations:
+                try:
+                    composite_eval_metadata: Optional[Dict[str, Any]] = None
+                    if isinstance(item, dict):
+                        composite_eval_metadata = item.get("metadata")
+                    elif hasattr(item, "metadata"):
+                        composite_eval_metadata = item.metadata
 
-                result = composite_evaluator(
-                    input=input_data,
-                    output=output,
-                    expected_output=expected_output,
-                    metadata=composite_eval_metadata,
-                    evaluations=evaluations,
-                )
+                    with _propagate_attributes(
+                        experiment=propagated_experiment_attributes
+                    ):
+                        result = composite_evaluator(
+                            input=input_data,
+                            output=output,
+                            expected_output=expected_output,
+                            metadata=composite_eval_metadata,
+                            evaluations=evaluations,
+                        )
 
-                # Handle async composite evaluators
-                if asyncio.iscoroutine(result):
-                    result = await result
+                        # Handle async composite evaluators
+                        if asyncio.iscoroutine(result):
+                            result = await result
 
-                # Normalize to list
-                composite_evals: List[Evaluation] = []
-                if isinstance(result, (dict, Evaluation)):
-                    composite_evals = [result]  # type: ignore
-                elif isinstance(result, list):
-                    composite_evals = result  # type: ignore
+                        # Normalize to list
+                        composite_evals: List[Evaluation] = []
+                        if isinstance(result, (dict, Evaluation)):
+                            composite_evals = [result]  # type: ignore
+                        elif isinstance(result, list):
+                            composite_evals = result  # type: ignore
 
-                # Store composite evaluations as scores and add to evaluations list
-                for composite_evaluation in composite_evals:
-                    self.create_score(
-                        trace_id=trace_id,
-                        observation_id=span.id,
-                        name=composite_evaluation.name,
-                        value=composite_evaluation.value,  # type: ignore
-                        comment=composite_evaluation.comment,
-                        metadata=composite_evaluation.metadata,
-                        config_id=composite_evaluation.config_id,
-                        data_type=composite_evaluation.data_type,  # type: ignore
-                    )
-                    evaluations.append(composite_evaluation)
+                        # Store composite evaluations as scores and add to evaluations list
+                        for composite_evaluation in composite_evals:
+                            self.create_score(
+                                trace_id=trace_id,
+                                observation_id=span.id,
+                                name=composite_evaluation.name,
+                                value=composite_evaluation.value,  # type: ignore
+                                comment=composite_evaluation.comment,
+                                metadata=composite_evaluation.metadata,
+                                config_id=composite_evaluation.config_id,
+                                data_type=composite_evaluation.data_type,  # type: ignore
+                            )
+                            evaluations.append(composite_evaluation)
 
-            except Exception as e:
-                langfuse_logger.error(f"Composite evaluator failed: {e}")
+                except Exception as e:
+                    langfuse_logger.error(f"Composite evaluator failed: {e}")
 
-        return ExperimentItemResult(
-            item=item,
-            output=output,
-            evaluations=evaluations,
-            trace_id=trace_id,
-            dataset_run_id=dataset_run_id,
-        )
+            return ExperimentItemResult(
+                item=item,
+                output=output,
+                evaluations=evaluations,
+                trace_id=trace_id,
+                dataset_run_id=dataset_run_id,
+            )
 
     def _create_experiment_run_name(
         self, *, name: Optional[str] = None, run_name: Optional[str] = None

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -682,7 +682,7 @@ def test_prompt_end_to_end():
 @pytest.fixture
 def langfuse():
     from langfuse._client.resource_manager import LangfuseResourceManager
-    
+
     langfuse_instance = Langfuse()
     langfuse_instance.api = Mock()
 


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

### Greptile Summary

This PR refactors the experiment evaluation workflow to ensure that evaluators run within the root experiment span context, enabling proper tracing and attribution of evaluation activities.

**Key Changes:**

1. **Evaluator Context Placement**: Moved the evaluator execution code (lines 2894-2988) from outside the span context into the `with self.start_as_current_span(name=span_name) as span:` block. This ensures evaluators are associated with the experiment span.

2. **Propagated Attributes Refactoring**: Extracted `PropagatedExperimentAttributes` into a variable (`propagated_experiment_attributes`) that can be reused across multiple context managers, including during task execution and evaluator runs.

3. **Wrapped Evaluator Calls**: Added `_propagate_attributes` context managers around both regular evaluator calls (line 2906-2916) and composite evaluator calls (line 2943-2977), ensuring experiment attributes are properly propagated through the evaluation chain.

**Behavior Preservation:**

- Exception handling remains unchanged: if the task fails, the exception is caught, the span is updated with error status, and the exception is re-raised, preventing evaluators from running
- The return statement now executes within the span context instead of after it closes
- All variable scopes remain valid as evaluators only run after successful task completion

**Impact:**

This change improves observability by ensuring evaluation traces are properly nested under the experiment span, making it easier to analyze experiment runs in the Langfuse UI.

### Confidence Score: 5/5

- Safe to merge - clean refactoring with no breaking changes or bugs
- The changes are a straightforward refactoring that moves evaluator execution inside the span context. All variable scopes are correct, exception handling is preserved, and the behavior remains identical except for the intended change (evaluators now run within span context). The test file change is just whitespace cleanup.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/client.py | 5/5 | Refactored experiment evaluators to run within the root experiment span context by moving evaluation code inside the span's with-block and adding _propagate_attributes context managers |
| tests/test_prompt.py | 5/5 | Removed trailing whitespace from import statement (formatting fix) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant _process_experiment_item
    participant Span as Span Context
    participant Task as _run_task
    participant Evaluator as _run_evaluator
    participant API as create_score

    Caller->>_process_experiment_item: Process experiment item
    _process_experiment_item->>Span: Enter span context
    activate Span
    
    Note over _process_experiment_item: Try block starts
    _process_experiment_item->>_process_experiment_item: Extract input_data, expected_output
    _process_experiment_item->>_process_experiment_item: Create propagated_experiment_attributes
    
    _process_experiment_item->>Task: Run task with _propagate_attributes
    activate Task
    Task-->>_process_experiment_item: Return output
    deactivate Task
    
    _process_experiment_item->>Span: Update span with input/output
    Note over _process_experiment_item: Try block succeeds
    
    Note over _process_experiment_item,Evaluator: Evaluators run INSIDE span context (NEW)
    loop For each evaluator
        _process_experiment_item->>Evaluator: Run evaluator with _propagate_attributes
        activate Evaluator
        Evaluator-->>_process_experiment_item: Return eval_results
        deactivate Evaluator
        
        loop For each evaluation
            _process_experiment_item->>API: create_score(trace_id, observation_id, ...)
        end
    end
    
    alt If composite_evaluator exists
        _process_experiment_item->>Evaluator: Run composite evaluator with _propagate_attributes
        activate Evaluator
        Evaluator-->>_process_experiment_item: Return composite results
        deactivate Evaluator
        
        loop For each composite evaluation
            _process_experiment_item->>API: create_score(trace_id, observation_id, ...)
        end
    end
    
    _process_experiment_item->>Span: Exit span context
    deactivate Span
    _process_experiment_item-->>Caller: Return ExperimentItemResult
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->