### PR TITLE
Add metadata parameter to score_current_span and score_current_trace

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -2108,6 +2108,7 @@ class Langfuse:
         data_type: Optional[Literal["NUMERIC", "BOOLEAN"]] = None,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        metadata: Optional[Any] = None,
     ) -> None: ...
 
     @overload
@@ -2120,6 +2121,7 @@ class Langfuse:
         data_type: Optional[Literal["CATEGORICAL"]] = "CATEGORICAL",
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        metadata: Optional[Any] = None,
     ) -> None: ...
 
     def score_current_span(
@@ -2131,6 +2133,7 @@ class Langfuse:
         data_type: Optional[ScoreDataType] = None,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        metadata: Optional[Any] = None,
     ) -> None:
         """Create a score for the current active span.
 
@@ -2144,6 +2147,7 @@ class Langfuse:
             data_type: Type of score (NUMERIC, BOOLEAN, or CATEGORICAL)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
+            metadata: Optional metadata to be attached to the score
 
         Example:
             ```python
@@ -2157,7 +2161,8 @@ class Langfuse:
                     name="relevance",
                     value=0.85,
                     data_type="NUMERIC",
-                    comment="Mostly relevant but contains some tangential information"
+                    comment="Mostly relevant but contains some tangential information",
+                    metadata={"model": "gpt-4", "prompt_version": "v2"}
                 )
             ```
         """
@@ -2180,6 +2185,7 @@ class Langfuse:
                 data_type=cast(Literal["CATEGORICAL"], data_type),
                 comment=comment,
                 config_id=config_id,
+                metadata=metadata,
             )
 
     @overload
@@ -2192,6 +2198,7 @@ class Langfuse:
         data_type: Optional[Literal["NUMERIC", "BOOLEAN"]] = None,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        metadata: Optional[Any] = None,
     ) -> None: ...
 
     @overload
@@ -2204,6 +2211,7 @@ class Langfuse:
         data_type: Optional[Literal["CATEGORICAL"]] = "CATEGORICAL",
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        metadata: Optional[Any] = None,
     ) -> None: ...
 
     def score_current_trace(
@@ -2215,6 +2223,7 @@ class Langfuse:
         data_type: Optional[ScoreDataType] = None,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
+        metadata: Optional[Any] = None,
     ) -> None:
         """Create a score for the current trace.
 
@@ -2229,6 +2238,7 @@ class Langfuse:
             data_type: Type of score (NUMERIC, BOOLEAN, or CATEGORICAL)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
+            metadata: Optional metadata to be attached to the score
 
         Example:
             ```python
@@ -2242,7 +2252,8 @@ class Langfuse:
                     name="overall_quality",
                     value=0.95,
                     data_type="NUMERIC",
-                    comment="High quality end-to-end response"
+                    comment="High quality end-to-end response",
+                    metadata={"evaluator": "gpt-4", "criteria": "comprehensive"}
                 )
             ```
         """
@@ -2263,6 +2274,7 @@ class Langfuse:
                 data_type=cast(Literal["CATEGORICAL"], data_type),
                 comment=comment,
                 config_id=config_id,
+                metadata=metadata,
             )
 
     def flush(self) -> None:


### PR DESCRIPTION
## Summary

This PR adds an optional `metadata` parameter to both `score_current_span` and `score_current_trace` methods, bringing these convenience methods to feature parity with the underlying `create_score` method which already supports metadata.

## Changes

- Added `metadata: Optional[Any] = None` parameter to all overloads of `score_current_span`
- Added `metadata: Optional[Any] = None` parameter to all overloads of `score_current_trace`
- Updated docstrings to document the new parameter
- Updated code examples in docstrings to demonstrate metadata usage
- Passed metadata parameter through to `create_score` calls

## Motivation

The `create_score` method already supports attaching metadata to scores, but the convenience methods `score_current_span` and `score_current_trace` did not expose this parameter. This made it impossible to attach metadata when using these convenience methods without falling back to the lower-level `create_score` API.

## Example Usage

### Before (not possible):
```python
langfuse.score_current_span(
    name="relevance",
    value=0.85,
    data_type="NUMERIC",
    comment="Mostly relevant"
)
# No way to add metadata!
```

### After:
```python
langfuse.score_current_span(
    name="relevance",
    value=0.85,
    data_type="NUMERIC",
    comment="Mostly relevant",
    metadata={"model": "gpt-4", "prompt_version": "v2"}
)
```

## Test plan

- [x] Verified parameter signatures are correct with proper type hints
- [x] Verified docstrings are updated
- [x] Verified metadata is passed through to `create_score`
- [ ] Integration tests should pass (existing tests continue to work as metadata is optional)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add optional `metadata` parameter to `score_current_span` and `score_current_trace` in `client.py`, updating docstrings and examples.
> 
>   - **Behavior**:
>     - Add `metadata: Optional[Any] = None` parameter to all overloads of `score_current_span` and `score_current_trace` in `client.py`.
>     - Pass `metadata` parameter to `create_score` calls in `score_current_span` and `score_current_trace`.
>   - **Documentation**:
>     - Update docstrings for `score_current_span` and `score_current_trace` to include `metadata` parameter.
>     - Update code examples in docstrings to demonstrate `metadata` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for b55d88ad7dae7abfdca2794acc1dd754fbffa833. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>


Added optional `metadata` parameter to `score_current_span` and `score_current_trace` convenience methods, bringing them to feature parity with the underlying `create_score` method.

**Key Changes:**
- Added `metadata: Optional[Any] = None` parameter to all overloads and implementations of both methods
- Updated docstrings to document the new parameter with usage examples
- Passed metadata parameter through to underlying `create_score` calls
- Changes are fully backward compatible as metadata is optional

**Impact:**
- Users can now attach metadata to scores when using convenience methods without falling back to the lower-level `create_score` API
- Existing code continues to work as metadata defaults to `None`
- API is now consistent across all score creation methods

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are straightforward and follow existing patterns. The metadata parameter is already supported in `create_score` and `ScoreBody`, so this PR simply exposes it through convenience methods. All parameter additions are optional with default `None` values, ensuring backward compatibility. The implementation correctly passes metadata through to the underlying `create_score` calls. Existing tests will continue to pass since metadata is optional.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_client/client.py | Added optional metadata parameter to `score_current_span` and `score_current_trace` convenience methods, matching the existing `create_score` API. Changes include type hints, docstrings, and passing metadata through to underlying calls. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant score_current_span
    participant score_current_trace
    participant create_score
    participant ScoreBody
    participant ResourceManager

    User->>score_current_span: score_current_span(name, value, metadata, ...)
    score_current_span->>score_current_span: Get current span context
    score_current_span->>score_current_span: Extract trace_id and observation_id
    score_current_span->>create_score: create_score(trace_id, observation_id, name, value, metadata, ...)
    
    User->>score_current_trace: score_current_trace(name, value, metadata, ...)
    score_current_trace->>score_current_trace: Get current span context
    score_current_trace->>score_current_trace: Extract trace_id
    score_current_trace->>create_score: create_score(trace_id, name, value, metadata, ...)
    
    create_score->>ScoreBody: new ScoreBody(id, traceId, observationId, name, value, metadata, ...)
    ScoreBody-->>create_score: ScoreBody instance
    create_score->>create_score: Create score event
    create_score->>ResourceManager: add_score_task(event)
    ResourceManager-->>create_score: Task queued
    create_score-->>User: Score created
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->