### PR TITLE
fix(langchain-openai): do not subtract priority token counts

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -1102,22 +1102,9 @@ def _flatten_comprehension(matrix: Any) -> Any:
     return [item for row in matrix for item in row]
 
 
-_TOKEN_DETAIL_SUBTRACT_KEYS = {
-    "audio",
-    "cache_read",
-    "cache_creation",
-    "reasoning",
-}
-
-
 def _should_subtract_token_detail(detail_key: str) -> bool:
     normalized_key = detail_key.lower()
-    for subtract_key in _TOKEN_DETAIL_SUBTRACT_KEYS:
-        if normalized_key == subtract_key or normalized_key.endswith(
-            f"_{subtract_key}"
-        ):
-            return True
-    return False
+    return not normalized_key.startswith("priority")
 
 
 def _parse_usage_model(usage: Union[pydantic.BaseModel, dict]) -> Any:

--- a/tests/test_langchain_usage.py
+++ b/tests/test_langchain_usage.py
@@ -33,17 +33,21 @@ def test_parse_usage_model_subtracts_known_details():
         "input_token_details": {
             "cache_read": 20,
             "audio": 5,
+            "custom_detail": 3,
         },
         "output_token_details": {
             "reasoning": 10,
+            "custom_output": 2,
         },
     }
 
     parsed = _parse_usage_model(usage)
 
-    assert parsed["input"] == 75
-    assert parsed["output"] == 40
+    assert parsed["input"] == 72
+    assert parsed["output"] == 38
     assert parsed["input_cache_read"] == 20
     assert parsed["input_audio"] == 5
+    assert parsed["input_custom_detail"] == 3
     assert parsed["output_reasoning"] == 10
+    assert parsed["output_custom_output"] == 2
     assert parsed["total"] == 150


### PR DESCRIPTION
Only subtract known token detail subcategories in `_parse_usage_model` to fix incorrect input/output totals caused by priority-tier metadata (fixes #11896).

---
<p><a href="https://cursor.com/background-agent?bcId=bc-cdad092e-691b-4e83-97c6-8ee1107769ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cdad092e-691b-4e83-97c6-8ee1107769ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix issue #11896 by updating `_parse_usage_model` to skip subtraction for 'priority' token details and adding tests in `test_langchain_usage.py`.
> 
>   - **Behavior**:
>     - Modify `_parse_usage_model` in `CallbackHandler.py` to skip subtraction for token details with keys starting with "priority".
>     - Introduce `_should_subtract_token_detail()` to determine if a token detail should be subtracted.
>   - **Tests**:
>     - Add `test_langchain_usage.py` with tests `test_parse_usage_model_skips_priority_subtraction` and `test_parse_usage_model_subtracts_known_details` to verify correct behavior of `_parse_usage_model`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 04fca344c56bf58446f33855be841356872381ba. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->