### PR TITLE
fix(langchain): skip priority-tier keys when subtracting token detail counts

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -1189,6 +1189,10 @@ def _parse_usage_model(usage: Union[pydantic.BaseModel, dict]) -> Any:
             for key, value in input_token_details.items():
                 usage_model[f"input_{key}"] = value
 
+                # Skip priority-tier keys as they are not exclusive sub-categories
+                if key == "priority" or key.startswith("priority_"):
+                    continue
+
                 if "input" in usage_model:
                     usage_model["input"] = max(0, usage_model["input"] - value)
 
@@ -1197,6 +1201,10 @@ def _parse_usage_model(usage: Union[pydantic.BaseModel, dict]) -> Any:
 
             for key, value in output_token_details.items():
                 usage_model[f"output_{key}"] = value
+
+                # Skip priority-tier keys as they are not exclusive sub-categories
+                if key == "priority" or key.startswith("priority_"):
+                    continue
 
                 if "output" in usage_model:
                     usage_model["output"] = max(0, usage_model["output"] - value)

--- a/tests/test_parse_usage_model.py
+++ b/tests/test_parse_usage_model.py
@@ -1,0 +1,34 @@
+from langfuse.langchain.CallbackHandler import _parse_usage_model
+
+
+def test_standard_tier_input_token_details():
+    """Standard tier: audio and cache_read are subtracted from input."""
+    usage = {
+        "input_tokens": 13,
+        "output_tokens": 1,
+        "total_tokens": 14,
+        "input_token_details": {"audio": 0, "cache_read": 3},
+        "output_token_details": {"audio": 0},
+    }
+    result = _parse_usage_model(usage)
+    assert result["input"] == 10  # 13 - 0 (audio) - 3 (cache_read)
+    assert result["output"] == 1  # 1 - 0 (audio)
+    assert result["total"] == 14
+
+
+def test_priority_tier_not_subtracted():
+    """Priority tier: 'priority' and 'priority_*' keys must NOT be subtracted."""
+    usage = {
+        "input_tokens": 13,
+        "output_tokens": 1,
+        "total_tokens": 14,
+        "input_token_details": {"audio": 0, "priority_cache_read": 0, "priority": 13},
+        "output_token_details": {"audio": 0, "priority_reasoning": 0, "priority": 1},
+    }
+    result = _parse_usage_model(usage)
+    assert result["input"] == 13  # priority keys not subtracted
+    assert result["output"] == 1
+    assert result["total"] == 14
+    # Priority keys are still stored with prefixed names
+    assert result["input_priority"] == 13
+    assert result["output_priority"] == 1


### PR DESCRIPTION
## Summary

Fixes langfuse/langfuse#11896

When using OpenAI models with `service_tier="priority"`, LangChain's `AIMessage.usage_metadata` includes extra keys like `priority` and `priority_cache_read` in `input_token_details`/`output_token_details`. The `_parse_usage_model` function subtracted **all** keys from the total, including these priority-tier metadata keys, which zeroed out token counts and resulted in $0 cost.

## Changes

- **`langfuse/langchain/CallbackHandler.py`**: Skip keys that are exactly `"priority"` or start with `"priority_"` when subtracting token detail values from the total
- **`tests/test_parse_usage_model.py`**: Added tests for standard tier (subtraction works correctly) and priority tier (priority keys not subtracted)

## Before

```
input_token_details: {audio: 0, priority_cache_read: 0, priority: 13}
→ input = 13 - 0 - 0 - 13 = 0  ❌
```

## After

```
input_token_details: {audio: 0, priority_cache_read: 0, priority: 13}
→ input = 13 - 0 = 13  ✅
(priority and priority_cache_read skipped)
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `_parse_usage_model` to skip priority-tier keys when subtracting token details, preventing zeroed token counts.
> 
>   - **Behavior**:
>     - Fixes `_parse_usage_model` in `CallbackHandler.py` to skip keys "priority" and those starting with "priority_" when subtracting token details.
>     - Ensures token counts are not zeroed out due to priority-tier keys.
>   - **Tests**:
>     - Adds `test_standard_tier_input_token_details()` and `test_priority_tier_not_subtracted()` in `test_parse_usage_model.py` to verify correct subtraction behavior for standard and priority tiers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for 47b1df36b4f5ae0a6baaf1973fb2f268f08dcc44. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Fixes critical bug in `_parse_usage_model` where OpenAI priority-tier metadata keys were incorrectly subtracted from token totals, causing $0 cost calculations.

**Key Changes:**
- Skip `priority` and `priority_*` keys in token detail subtraction logic (they represent tier metadata, not exclusive token subcategories)
- Preserve priority key values in output (e.g., `input_priority`) for observability
- Add comprehensive tests verifying both standard and priority tier behavior

**Technical Context:**
When `service_tier="priority"`, OpenAI's API returns keys like `priority: 13` in `input_token_details`. These represent the total tokens used in priority tier, not a subset. Previously, the code subtracted ALL detail keys from totals (13 - 13 = 0), incorrectly zeroing out token counts.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted bug fix with comprehensive test coverage
- Minimal, well-tested change that fixes a critical cost calculation bug. The logic is straightforward (skip priority keys during subtraction), properly tested with both standard and priority tier scenarios, and doesn't affect existing functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| langfuse/langchain/CallbackHandler.py | Added logic to skip priority-tier keys (`priority` and `priority_*`) when subtracting token detail counts, fixing the bug where token counts were incorrectly zeroed out |
| tests/test_parse_usage_model.py | New test file with comprehensive tests for standard tier (verifies subtraction works) and priority tier (verifies priority keys are not subtracted) |

</details>



<sub>Last reviewed commit: 47b1df3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->