### PR TITLE
feat(serializer): set ensure_ascii=False by default for Unicode support

### DIFF
--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import enum
 import math
+import os
 from asyncio import Queue
 from collections.abc import Sequence
 from dataclasses import asdict, is_dataclass
@@ -38,6 +39,9 @@ logger = getLogger(__name__)
 class EventSerializer(JSONEncoder):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self.ensure_ascii = os.environ.get(
+            "LANGFUSE_ENSURE_ASCII", "false"
+        ).lower() in ("true", "1", "yes")
         self.seen: set[int] = set()  # Track seen objects to detect circular references
 
     def default(self, obj: Any) -> Any:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -174,3 +174,19 @@ def test_slots():
     obj = SlotClass()
     serializer = EventSerializer()
     assert json.loads(serializer.encode(obj)) == {"field": "value"}
+
+
+def test_unicode_not_escaped_by_default():
+    """Non-ASCII characters should be preserved by default (ensure_ascii=False)."""
+    serializer = EventSerializer()
+    result = serializer.encode({"message": "你好世界"})
+    assert "你好世界" in result
+    assert "\\u" not in result
+
+
+def test_unicode_escaped_with_env_var(monkeypatch):
+    """When LANGFUSE_ENSURE_ASCII=true, non-ASCII characters should be escaped."""
+    monkeypatch.setenv("LANGFUSE_ENSURE_ASCII", "true")
+    serializer = EventSerializer()
+    result = serializer.encode({"message": "你好世界"})
+    assert "\\u" in result


### PR DESCRIPTION
## Summary

Fixes langfuse/langfuse#10972

The `EventSerializer` now preserves non-ASCII characters (Chinese, Japanese, emoji, etc.) in JSON output instead of escaping them as `\uXXXX` sequences.

## Changes

- **`langfuse/_utils/serializer.py`**: Override `ensure_ascii` to `False` after `JSONEncoder.__init__()`, controlled by the `LANGFUSE_ENSURE_ASCII` environment variable (defaults to `false`)
- **`tests/test_serializer.py`**: Added 2 tests for Unicode preservation and env var override

## Before

```
{"message": "\u4f60\u597d\u4e16\u754c"}
```

## After

```
{"message": "你好世界"}
```

## Configuration

To restore the old behavior: `LANGFUSE_ENSURE_ASCII=true`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `EventSerializer` now preserves Unicode characters in JSON output by default, with an option to escape them using an environment variable.
> 
>   - **Behavior**:
>     - `EventSerializer` in `serializer.py` now sets `ensure_ascii=False` by default, preserving Unicode characters in JSON output.
>     - Controlled by `LANGFUSE_ENSURE_ASCII` environment variable; set to `true` to escape Unicode.
>   - **Tests**:
>     - Added `test_unicode_not_escaped_by_default` in `test_serializer.py` to verify Unicode preservation.
>     - Added `test_unicode_escaped_with_env_var` in `test_serializer.py` to verify environment variable override.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 5c16576d4f91d8cd22414810be45326f68ce4897. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Changed `EventSerializer` to preserve Unicode characters by default instead of escaping them as `\uXXXX` sequences. The behavior is controlled by the `LANGFUSE_ENSURE_ASCII` environment variable (defaults to `false` for Unicode preservation).

- Implementation correctly overrides `ensure_ascii` after parent initialization
- `import os` added at module top (compliant with code organization standards)
- Tests verify both default Unicode preservation and env var override functionality
- Backwards compatibility maintained via `LANGFUSE_ENSURE_ASCII=true` setting

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The implementation is straightforward and correct, with comprehensive test coverage for both the new default behavior and env var override. The change is backwards compatible, follows coding standards, and introduces no security or logical issues
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/_utils/serializer.py | Sets `ensure_ascii=False` by default for Unicode preservation, controlled by `LANGFUSE_ENSURE_ASCII` env var |
| tests/test_serializer.py | Added comprehensive tests for Unicode preservation default behavior and env var override |

</details>



<sub>Last reviewed commit: 5c16576</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->