### PR TITLE
fix(client): pass release variable to span clients

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -52,6 +52,7 @@ from langfuse._client.environment_variables import (
     LANGFUSE_DEBUG,
     LANGFUSE_HOST,
     LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_RELEASE,
     LANGFUSE_SAMPLE_RATE,
     LANGFUSE_SECRET_KEY,
     LANGFUSE_TIMEOUT,
@@ -77,6 +78,7 @@ from langfuse._client.span import (
 )
 from langfuse._client.utils import get_sha256_hash_hex, run_async_safely
 from langfuse._utils import _get_timestamp
+from langfuse._utils.environment import get_common_release_envs
 from langfuse._utils.parse_error import handle_fern_exception
 from langfuse._utils.prompt_cache import PromptCache
 from langfuse.api import (
@@ -251,6 +253,11 @@ class Langfuse:
         )
         self._environment = environment or cast(
             str, os.environ.get(LANGFUSE_TRACING_ENVIRONMENT)
+        )
+        self._release = (
+            release
+            or os.environ.get(LANGFUSE_RELEASE, None)
+            or get_common_release_envs()
         )
         self._project_id: Optional[str] = None
         sample_rate = sample_rate or float(os.environ.get(LANGFUSE_SAMPLE_RATE, 1.0))
@@ -633,6 +640,7 @@ class Langfuse:
                 otel_span=otel_span,
                 langfuse_client=self,
                 environment=self._environment,
+                release=self._release,
                 input=input,
                 output=output,
                 metadata=metadata,
@@ -655,6 +663,7 @@ class Langfuse:
                 otel_span=otel_span,
                 langfuse_client=self,
                 environment=self._environment,
+                release=self._release,
                 input=input,
                 output=output,
                 metadata=metadata,
@@ -1168,6 +1177,7 @@ class Langfuse:
                 "otel_span": otel_span,
                 "langfuse_client": self,
                 "environment": self._environment,
+                "release": self._release,
                 "input": input,
                 "output": output,
                 "metadata": metadata,
@@ -1346,6 +1356,7 @@ class Langfuse:
                 otel_span=current_otel_span,
                 langfuse_client=self,
                 environment=self._environment,
+                release=self._release,
             )
 
             if name:
@@ -1403,6 +1414,7 @@ class Langfuse:
                 otel_span=current_otel_span,
                 langfuse_client=self,
                 environment=self._environment,
+                release=self._release,
             )
 
             span.set_trace_io(
@@ -1502,6 +1514,7 @@ class Langfuse:
                             otel_span=otel_span,
                             langfuse_client=self,
                             environment=self._environment,
+                            release=self._release,
                             input=input,
                             output=output,
                             metadata=metadata,
@@ -1519,6 +1532,7 @@ class Langfuse:
                 otel_span=otel_span,
                 langfuse_client=self,
                 environment=self._environment,
+                release=self._release,
                 input=input,
                 output=output,
                 metadata=metadata,

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -85,6 +85,7 @@ class LangfuseObservationWrapper:
         output: Optional[Any] = None,
         metadata: Optional[Any] = None,
         environment: Optional[str] = None,
+        release: Optional[str] = None,
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
@@ -105,6 +106,7 @@ class LangfuseObservationWrapper:
             output: Output data from the span (any JSON-serializable object)
             metadata: Additional metadata to associate with the span
             environment: The tracing environment
+            release: Release identifier for the application
             version: Version identifier for the code or component
             level: Importance level of the span (info, warning, error)
             status_message: Optional status message for the span
@@ -129,6 +131,12 @@ class LangfuseObservationWrapper:
         if self._environment is not None:
             self._otel_span.set_attribute(
                 LangfuseOtelSpanAttributes.ENVIRONMENT, self._environment
+            )
+
+        self._release = release or self._langfuse_client._release
+        if self._release is not None:
+            self._otel_span.set_attribute(
+                LangfuseOtelSpanAttributes.RELEASE, self._release
             )
 
         # Handle media only if span is sampled
@@ -925,6 +933,7 @@ class LangfuseObservationWrapper:
                     output=output,
                     metadata=metadata,
                     environment=self._environment,
+                    release=self._release,
                     version=version,
                     level=level,
                     status_message=status_message,
@@ -945,6 +954,7 @@ class LangfuseObservationWrapper:
             "otel_span": new_otel_span,
             "langfuse_client": self._langfuse_client,
             "environment": self._environment,
+            "release": self._release,
             "input": input,
             "output": output,
             "metadata": metadata,
@@ -1225,6 +1235,7 @@ class LangfuseObservationWrapper:
                 output=output,
                 metadata=metadata,
                 environment=self._environment,
+                release=self._release,
                 version=version,
                 level=level,
                 status_message=status_message,
@@ -1251,6 +1262,7 @@ class LangfuseSpan(LangfuseObservationWrapper):
         output: Optional[Any] = None,
         metadata: Optional[Any] = None,
         environment: Optional[str] = None,
+        release: Optional[str] = None,
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
@@ -1264,6 +1276,7 @@ class LangfuseSpan(LangfuseObservationWrapper):
             output: Output data from the span (any JSON-serializable object)
             metadata: Additional metadata to associate with the span
             environment: The tracing environment
+            release: Release identifier for the application
             version: Version identifier for the code or component
             level: Importance level of the span (info, warning, error)
             status_message: Optional status message for the span
@@ -1276,6 +1289,7 @@ class LangfuseSpan(LangfuseObservationWrapper):
             output=output,
             metadata=metadata,
             environment=environment,
+            release=release,
             version=version,
             level=level,
             status_message=status_message,
@@ -1299,6 +1313,7 @@ class LangfuseGeneration(LangfuseObservationWrapper):
         output: Optional[Any] = None,
         metadata: Optional[Any] = None,
         environment: Optional[str] = None,
+        release: Optional[str] = None,
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
@@ -1318,6 +1333,7 @@ class LangfuseGeneration(LangfuseObservationWrapper):
             output: Output from the generation (e.g., completions)
             metadata: Additional metadata to associate with the generation
             environment: The tracing environment
+            release: Release identifier for the application
             version: Version identifier for the model or component
             level: Importance level of the generation (info, warning, error)
             status_message: Optional status message for the generation
@@ -1336,6 +1352,7 @@ class LangfuseGeneration(LangfuseObservationWrapper):
             output=output,
             metadata=metadata,
             environment=environment,
+            release=release,
             version=version,
             level=level,
             status_message=status_message,
@@ -1360,6 +1377,7 @@ class LangfuseEvent(LangfuseObservationWrapper):
         output: Optional[Any] = None,
         metadata: Optional[Any] = None,
         environment: Optional[str] = None,
+        release: Optional[str] = None,
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
@@ -1373,6 +1391,7 @@ class LangfuseEvent(LangfuseObservationWrapper):
             output: Output from the event
             metadata: Additional metadata to associate with the generation
             environment: The tracing environment
+            release: Release identifier for the application
             version: Version identifier for the model or component
             level: Importance level of the generation (info, warning, error)
             status_message: Optional status message for the generation
@@ -1385,6 +1404,7 @@ class LangfuseEvent(LangfuseObservationWrapper):
             output=output,
             metadata=metadata,
             environment=environment,
+            release=release,
             version=version,
             level=level,
             status_message=status_message,

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -27,6 +27,7 @@ def test_get_client_preserves_all_settings():
     retrieved_client = get_client()
 
     assert retrieved_client._environment == settings["environment"]
+    assert retrieved_client._release == settings["release"]
 
     assert retrieved_client._resources is not None
     rm = retrieved_client._resources


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pass `release` attribute to span clients in Langfuse, updating span creation and observation methods to include this attribute.
> 
>   - **Behavior**:
>     - Pass `release` attribute to span clients in `Langfuse` class in `client.py`.
>     - Update `_create_observation_from_otel_span()` and `create_event()` in `client.py` to include `release`.
>     - Ensure `release` is set in `LangfuseObservationWrapper` and its subclasses in `span.py`.
>   - **Tests**:
>     - Add assertion for `release` in `test_get_client_preserves_all_settings()` in `test_resource_manager.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for f1b31fd56a5a92e32174eacbf60af95a28feedc8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a `release` field on the Langfuse client and propagates it into span/observation wrappers so it’s set as an OpenTelemetry attribute and forwarded through nested observation creation. It also adds a regression assertion ensuring `get_client()` preserves the configured `release`.

The main remaining issue is an inconsistent instantiation path: `Langfuse.update_current_generation()` still constructs `LangfuseGeneration` without passing `environment`/`release`, so the current OTEL span won’t receive the intended `release` attribute in that flow. Aligning it with the other creation sites in `client.py` should make release propagation consistent across all span/generation APIs.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge after fixing one missed propagation path for `release` in `update_current_generation()`.
- Changes are localized to adding a new client setting and threading it through existing span/observation creation patterns, plus a test assertion. One definite inconsistency remains where a generation wrapper is created without passing environment/release, which undermines the stated goal in that code path.
- langfuse/_client/client.py (update_current_generation instantiation)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_client/client.py | Adds release handling (init/env propagation) and passes it to most span/generation creation sites; one existing code path (update_current_generation) still instantiates LangfuseGeneration without environment/release, so release won’t be applied there. |
| langfuse/_client/span.py | Extends observation wrappers (Span/Generation/Event) to accept `release`, store it, and set OTEL attribute; propagates release to nested observations. Changes look consistent with existing environment propagation. |
| tests/test_resource_manager.py | Adds assertion that retrieved client preserves `release` setting; straightforward and aligned with change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    autonumber
    participant U as User Code
    participant LF as Langfuse(Client)
    participant SC as Span Client
    participant OW as Observation Wrapper
    participant API as Langfuse API

    U->>LF: Langfuse(..., release=R)
    U->>LF: trace()/span()/event(...)
    LF->>SC: create_span(..., release=R)
    SC->>API: POST /spans { ..., release: R }
    LF->>OW: wrap observation (set release=R)
    OW->>API: update/create observation { ..., release: R }
    LF->>LF: _create_observation_from_otel_span(otelSpan)
    LF->>API: create observation { ..., release: R }
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Move imports to the top of the module instead of placing them within functions or methods. ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

<!-- /greptile_comment -->