### PR TITLE
fix(experiments): remove dataset version from run item request if None

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -2931,7 +2931,7 @@ class Langfuse:
                                 traceId=trace_id,
                                 observationId=span.id,
                                 datasetVersion=dataset_version,
-                            ),
+                            ).dict(exclude_none=True),
                         )
 
                         dataset_run_id = dataset_run_item.dataset_run_id


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Exclude `None` values from `CreateDatasetRunItemRequest` in `_process_experiment_item()` to prevent unnecessary data in requests.
> 
>   - **Behavior**:
>     - Modify `_process_experiment_item()` in `client.py` to exclude `None` values from `CreateDatasetRunItemRequest` by using `.dict(exclude_none=True)`. This prevents `datasetVersion` from being included if it is `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 826049b4dd11bcb006c6c8412634b3e05b130fbf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes an issue where `None` values were being sent in dataset run item creation requests. The change adds `.dict(exclude_none=True)` when creating `CreateDatasetRunItemRequest` objects, ensuring that when `datasetVersion` is `None`, it is excluded from the API request payload.

**Key Changes:**
- Modified `_process_experiment_item()` in `client.py:2934` to call `.dict(exclude_none=True)` on the `CreateDatasetRunItemRequest` object
- This prevents sending `datasetVersion: None` in the request when no dataset version is specified
- The change is consistent with the Pydantic model's built-in behavior for handling optional fields

**Technical Context:**
- The `CreateDatasetRunItemRequest` model already has a custom `.dict()` method that uses `exclude_none` by default (see `create_dataset_run_item_request.py:51-66`)
- The HTTP client's `jsonable_encoder` properly handles both Pydantic models and dictionaries
- When `dataset_version` parameter is `None` (which is the default), the field should not be included in the API request

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a small, well-scoped fix that improves API request cleanliness by excluding `None` values. The implementation is correct - the HTTP client's `jsonable_encoder` handles dictionaries properly, and the `CreateDatasetRunItemRequest` model already has built-in support for `exclude_none`. No breaking changes or side effects expected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_client/client.py | Adds `.dict(exclude_none=True)` to prevent sending `None` values for `datasetVersion` in dataset run item requests. Change is safe and follows best practices for API request serialization. |

</details>



<sub>Last reviewed commit: 826049b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->