### PR TITLE
fix(openai): parse usage details from response API response chunk

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -591,7 +591,8 @@ def _extract_streamed_response_api_response(chunks: Any) -> Any:
     for raw_chunk in chunks:
         chunk = raw_chunk.__dict__
         if raw_response := chunk.get("response", None):
-            usage = chunk.get("usage", None)
+            usage = chunk.get("usage", None) or getattr(raw_response, "usage", None)
+
             response = raw_response.__dict__
             model = response.get("model")
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes parsing of `usage` details in `_extract_streamed_response_api_response()` in `openai.py` to ensure complete data extraction.
> 
>   - **Behavior**:
>     - Fixes parsing of `usage` details in `_extract_streamed_response_api_response()` in `openai.py`.
>     - Now retrieves `usage` from `raw_response.usage` if not present in `chunk`.
>   - **Misc**:
>     - Minor change to ensure complete usage data extraction from API response chunks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for fc947dcebf4e2be0c68af2e0baf27e90569be716. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Fixes missing usage data in streamed Response API responses by adding a fallback to retrieve usage from `raw_response.usage` when not present in the chunk dictionary.

- Previously, usage data would be `None` if only available on the `raw_response` object rather than in the chunk's `__dict__`
- The fix uses the `or` operator to check `raw_response.usage` as a fallback, ensuring usage metrics are captured correctly
- This is a minimal, focused fix that follows the existing pattern of using `getattr()` for object attribute access elsewhere in the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a simple bug fix that adds a fallback for data extraction
- The change is a straightforward one-line fix that adds a fallback mechanism to retrieve usage data. It follows existing patterns in the codebase (using `getattr()` and the `or` operator), doesn't introduce new dependencies, and only affects the specific function handling streamed Response API responses. The logic is sound and the change is minimal.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/openai.py | Added fallback to retrieve usage from `raw_response.usage` when not present in chunk dictionary - ensures complete usage data extraction from streamed Response API responses |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Iterate through chunks] --> B{raw_response exists in chunk?}
    B -->|No| A
    B -->|Yes| C[Try to get usage from chunk dict]
    C --> D{usage found in chunk?}
    D -->|Yes| E[Use chunk usage]
    D -->|No| F[Fallback: get usage from raw_response.usage]
    E --> G[Continue processing]
    F --> G
    G --> H[Extract model, output, metadata]
    H --> I[Return model, completion, usage, metadata]
```

<sub>Last reviewed commit: fc947dc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->