### PR TITLE
fix(batch-evaluation): pass trace ID for score creation if scope = observations

### DIFF
--- a/langfuse/batch_evaluation.py
+++ b/langfuse/batch_evaluation.py
@@ -20,6 +20,7 @@ from typing import (
     Protocol,
     Tuple,
     Union,
+    cast,
 )
 
 from langfuse.api.resources.commons.types import (
@@ -1220,6 +1221,9 @@ class BatchEvaluationRunner:
             self._create_score_for_scope(
                 scope=scope,
                 item_id=item_id,
+                trace_id=cast(ObservationsView, item).trace_id
+                if scope == "observations"
+                else None,
                 evaluation=evaluation,
                 additional_metadata=metadata,
             )
@@ -1242,6 +1246,9 @@ class BatchEvaluationRunner:
                     self._create_score_for_scope(
                         scope=scope,
                         item_id=item_id,
+                        trace_id=cast(ObservationsView, item).trace_id
+                        if scope == "observations"
+                        else None,
                         evaluation=composite_eval,
                         additional_metadata=metadata,
                     )
@@ -1361,8 +1368,10 @@ class BatchEvaluationRunner:
 
     def _create_score_for_scope(
         self,
+        *,
         scope: str,
         item_id: str,
+        trace_id: Optional[str] = None,
         evaluation: Evaluation,
         additional_metadata: Optional[Dict[str, Any]],
     ) -> None:
@@ -1371,6 +1380,7 @@ class BatchEvaluationRunner:
         Args:
             scope: The type of entity ("traces", "observations").
             item_id: The ID of the entity.
+            trace_id: The trace ID of the entity; required if scope=observations
             evaluation: The evaluation result to create a score from.
             additional_metadata: Additional metadata to merge with evaluation metadata.
         """
@@ -1393,6 +1403,7 @@ class BatchEvaluationRunner:
         elif scope == "observations":
             self.client.create_score(
                 observation_id=item_id,
+                trace_id=trace_id,
                 name=evaluation.name,
                 value=evaluation.value,  # type: ignore
                 comment=evaluation.comment,

--- a/tests/test_batch_evaluation.py
+++ b/tests/test_batch_evaluation.py
@@ -25,7 +25,7 @@ from tests.utils import create_uuid
 # ============================================================================
 
 
-pytestmark = pytest.mark.skip(reason="Github CI runner overwhelmed by score volume")
+# pytestmark = pytest.mark.skip(reason="Github CI runner overwhelmed by score volume")
 
 
 @pytest.fixture
@@ -65,6 +65,32 @@ def simple_evaluator(*, input, output, expected_output=None, metadata=None, **kw
 # ============================================================================
 # BASIC FUNCTIONALITY TESTS
 # ============================================================================
+
+
+def test_run_batched_evaluation_on_observations_basic(langfuse_client):
+    """Test basic batch evaluation on traces."""
+    result = langfuse_client.run_batched_evaluation(
+        scope="observations",
+        mapper=simple_trace_mapper,
+        evaluators=[simple_evaluator],
+        max_items=1,
+        verbose=True,
+    )
+
+    # Validate result structure
+    assert isinstance(result, BatchEvaluationResult)
+    assert result.total_items_fetched >= 0
+    assert result.total_items_processed >= 0
+    assert result.total_scores_created >= 0
+    assert result.completed is True
+    assert isinstance(result.duration_seconds, float)
+    assert result.duration_seconds > 0
+
+    # Verify evaluator stats
+    assert len(result.evaluator_stats) == 1
+    stats = result.evaluator_stats[0]
+    assert isinstance(stats, EvaluatorStats)
+    assert stats.name == "simple_evaluator"
 
 
 def test_run_batched_evaluation_on_traces_basic(langfuse_client):


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed batch evaluation score creation for observations by passing the required `trace_id` parameter. When creating scores for observations, the Langfuse API requires both `observation_id` and `trace_id`. This PR correctly extracts the `trace_id` from the `ObservationsView` item and passes it to `_create_score_for_scope`.

**Key changes:**
- Added `cast` import at the top of the module
- Modified `_create_score_for_scope` to accept optional `trace_id` parameter (keyword-only)
- Updated both call sites to pass `trace_id` when `scope == "observations"`
- Added test coverage for observations batch evaluation
- Uncommented test suite to enable validation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix correctly addresses a critical bug where observation scores couldn't be created due to missing trace_id parameter. The implementation is type-safe using proper casts, follows best practices with keyword-only parameters, and includes test coverage. The change is minimal, focused, and aligns with the API requirements.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/batch_evaluation.py | Added trace_id parameter to _create_score_for_scope and passes it when scope=observations, fixing score creation for observations |
| tests/test_batch_evaluation.py | Added test for batch evaluation on observations and uncommented test suite |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant BatchEvaluationRunner
    participant Evaluator
    participant LangfuseClient
    
    Caller->>BatchEvaluationRunner: run_batched_evaluation(scope="observations")
    BatchEvaluationRunner->>BatchEvaluationRunner: fetch observations
    
    loop For each observation
        BatchEvaluationRunner->>BatchEvaluationRunner: _process_batch_evaluation_item(item)
        BatchEvaluationRunner->>Evaluator: run evaluator on observation
        Evaluator-->>BatchEvaluationRunner: evaluation result
        
        Note over BatchEvaluationRunner: Extract trace_id from ObservationsView
        BatchEvaluationRunner->>BatchEvaluationRunner: cast(ObservationsView, item).trace_id
        
        BatchEvaluationRunner->>BatchEvaluationRunner: _create_score_for_scope(scope, item_id, trace_id)
        
        alt scope == "observations"
            BatchEvaluationRunner->>LangfuseClient: create_score(observation_id, trace_id, ...)
        else scope == "traces"
            BatchEvaluationRunner->>LangfuseClient: create_score(trace_id, ...)
        end
        
        LangfuseClient-->>BatchEvaluationRunner: score created
    end
    
    BatchEvaluationRunner-->>Caller: BatchEvaluationResult
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->