### PR TITLE
fix(experiment): replace escaped newlines with actual newlines in format output

### DIFF
--- a/langfuse/experiment.py
+++ b/langfuse/experiment.py
@@ -458,7 +458,7 @@ class ExperimentResult:
 
             # Or create summary report
             summary = result.format()  # Aggregate view only
-            print(f"Experiment Summary:\\n{summary}")
+            print(f"Experiment Summary:\n{summary}")
             ```
 
             Integration with logging systems:
@@ -467,11 +467,11 @@ class ExperimentResult:
             logger = logging.getLogger("experiments")
 
             # Log summary after experiment
-            logger.info(f"Experiment completed:\\n{result.format()}")
+            logger.info(f"Experiment completed:\n{result.format()}")
 
             # Log detailed results for failed experiments
             if any(eval['value'] < threshold for eval in result.run_evaluations):
-                logger.warning(f"Poor performance detected:\\n{result.format(include_item_results=True)}")
+                logger.warning(f"Poor performance detected:\n{result.format(include_item_results=True)}")
             ```
         """
         if not self.item_results:
@@ -482,7 +482,7 @@ class ExperimentResult:
         # Individual results section
         if include_item_results:
             for i, result in enumerate(self.item_results):
-                output += f"\\n{i + 1}. Item {i + 1}:\\n"
+                output += f"\n{i + 1}. Item {i + 1}:\n"
 
                 # Extract and display input
                 item_input = None
@@ -492,7 +492,7 @@ class ExperimentResult:
                     item_input = result.item.input
 
                 if item_input is not None:
-                    output += f"   Input:    {_format_value(item_input)}\\n"
+                    output += f"   Input:    {_format_value(item_input)}\n"
 
                 # Extract and display expected output
                 expected_output = None
@@ -502,36 +502,36 @@ class ExperimentResult:
                     expected_output = result.item.expected_output
 
                 if expected_output is not None:
-                    output += f"   Expected: {_format_value(expected_output)}\\n"
-                output += f"   Actual:   {_format_value(result.output)}\\n"
+                    output += f"   Expected: {_format_value(expected_output)}\n"
+                output += f"   Actual:   {_format_value(result.output)}\n"
 
                 # Display evaluation scores
                 if result.evaluations:
-                    output += "   Scores:\\n"
+                    output += "   Scores:\n"
                     for evaluation in result.evaluations:
                         score = evaluation.value
                         if isinstance(score, (int, float)):
                             score = f"{score:.3f}"
                         output += f"     • {evaluation.name}: {score}"
                         if evaluation.comment:
-                            output += f"\\n       💭 {evaluation.comment}"
-                        output += "\\n"
+                            output += f"\n       💭 {evaluation.comment}"
+                        output += "\n"
 
                 # Display trace link if available
                 if result.trace_id:
-                    output += f"\\n   Trace ID: {result.trace_id}\\n"
+                    output += f"\n   Trace ID: {result.trace_id}\n"
         else:
-            output += f"Individual Results: Hidden ({len(self.item_results)} items)\\n"
-            output += "💡 Set include_item_results=True to view them\\n"
+            output += f"Individual Results: Hidden ({len(self.item_results)} items)\n"
+            output += "💡 Set include_item_results=True to view them\n"
 
         # Experiment overview section
-        output += f"\\n{'─' * 50}\\n"
+        output += f"\n{'─' * 50}\n"
         output += f"🧪 Experiment: {self.name}"
         output += f"\n📋 Run name: {self.run_name}"
         if self.description:
             output += f" - {self.description}"
 
-        output += f"\\n{len(self.item_results)} items"
+        output += f"\n{len(self.item_results)} items"
 
         # Collect unique evaluation names across all items
         evaluation_names = set()
@@ -540,14 +540,14 @@ class ExperimentResult:
                 evaluation_names.add(evaluation.name)
 
         if evaluation_names:
-            output += "\\nEvaluations:"
+            output += "\nEvaluations:"
             for eval_name in evaluation_names:
-                output += f"\\n  • {eval_name}"
-            output += "\\n"
+                output += f"\n  • {eval_name}"
+            output += "\n"
 
         # Calculate and display average scores
         if evaluation_names:
-            output += "\\nAverage Scores:"
+            output += "\nAverage Scores:"
             for eval_name in evaluation_names:
                 scores = []
                 for result in self.item_results:
@@ -559,24 +559,24 @@ class ExperimentResult:
 
                 if scores:
                     avg = sum(scores) / len(scores)
-                    output += f"\\n  • {eval_name}: {avg:.3f}"
-            output += "\\n"
+                    output += f"\n  • {eval_name}: {avg:.3f}"
+            output += "\n"
 
         # Display run-level evaluations
         if self.run_evaluations:
-            output += "\\nRun Evaluations:"
+            output += "\nRun Evaluations:"
             for run_eval in self.run_evaluations:
                 score = run_eval.value
                 if isinstance(score, (int, float)):
                     score = f"{score:.3f}"
-                output += f"\\n  • {run_eval.name}: {score}"
+                output += f"\n  • {run_eval.name}: {score}"
                 if run_eval.comment:
-                    output += f"\\n    💭 {run_eval.comment}"
-            output += "\\n"
+                    output += f"\n    💭 {run_eval.comment}"
+            output += "\n"
 
         # Add dataset run URL if available
         if self.dataset_run_url:
-            output += f"\\n🔗 Dataset Run:\\n   {self.dataset_run_url}"
+            output += f"\n🔗 Dataset Run:\n   {self.dataset_run_url}"
 
         return output
 


### PR DESCRIPTION
## Summary

Fixes langfuse/langfuse#10869

The `ExperimentResult.format()` method and related logging calls used double-escaped newlines (`\\\\n`) instead of proper newline escapes (`\\n`), causing the formatted output to display literal `\n` characters rather than actual line breaks.

## Changes

- Replaced all 27 occurrences of `\\\\n` with `\\n` in `langfuse/experiment.py`
  - 24 in `ExperimentResult.format()` method
  - 3 in related logging calls (`print()`, `logger.info()`, `logger.warning()`)

## Before

```
🧪 Experiment Summary:\n─────────\n1. Item 1:\n   Input:    hello\n   Actual:   world\n
```

## After

```
🧪 Experiment Summary:
─────────
1. Item 1:
   Input:    hello
   Actual:   world
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes newline formatting in `ExperimentResult.format()` and related logging calls in `langfuse/experiment.py`.
> 
>   - **Behavior**:
>     - Fixes `ExperimentResult.format()` in `langfuse/experiment.py` to use `\n` instead of `\\n` for newlines, ensuring proper line breaks.
>     - Updates 3 logging calls (`print()`, `logger.info()`, `logger.warning()`) to use `\n` for newlines.
>   - **Misc**:
>     - Replaces 27 occurrences of `\\n` with `\n` in `langfuse/experiment.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 9b49ca9712ee4360b7363cc88c886e8b43f86bae. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a formatting bug in the `ExperimentResult.format()` method where escaped newlines (`\\n`) were displaying as literal "\n" characters instead of actual line breaks. The fix replaces all 27 occurrences of `\\n` with `\n` in `langfuse/experiment.py`:

- 24 replacements in the `format()` method implementation
- 3 replacements in docstring examples (`print()`, `logger.info()`, `logger.warning()`)

The change is straightforward and correct - the original code was producing strings with visible "\n" characters, while the fixed code produces proper line breaks for human-readable output.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are purely cosmetic bug fixes that replace incorrect escape sequences with correct ones. The fix is localized to a single formatting method, has no logic changes, and corrects an obvious bug where literal '\n' characters were displayed instead of actual newlines.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/experiment.py | Fixed newline formatting bug by replacing escaped newlines (`\\n`) with actual newlines (`\n`) throughout the format() method - straightforward bug fix |

</details>



<sub>Last reviewed commit: 9b49ca9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->