### PR TITLE
Use iscoroutinefunction from inspect

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -195,7 +195,7 @@ class LangfuseDecorator:
                     capture_output=should_capture_output,
                     transform_to_string=transform_to_string,
                 )
-                if asyncio.iscoroutinefunction(func)
+                if inspect.iscoroutinefunction(func)
                 else self._sync_observe(
                     func,
                     name=name,


### PR DESCRIPTION
`iscoroutinefunction` in `asyncio` is deprecated and it should be imported from `inspect` instead. In python 3.14, this the use of this function raises deprecation warnings. The function was added to `inspect` in python 3.5  so this change should be backwards compatible with previous python versions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in `langfuse/_client/observe.py` for Python 3.14 compatibility.
> 
>   - **Behavior**:
>     - Replace `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in `decorator()` in `langfuse/_client/observe.py` to avoid deprecation warnings in Python 3.14.
>   - **Compatibility**:
>     - Backward compatible with Python 3.5 and later.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-python&utm_source=github&utm_medium=referral)<sup> for bd0adbbade447790c49108762bc3dfa996dd0ea0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR replaces the deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in the decorator dispatch logic of `LangfuseDecorator`. The change is correct and forward-compatible — `inspect.iscoroutinefunction` has been available since Python 3.5, and `inspect` is already imported at the top of the module. The `asyncio` import is preserved because it is still needed for `asyncio.create_task` elsewhere in the file.

- **Single line changed** in `langfuse/_client/observe.py` (line 198): `asyncio.iscoroutinefunction(func)` → `inspect.iscoroutinefunction(func)`
- **No import changes required**: `inspect` is already imported at line 3; `asyncio` remains necessary for other usages
- **Backwards compatible**: `inspect.iscoroutinefunction` is available since Python 3.5, covering all supported versions
- **Addresses deprecation warning** introduced in Python 3.14 for `asyncio.iscoroutinefunction`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, semantically equivalent substitution that resolves a Python 3.14 deprecation warning.
- The change is a one-line swap between two functions with identical semantics. Both modules are already imported at the top of the file, no new dependencies are introduced, and the `asyncio` import is correctly kept because it is still used elsewhere in the file. There are no logic, safety, or compatibility concerns. The change is backwards compatible with Python 3.5+.
- No files require special attention

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["observe() decorator called with func"] --> B{"inspect.iscoroutinefunction(func)?"}
    B -- "True (async func)" --> C["self._async_observe(func, ...)"]
    B -- "False (sync func)" --> D["self._sync_observe(func, ...)"]
    C --> E["Returns async-wrapped decorator"]
    D --> F["Returns sync-wrapped decorator"]
```

<sub>Last reviewed commit: bd0adbb</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->