### PR TITLE
feat(openai): add support for image generation tracking

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -91,6 +91,48 @@ OPENAI_METHODS_V1 = [
         sync=True,
     ),
     OpenAiDefinition(
+        module="openai.resources.images",
+        object="Images",
+        method="generate",
+        type="image",
+        sync=True,
+    ),
+    OpenAiDefinition(
+        module="openai.resources.images",
+        object="AsyncImages",
+        method="generate",
+        type="image",
+        sync=False,
+    ),
+    OpenAiDefinition(
+        module="openai.resources.images",
+        object="Images",
+        method="edit",
+        type="image",
+        sync=True,
+    ),
+    OpenAiDefinition(
+        module="openai.resources.images",
+        object="AsyncImages",
+        method="edit",
+        type="image",
+        sync=False,
+    ),
+    OpenAiDefinition(
+        module="openai.resources.images",
+        object="Images",
+        method="create_variation",
+        type="image",
+        sync=True,
+    ),
+    OpenAiDefinition(
+        module="openai.resources.images",
+        object="AsyncImages",
+        method="create_variation",
+        type="image",
+        sync=False,
+    ),
+    OpenAiDefinition(
         module="openai.resources.completions",
         object="Completions",
         method="create",
@@ -354,9 +396,12 @@ def _extract_chat_response(kwargs: Any) -> Any:
 
 
 def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> Any:
-    default_name = (
-        "OpenAI-embedding" if resource.type == "embedding" else "OpenAI-generation"
-    )
+    if resource.type == "embedding":
+        default_name = "OpenAI-embedding"
+    elif resource.type == "image":
+        default_name = "OpenAI-image"
+    else:
+        default_name = "OpenAI-generation"
     name = kwargs.get("name", default_name)
 
     if name is None:
@@ -417,6 +462,12 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
         prompt = _extract_chat_prompt(kwargs)
     elif resource.type == "embedding":
         prompt = kwargs.get("input", None)
+    elif resource.type == "image":
+        # generate() and edit() accept prompt, but create_variation() does not
+        if resource.method in ["generate", "edit"]:
+            prompt = kwargs.get("prompt", None)
+        else:
+            prompt = None  # create_variation uses image input, not text prompt
 
     parsed_temperature = (
         kwargs.get("temperature", 1)
@@ -479,6 +530,44 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
             modelParameters["dimensions"] = parsed_dimensions
         if parsed_encoding_format != "float":
             modelParameters["encoding_format"] = parsed_encoding_format
+    elif resource.type == "image":
+        # Image generation parameters
+        modelParameters = {}
+
+        parsed_size = (
+            kwargs.get("size", None)
+            if not isinstance(kwargs.get("size", None), NotGiven)
+            else None
+        )
+        if parsed_size is not None:
+            modelParameters["size"] = parsed_size
+
+        parsed_quality = (
+            kwargs.get("quality", None)
+            if not isinstance(kwargs.get("quality", None), NotGiven)
+            else None
+        )
+        if parsed_quality is not None:
+            modelParameters["quality"] = parsed_quality
+
+        parsed_style = (
+            kwargs.get("style", None)
+            if not isinstance(kwargs.get("style", None), NotGiven)
+            else None
+        )
+        if parsed_style is not None:
+            modelParameters["style"] = parsed_style
+
+        parsed_response_format = (
+            kwargs.get("response_format", None)
+            if not isinstance(kwargs.get("response_format", None), NotGiven)
+            else None
+        )
+        if parsed_response_format is not None:
+            modelParameters["response_format"] = parsed_response_format
+
+        if parsed_n is not None and isinstance(parsed_n, int) and parsed_n > 1:
+            modelParameters["n"] = parsed_n
     else:
         modelParameters = {
             "temperature": parsed_temperature,
@@ -791,6 +880,33 @@ def _get_langfuse_data_from_default_response(
                 "count": len(data),
             }
 
+    elif resource.type == "image":
+        data = response.get("data", [])
+        completion = []
+        for item in data:
+            image_data = item.__dict__ if hasattr(item, "__dict__") else item
+            image_result = {}
+
+            # Handle URL response
+            if image_data.get("url"):
+                image_result["url"] = image_data["url"]
+
+            # Handle base64 response
+            if image_data.get("b64_json"):
+                # Wrap in LangfuseMedia for proper handling
+                base64_data_uri = f"data:image/png;base64,{image_data['b64_json']}"
+                image_result["image"] = LangfuseMedia(base64_data_uri=base64_data_uri)
+
+            # Include revised_prompt if present (DALL-E 3)
+            if image_data.get("revised_prompt"):
+                image_result["revised_prompt"] = image_data["revised_prompt"]
+
+            completion.append(image_result)
+
+        # If only one image, unwrap from list
+        if len(completion) == 1:
+            completion = completion[0]
+
     usage = _parse_usage(response.get("usage", None))
 
     return (model, completion, usage)
@@ -841,6 +957,28 @@ def _wrap(
 
     try:
         openai_response = wrapped(**arg_extractor.get_openai_args())
+
+        # Handle image generation (non-streaming)
+        if open_ai_resource.type == "image":
+            model, completion, usage = _get_langfuse_data_from_default_response(
+                open_ai_resource,
+                (openai_response and openai_response.__dict__)
+                if _is_openai_v1()
+                else openai_response,
+            )
+
+            # Calculate image count for usage tracking
+            image_count = 1
+            if isinstance(completion, list):
+                image_count = len(completion)
+
+            generation.update(
+                model=model,
+                output=completion,
+                usage_details={"output": image_count, "total": image_count, "unit": "IMAGES"},
+            ).end()
+
+            return openai_response
 
         if _is_streaming_response(openai_response):
             return LangfuseResponseGeneratorSync(
@@ -912,6 +1050,28 @@ async def _wrap_async(
 
     try:
         openai_response = await wrapped(**arg_extractor.get_openai_args())
+
+        # Handle image generation (non-streaming)
+        if open_ai_resource.type == "image":
+            model, completion, usage = _get_langfuse_data_from_default_response(
+                open_ai_resource,
+                (openai_response and openai_response.__dict__)
+                if _is_openai_v1()
+                else openai_response,
+            )
+
+            # Calculate image count for usage tracking
+            image_count = 1
+            if isinstance(completion, list):
+                image_count = len(completion)
+
+            generation.update(
+                model=model,
+                output=completion,
+                usage_details={"output": image_count, "total": image_count, "unit": "IMAGES"},
+            ).end()
+
+            return openai_response
 
         if _is_streaming_response(openai_response):
             return LangfuseResponseGeneratorAsync(


### PR DESCRIPTION
## Summary

Adds automatic tracing for OpenAI image generation API calls:
- `images.generate()`
- `images.edit()`
- `images.create_variation()`

## Changes

### `langfuse/openai.py`
- Added 6 new `OpenAiDefinition` entries for image methods (sync and async variants)
- Extended `_get_langfuse_data_from_kwargs()` to extract image generation parameters (size, quality, style, response_format, n)
- Extended `_get_langfuse_data_from_default_response()` to parse image responses (URLs and base64 data wrapped in `LangfuseMedia`)
- Added handling in `_wrap()` and `_wrap_async()` to track image count as usage metrics

### `tests/test_openai.py`
- Added tests for sync and async `images.generate()`
- Added skipped test stubs for `images.edit()` and `images.create_variation()` (require DALL-E 2 + image files)

## Tracked Data

| Field | Value |
|-------|-------|
| **name** | `OpenAI-image` (default) |
| **input** | Prompt text (`generate`/`edit`) or `None` (`create_variation`) |
| **model** | `dall-e-2`, `dall-e-3`, `gpt-image-1`, etc. |
| **model_parameters** | `size`, `quality`, `style`, `response_format`, `n` |
| **output** | URL or base64 image wrapped in `LangfuseMedia` |
| **usage** | Image count (`{output: N, total: N, unit: IMAGES}`) |

## Notes

- `create_variation()` does not accept a prompt parameter, so `input` will be `None` for those calls. This is expected behavior.
- Base64 responses are wrapped in `LangfuseMedia` for proper handling in the Langfuse UI.
- Tests for `edit()` and `create_variation()` are skipped as they require DALL-E 2 API access and PNG image files with alpha channels.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for tracking OpenAI image generation API calls in Langfuse, including handling image-specific parameters and responses.
> 
>   - **Behavior**:
>     - Adds support for tracking OpenAI image generation API calls in `langfuse/openai.py`, including `images.generate()`, `images.edit()`, and `images.create_variation()`.
>     - Extends `_get_langfuse_data_from_kwargs()` to handle image parameters like `size`, `quality`, `style`, `response_format`, and `n`.
>     - Extends `_get_langfuse_data_from_default_response()` to parse image responses, wrapping base64 data in `LangfuseMedia`.
>     - Updates `_wrap()` and `_wrap_async()` to track image count as usage metrics.
>   - **Tests**:
>     - Adds tests in `tests/test_openai.py` for sync and async `images.generate()`.
>     - Adds skipped test stubs for `images.edit()` and `images.create_variation()` due to DALL-E 2 requirements.
>   - **Misc**:
>     - `create_variation()` does not use a prompt, so `input` is `None` for these calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 7154a72a2cbcdeff4080a806f2b1dd98a346cc8f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds comprehensive tracking support for OpenAI image generation APIs (`images.generate()`, `images.edit()`, and `images.create_variation()`).

**Key changes:**
- Added 6 new `OpenAiDefinition` entries for image methods (sync/async variants)
- Extended parameter extraction to capture image-specific parameters (size, quality, style, response_format, n)
- Added response parsing to handle both URL and base64 image responses, wrapping base64 data in `LangfuseMedia`
- Implemented custom usage tracking with image count metrics
- Added comprehensive tests for `generate()` with appropriate skipped stubs for `edit()` and `create_variation()`

**Implementation quality:**
The implementation follows existing patterns in the codebase and handles edge cases well. The code properly differentiates between methods that accept prompts (`generate`, `edit`) vs those that don't (`create_variation`). Response handling correctly unwraps single-image responses while preserving lists for multiple images. Usage tracking accurately counts images regardless of response format.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured and follows existing patterns in the codebase. The code properly handles different image generation methods, parameter extraction, and response parsing. Tests are comprehensive for the testable portions. No security issues or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/openai.py | Added image generation tracking support with proper parameter extraction and usage metrics - implementation is solid with good separation of concerns |
| tests/test_openai.py | Added comprehensive tests for image generation with proper assertions - sync and async tests included, edit/variation tests appropriately skipped |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant LF as Langfuse Wrapper
    participant OAI as OpenAI API
    participant DB as Langfuse Backend

    App->>LF: images.generate(prompt, model, size, ...)
    activate LF
    LF->>LF: _get_langfuse_data_from_kwargs()
    Note over LF: Extract prompt, model, params<br/>(size, quality, style, n)
    LF->>DB: start_observation(type="generation")
    LF->>OAI: images.generate()
    activate OAI
    OAI-->>LF: ImagesResponse (url or b64_json)
    deactivate OAI
    LF->>LF: _get_langfuse_data_from_default_response()
    Note over LF: Parse response, wrap base64 in<br/>LangfuseMedia, extract revised_prompt
    LF->>LF: Calculate usage (image_count)
    LF->>DB: update(output, usage_details, model)
    LF->>DB: end()
    LF-->>App: Return OpenAI response
    deactivate LF
```

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->