### PR TITLE
fix: use httpx for media uploads, like the rest of the library

### DIFF
--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -5,7 +5,7 @@ from queue import Empty, Full, Queue
 from typing import Any, Callable, Optional, TypeVar, cast
 
 import backoff
-import requests
+import httpx
 from typing_extensions import ParamSpec
 
 from langfuse._client.environment_variables import LANGFUSE_MEDIA_UPLOAD_ENABLED
@@ -256,10 +256,10 @@ class MediaManager:
 
         upload_start_time = time.time()
         upload_response = self._request_with_backoff(
-            requests.put,
+            httpx.put,
             upload_url,
             headers=headers,
-            data=data["content_bytes"],
+            content=data["content_bytes"],
         )
         upload_time_ms = int((time.time() - upload_start_time) * 1000)
 
@@ -288,7 +288,7 @@ class MediaManager:
                     and 400 <= e.status_code < 500
                     and e.status_code != 429
                 )
-            if isinstance(e, requests.exceptions.RequestException):
+            if isinstance(e, httpx.HTTPStatusError):
                 return (
                     e.response is not None
                     and e.response.status_code < 500

--- a/langfuse/media.py
+++ b/langfuse/media.py
@@ -7,7 +7,7 @@ import os
 import re
 from typing import TYPE_CHECKING, Any, Literal, Optional, Tuple, TypeVar, cast
 
-import requests
+import httpx
 
 if TYPE_CHECKING:
     from langfuse._client.client import Langfuse
@@ -293,11 +293,10 @@ class LangfuseMedia:
                         media_data = langfuse_client.api.media.get(
                             parsed_media_reference["media_id"]
                         )
-                        media_content = requests.get(
+                        media_content = httpx.get(
                             media_data.url, timeout=content_fetch_timeout_seconds
                         )
-                        if not media_content.ok:
-                            raise Exception("Failed to fetch media content")
+                        media_content.raise_for_status()
 
                         base64_media_content = base64.b64encode(
                             media_content.content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ backoff = ">=1.10.0"
 openai = { version = ">=0.27.8", optional = true }
 wrapt = "^1.14"
 packaging = ">=23.2,<26.0"
-requests = "^2"
 opentelemetry-api = "^1.33.1"
 opentelemetry-sdk = "^1.33.1"
 opentelemetry-exporter-otlp-proto-http = "^1.33.1"


### PR DESCRIPTION
I noticed media uploads were using `requests` instead of `httpx` like the rest of the library.

I think there's a bug in the retry logic (added in #1100) in the media manager though: `requests.put` (or `httpx.put`) will never actually raise a status exception by itself, so the media PUT is never retried. That's out of the scope for this PR though, especially since the media PUT's status code seems to be important for the API call next.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `requests` with `httpx` for media uploads in `media_manager.py` and `media.py`, and remove `requests` from `pyproject.toml`.
> 
>   - **HTTP Client Update**:
>     - Replace `requests` with `httpx` for media uploads in `media_manager.py` and `media.py`.
>     - Change `requests.put` to `httpx.put` and `requests.get` to `httpx.get`.
>     - Use `content` instead of `data` in `httpx.put`.
>   - **Error Handling**:
>     - Replace `requests.exceptions.RequestException` with `httpx.HTTPStatusError` in `_should_give_up()` in `media_manager.py`.
>     - Use `raise_for_status()` instead of checking `ok` in `media.py`.
>   - **Dependencies**:
>     - Remove `requests` from `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 781aa4b6db67a95d887f0fe318dd71ed748e74b3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Replaced `requests` library with `httpx` for media uploads to maintain consistency with the rest of the codebase.

- Changed `requests.put` to `httpx.put` in media manager (with parameter change from `data=` to `content=`)
- Changed `requests.get` to `httpx.get` in media resolution
- Updated exception handling from `requests.exceptions.RequestException` to `httpx.HTTPStatusError`
- Improved error handling in `media.py` by using `raise_for_status()` instead of manual status checks
- Removed `requests` dependency from `pyproject.toml`

The PR correctly migrates all media upload code to use `httpx`, which is already used throughout the library. All imports are properly placed at the top of modules.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward library migration with correct API usage
- The changes are a clean migration from `requests` to `httpx` with all necessary API adjustments made correctly (parameter names, exception types, error handling). The author properly identified and noted the pre-existing retry logic bug but correctly scoped it out of this PR. All changes maintain backward compatibility in behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_task_manager/media_manager.py | Migrated from `requests.put` to `httpx.put`, changed parameter from `data=` to `content=`, and updated exception handling from `requests.exceptions.RequestException` to `httpx.HTTPStatusError` |
| langfuse/media.py | Replaced `requests.get` with `httpx.get` and simplified error handling to use `raise_for_status()` instead of manual `ok` check |
| pyproject.toml | Removed `requests` dependency as it's no longer used anywhere in the codebase |

</details>



<sub>Last reviewed commit: 781aa4b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->