### PR TITLE
fix(openai): parse finish_reason from chat completion stream

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -614,7 +614,7 @@ def _extract_streamed_response_api_response(chunks: Any) -> Any:
 
 def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
     completion: Any = defaultdict(lambda: None) if resource.type == "chat" else ""
-    model, usage = None, None
+    model, usage, finish_reason = None, None, None
 
     for chunk in chunks:
         if _is_openai_v1():
@@ -630,6 +630,7 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                 choice = choice.__dict__
             if resource.type == "chat":
                 delta = choice.get("delta", None)
+                finish_reason = choice.get("finish_reason", None)
 
                 if _is_openai_v1():
                     delta = delta.__dict__
@@ -728,7 +729,7 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
         model,
         get_response_for_chat() if resource.type == "chat" else completion,
         usage,
-        None,
+        {"finish_reason": finish_reason} if finish_reason is not None else None,
     )
 
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Parse `finish_reason` from chat completion streams in `_extract_streamed_openai_response()` and include it in metadata if present.
> 
>   - **Behavior**:
>     - Parse `finish_reason` from chat completion streams in `_extract_streamed_openai_response()` in `openai.py`.
>     - Include `finish_reason` in returned metadata if not `None`.
>   - **Functions**:
>     - Modify `_extract_streamed_openai_response()` to capture `finish_reason` from `choices` in response chunks.
>   - **Misc**:
>     - Adjust return statement in `_extract_streamed_openai_response()` to include `finish_reason` in metadata.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for a4f65bad0fb23efcdd3371f2b0861663a733000d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR extracts `finish_reason` from streamed OpenAI chat completion responses and passes it as metadata to the Langfuse generation update. Previously, the 4th tuple element returned by `_extract_streamed_openai_response` was hardcoded to `None`, meaning `finish_reason` was lost during streaming. Now it is captured per-choice and wrapped in a metadata dict `{"finish_reason": finish_reason}`.

- Adds `finish_reason` variable tracking in `_extract_streamed_openai_response`
- Extracts `finish_reason` from each streamed choice (chat type only)
- Returns the value as metadata in the function's 4-tuple return, consistent with how `_extract_streamed_response_api_response` returns metadata
- Only applies to chat completions, not legacy completion or embedding types

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a small, well-scoped feature to capture finish_reason from streamed responses.
- The change is minimal (3 lines), follows existing patterns in the codebase, and only affects streaming metadata. The logic correctly handles the standard OpenAI streaming protocol where finish_reason appears in the final content chunk. One minor consideration: finish_reason could theoretically be overwritten by a subsequent chunk with choices, but this doesn't occur in practice with the OpenAI API. No tests were added, but the change is low risk.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/openai.py | Adds `finish_reason` extraction from streamed chat completion chunks and passes it as metadata. The logic correctly preserves the value from the last chunk with choices, which is the standard behavior for OpenAI streaming. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant OpenAI as OpenAI API
    participant Extract as _extract_streamed_openai_response
    participant Update as _create_langfuse_update
    participant Langfuse as Langfuse Generation

    Client->>OpenAI: Chat completion (stream=True)
    loop For each streamed chunk
        OpenAI-->>Extract: chunk (delta, finish_reason=null)
        Extract->>Extract: Accumulate content
    end
    OpenAI-->>Extract: Final chunk (finish_reason="stop")
    Extract->>Extract: Capture finish_reason
    OpenAI-->>Extract: Usage chunk (choices=[])
    Extract->>Extract: finish_reason preserved (no choices)
    Extract-->>Update: (model, completion, usage, {finish_reason})
    Update->>Langfuse: generation.update(metadata={finish_reason})
```

<sub>Last reviewed commit: a4f65ba</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->