### PR TITLE
fix(media): retry failed uploads

### DIFF
--- a/tests/test_media_manager.py
+++ b/tests/test_media_manager.py
@@ -1,0 +1,80 @@
+from queue import Queue
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from langfuse._task_manager.media_manager import MediaManager
+
+
+def _upload_response(status_code: int, text: str = "") -> httpx.Response:
+    request = httpx.Request("PUT", "https://example.com/upload")
+    return httpx.Response(status_code=status_code, request=request, text=text)
+
+
+def _upload_job() -> dict:
+    return {
+        "media_id": "media-id",
+        "content_bytes": b"payload",
+        "content_type": "image/jpeg",
+        "content_length": 7,
+        "content_sha256_hash": "sha256hash",
+        "trace_id": "trace-id",
+        "observation_id": None,
+        "field": "input",
+    }
+
+
+def test_media_upload_retries_on_retryable_http_status():
+    media_api = Mock()
+    media_api.get_upload_url.return_value = SimpleNamespace(
+        upload_url="https://example.com/upload",
+        media_id="media-id",
+    )
+    media_api.patch.return_value = None
+
+    httpx_client = Mock()
+    httpx_client.put.side_effect = [
+        _upload_response(503, "temporary failure"),
+        _upload_response(200, "ok"),
+    ]
+
+    manager = MediaManager(
+        api_client=SimpleNamespace(media=media_api),
+        httpx_client=httpx_client,
+        media_upload_queue=Queue(),
+        max_retries=3,
+    )
+
+    manager._process_upload_media_job(data=_upload_job())
+
+    assert httpx_client.put.call_count == 2
+    media_api.patch.assert_called_once()
+    assert media_api.patch.call_args.kwargs["upload_http_status"] == 200
+
+
+def test_media_upload_gives_up_on_non_retryable_http_status():
+    media_api = Mock()
+    media_api.get_upload_url.return_value = SimpleNamespace(
+        upload_url="https://example.com/upload",
+        media_id="media-id",
+    )
+    media_api.patch.return_value = None
+
+    httpx_client = Mock()
+    httpx_client.put.return_value = _upload_response(403, "forbidden")
+
+    manager = MediaManager(
+        api_client=SimpleNamespace(media=media_api),
+        httpx_client=httpx_client,
+        media_upload_queue=Queue(),
+        max_retries=3,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        manager._process_upload_media_job(data=_upload_job())
+
+    assert httpx_client.put.call_count == 1
+    media_api.patch.assert_called_once()
+    assert media_api.patch.call_args.kwargs["upload_http_status"] == 403


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add retry mechanism for failed media uploads in `MediaManager` with tests for retryable and non-retryable HTTP statuses.
> 
>   - **Behavior**:
>     - Add retry mechanism for failed media uploads in `MediaManager`.
>     - Introduce `_upload_with_status_check` function in `media_manager.py` to handle upload and status check.
>     - Update `_process_upload_media_job` to use `_upload_with_status_check` with backoff strategy.
>     - Log failed upload attempts and retry if status is retryable.
>   - **Tests**:
>     - Add `test_media_upload_retries_on_retryable_http_status` in `test_media_manager.py` to verify retry on 503 status.
>     - Add `test_media_upload_gives_up_on_non_retryable_http_status` in `test_media_manager.py` to verify no retry on 403 status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for bc20c1a3ac539579777466cf3297b1c5e52b6e80. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Added retry mechanism for failed media uploads with proper error tracking. The implementation wraps the upload operation in `_upload_with_status_check` which calls `raise_for_status()` to ensure HTTP errors are properly caught. Failed uploads are now logged via the `media.patch` API before the exception is re-raised, ensuring visibility into upload failures even when retries are exhausted.

- Introduced `_upload_with_status_check` function that performs the upload and validates HTTP status
- Updated error handling to log failed uploads via `media.patch` API with status code, error message, and timing
- Leverages existing `_request_with_backoff` retry logic which retries 5xx errors and 429, but gives up on other 4xx errors
- Added comprehensive tests verifying retry behavior for retryable (503) and non-retryable (403) status codes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-structured and properly tested. The retry logic leverages the existing `_request_with_backoff` mechanism which already has proper retry/giveup logic for different HTTP status codes. The addition of error logging via `media.patch` ensures visibility into upload failures. The comprehensive tests verify both retryable and non-retryable scenarios, confirming the implementation works as expected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_task_manager/media_manager.py | Added retry logic for failed uploads with proper error logging via `media.patch` API call |
| tests/test_media_manager.py | New test file with comprehensive coverage for retryable (503) and non-retryable (403) HTTP status scenarios |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start Upload] --> B[Call _upload_with_status_check]
    B --> C[HTTP PUT to upload_url]
    C --> D[Call raise_for_status]
    D --> E{Status OK?}
    E -->|2xx| F[Return Response]
    E -->|Error| G[Raise HTTPStatusError]
    G --> H{Retryable?}
    H -->|5xx or 429| I[Backoff Retry]
    I --> B
    H -->|4xx except 429| J[Catch in Exception Handler]
    F --> K[Log Success via media.patch]
    J --> L[Log Failure via media.patch]
    L --> M[Re-raise Exception]
    K --> N[Complete]
    M --> O[Error Logged & Propagated]
```

<sub>Last reviewed commit: bc20c1a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->