### PR TITLE
fix Evaluation docstring examples to use value=0 instead of value=None

### DIFF
--- a/langfuse/_client/datasets.py
+++ b/langfuse/_client/datasets.py
@@ -286,7 +286,7 @@ class DatasetClient:
 
             def accuracy_evaluator(*, input, output, expected_output=None, **kwargs):
                 if not expected_output:
-                    return {"name": "accuracy", "value": None, "comment": "No expected output"}
+                    return {"name": "accuracy", "value": 0, "comment": "No expected output"}
 
                 is_correct = output.strip().lower() == expected_output.strip().lower()
                 return {

--- a/langfuse/experiment.py
+++ b/langfuse/experiment.py
@@ -719,7 +719,7 @@ class EvaluatorFunction(Protocol):
             ```python
             def accuracy_evaluator(*, input, output, expected_output=None, **kwargs):
                 if expected_output is None:
-                    return {"name": "accuracy", "value": None, "comment": "No expected output"}
+                    return {"name": "accuracy", "value": 0, "comment": "No expected output"}
 
                 is_correct = output.strip().lower() == expected_output.strip().lower()
                 return {
@@ -773,7 +773,7 @@ class EvaluatorFunction(Protocol):
                 except ValueError:
                     return {
                         "name": "llm_judge_quality",
-                        "value": None,
+                        "value": 0,
                         "comment": "Could not parse LLM judge score"
                     }
             ```
@@ -867,7 +867,7 @@ class RunEvaluatorFunction(Protocol):
                             accuracy_values.append(evaluation.value)
 
                 if not accuracy_values:
-                    return {"name": "avg_accuracy", "value": None, "comment": "No accuracy evaluations found"}
+                    return {"name": "avg_accuracy", "value": 0, "comment": "No accuracy evaluations found"}
 
                 avg = sum(accuracy_values) / len(accuracy_values)
                 return {


### PR DESCRIPTION
## Summary

Fixes inconsistency in `Evaluation` class docstring examples where `value=None` was used, which conflicts with the type definition `Union[int, float, str, bool]` that does not allow `None`.

This change aligns with the established pattern from commit d11155e5492b401db227d87e32b587ad31bab7e9 which clarified that Evaluation score values cannot be None.

## Related

- Related to langfuse/langfuse#11925
- Follows the pattern established in d11155e5492b401db227d87e32b587ad31bab7e9
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `Evaluation` docstring examples and related functions to use `value=0` instead of `value=None` in `experiment.py`, aligning with type definitions and previous patterns.
> 
>   - **Behavior**:
>     - Fixes `Evaluation` class docstring examples to use `value=0` instead of `value=None` in `experiment.py`.
>     - Updates `accuracy_evaluator` and `llm_judge_evaluator` functions in `experiment.py` to return `value=0` when no expected output or score parsing fails.
>     - Modifies `average_accuracy` function in `experiment.py` to return `value=0` when no accuracy evaluations are found.
>   - **Misc**:
>     - Aligns with type definition `Union[int, float, str, bool]` and previous commit d11155e5492b401db227d87e32b587ad31bab7e9.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for e057f24bb50503ce967740141b509a75eb4c2f25. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates docstring examples for evaluator return values to use `value=0` instead of `value=None` in `langfuse/experiment.py` and `langfuse/_client/datasets.py`. This aligns the documentation with the SDK’s `Evaluation.value` type (`Union[int, float, str, bool]`) and avoids showing examples that would violate the declared type.

No runtime behavior changes were introduced; only example snippets in protocol/docstrings were adjusted.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to docstring/example snippets and align examples with the declared Evaluation value type; no functional logic or imports were modified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_client/datasets.py | Docstring example in DatasetClient.run_experiment updated to use value=0 instead of None for accuracy_evaluator, matching Evaluation value type constraints. |
| langfuse/experiment.py | Evaluation-related docstring examples updated to use value=0 instead of None in evaluator examples, aligning with Evaluation.value type and existing patterns; no functional code changes. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DatasetClient as DatasetClient.run_experiment
    participant Langfuse as Langfuse.run_experiment
    participant Task as task(item)
    participant Eval as evaluator(input, output, expected_output)
    participant RunEval as run_evaluator(item_results)

    User->>DatasetClient: run_experiment(name, task, evaluators, run_evaluators)
    DatasetClient->>Langfuse: run_experiment(data=items, ...)

    loop For each dataset item
        Languse->>Task: execute task(item)
        Task-->>Langfuse: output
        Langfuse->>Eval: evaluate(input, output, expected_output)
        Eval-->>Langfuse: {name, value=0 on missing expected/parse fail}
    end

    Langfuse->>RunEval: compute aggregates across item_results
    RunEval-->>Langfuse: {name, value=0 if no accuracy evaluations}
    Langfuse-->>User: ExperimentResult (item_results, run_evaluations)
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->