### PR TITLE
feat(client): add score metadata argument to span client score methods

### DIFF
--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -277,6 +277,7 @@ class LangfuseObservationWrapper:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         timestamp: Optional[datetime] = None,
+        metadata: Optional[Any] = None,
     ) -> None: ...
 
     @overload
@@ -290,6 +291,7 @@ class LangfuseObservationWrapper:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         timestamp: Optional[datetime] = None,
+        metadata: Optional[Any] = None,
     ) -> None: ...
 
     def score(
@@ -302,6 +304,7 @@ class LangfuseObservationWrapper:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         timestamp: Optional[datetime] = None,
+        metadata: Optional[Any] = None,
     ) -> None:
         """Create a score for this specific span.
 
@@ -316,6 +319,7 @@ class LangfuseObservationWrapper:
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
             timestamp: Optional timestamp for the score (defaults to current UTC time)
+            metadata: Optional metadata to be attached to the score
 
         Example:
             ```python
@@ -342,6 +346,7 @@ class LangfuseObservationWrapper:
             comment=comment,
             config_id=config_id,
             timestamp=timestamp,
+            metadata=metadata,
         )
 
     @overload
@@ -355,6 +360,7 @@ class LangfuseObservationWrapper:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         timestamp: Optional[datetime] = None,
+        metadata: Optional[Any] = None,
     ) -> None: ...
 
     @overload
@@ -368,6 +374,7 @@ class LangfuseObservationWrapper:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         timestamp: Optional[datetime] = None,
+        metadata: Optional[Any] = None,
     ) -> None: ...
 
     def score_trace(
@@ -380,6 +387,7 @@ class LangfuseObservationWrapper:
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         timestamp: Optional[datetime] = None,
+        metadata: Optional[Any] = None,
     ) -> None:
         """Create a score for the entire trace that this span belongs to.
 
@@ -395,6 +403,7 @@ class LangfuseObservationWrapper:
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
             timestamp: Optional timestamp for the score (defaults to current UTC time)
+            metadata: Optional metadata to be attached to the score
 
         Example:
             ```python
@@ -420,6 +429,7 @@ class LangfuseObservationWrapper:
             comment=comment,
             config_id=config_id,
             timestamp=timestamp,
+            metadata=metadata,
         )
 
     def _set_processed_span_attributes(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add optional `metadata` argument to `score` and `score_trace` methods in `langfuse/_client/span.py` to allow attaching additional data to scores.
> 
>   - **Behavior**:
>     - Add `metadata` argument to `score()` and `score_trace()` methods in `langfuse/_client/span.py`.
>     - `metadata` is optional and allows attaching additional data to scores.
>   - **Methods**:
>     - Update `score()` and `score_trace()` to include `metadata` in all overloads and internal `create_score` calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 44ce8e0d1fdc3823d42798d527fc7918cde77abe. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds optional `metadata` parameter support to the `score()` and `score_trace()` methods in the `LangfuseObservationWrapper` class, enabling users to attach additional contextual data to scores.

## Changes Made
- Added `metadata: Optional[Any] = None` parameter to both overloads and implementations of `score()` method (lines 280, 294, 307)
- Added `metadata: Optional[Any] = None` parameter to both overloads and implementations of `score_trace()` method (lines 363, 377, 390)
- Updated docstrings to document the new parameter
- Modified internal `create_score` calls to pass the metadata parameter through (lines 349, 432)

## Implementation Details
The implementation correctly passes the metadata parameter through to the underlying `create_score` method in the Langfuse client, which already supports metadata via the `ScoreBody` API type. The feature is backward compatible since metadata is optional and defaults to `None`.

## Issue Found
**Parameter Order Inconsistency**: The PR adds `metadata` after `timestamp` in the method signatures, but the underlying `create_score` method in `client.py` has `metadata` before `timestamp`. While this doesn't cause functional issues (all parameters are keyword-only), it creates an API inconsistency that could confuse developers and violates the principle of matching parameter order with the underlying implementation.

### Confidence Score: 4/5

- This PR is safe to merge with minor style improvements recommended
- The implementation is functionally correct and complete - all overloads are updated, the parameter is properly typed, documented, and passed through to the underlying API which already supports it. The feature is backward compatible and follows existing patterns. The score is 4/5 (not 5/5) due to a parameter ordering inconsistency with the underlying create_score method that should be fixed for API consistency, though this is a non-critical style issue that doesn't affect functionality.
- No files require special attention - the single style comment addresses parameter ordering across all affected methods

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| langfuse/_client/span.py | 4/5 | Added optional metadata parameter to score() and score_trace() methods; parameter order inconsistency found |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Span as LangfuseObservationWrapper
    participant Client as Langfuse Client
    participant API as Score API

    User->>Span: span.score(name, value, metadata={...})
    Note over Span: Validates parameters<br/>Prepares score data
    Span->>Client: create_score(name, value, trace_id, observation_id, metadata)
    Note over Client: Creates ScoreBody<br/>with metadata field
    Client->>API: POST score-create event
    Note over API: Score stored with<br/>attached metadata
    API-->>Client: Success
    Client-->>Span: Score created
    Span-->>User: Returns

    User->>Span: span.score_trace(name, value, metadata={...})
    Note over Span: Validates parameters<br/>Prepares trace score
    Span->>Client: create_score(name, value, trace_id, metadata)
    Note over Client: Creates ScoreBody<br/>with metadata field
    Client->>API: POST score-create event
    Note over API: Trace score stored<br/>with metadata
    API-->>Client: Success
    Client-->>Span: Score created
    Span-->>User: Returns
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->