### PR TITLE
fix: shut down media manager thread more quickly

### DIFF
--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -42,10 +42,11 @@ class MediaManager:
     def process_next_media_upload(self) -> None:
         try:
             upload_job = self._queue.get(block=True, timeout=1)
-            self._log.debug(
-                f"Media: Processing upload for media_id={upload_job['media_id']} in trace_id={upload_job['trace_id']}"
-            )
-            self._process_upload_media_job(data=upload_job)
+            if upload_job is not None:
+                self._log.debug(
+                    f"Media: Processing upload for media_id={upload_job['media_id']} in trace_id={upload_job['trace_id']}"
+                )
+                self._process_upload_media_job(data=upload_job)
 
             self._queue.task_done()
         except Empty:
@@ -55,6 +56,12 @@ class MediaManager:
                 f"Media upload error: Failed to upload media due to unexpected error. Queue item marked as done. Error: {e}"
             )
             self._queue.task_done()
+
+    def pause(self) -> None:
+        """
+        Signal the media manager's thread is pausing.
+        """
+        self._queue.put(None)
 
     def _find_and_process_media(
         self,

--- a/langfuse/_task_manager/media_upload_consumer.py
+++ b/langfuse/_task_manager/media_upload_consumer.py
@@ -42,3 +42,4 @@ class MediaUploadConsumer(threading.Thread):
             f"Thread: Pausing media upload consumer thread #{self._identifier}"
         )
         self.running = False
+        self._media_manager.pause()


### PR DESCRIPTION
When `.pause()` is called, a `None` item is posted into the media manager's queue, so there is no timeout of up to 1 second.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `pause()` to `MediaManager` for quicker thread shutdown by inserting `None` into the queue, integrated with `MediaUploadConsumer`.
> 
>   - **Behavior**:
>     - Adds `pause()` method to `MediaManager` to insert `None` into the queue, allowing immediate thread shutdown.
>     - Updates `pause()` in `MediaUploadConsumer` to call `MediaManager.pause()` for quicker shutdown.
>   - **Functions**:
>     - Modifies `process_next_media_upload()` in `media_manager.py` to handle `None` from the queue, skipping processing.
>   - **Misc**:
>     - Minor logging adjustments in `media_upload_consumer.py` for thread pausing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 5f0ddd9d25b401130f174a37d299ee015dd3e400. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Adds graceful shutdown mechanism for media upload threads by inserting sentinel `None` value into queue when `pause()` is called, eliminating up to 1 second wait time on thread shutdown.

**Key changes:**
- Added `MediaManager.pause()` method that puts `None` in queue as shutdown signal
- Updated `process_next_media_upload()` to check for and skip `None` items while still calling `task_done()`
- Integrated `MediaManager.pause()` call in `MediaUploadConsumer.pause()` for immediate wake-up of blocked threads

**Impact:**
Shutdown time reduced from up to 1 second (queue timeout) to near-instant when threads are waiting on empty queue.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration for edge case handling
- The implementation correctly solves the shutdown delay problem using a standard sentinel value pattern. The `None` check is properly placed before accessing dictionary keys, and `task_done()` is correctly called in all paths. One minor concern: multiple `pause()` calls would insert multiple `None` values, but this is harmless as they're all handled correctly.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_task_manager/media_manager.py | Adds `pause()` method to insert `None` into queue for quick shutdown, and updates `process_next_media_upload()` to skip `None` items |
| langfuse/_task_manager/media_upload_consumer.py | Integrates `MediaManager.pause()` call in consumer's `pause()` method to enable quicker thread shutdown |

</details>



<sub>Last reviewed commit: 5f0ddd9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->