### PR TITLE
fix: coerce non-string metadata values instead of dropping them

### DIFF
--- a/langfuse/_client/propagation.py
+++ b/langfuse/_client/propagation.py
@@ -253,8 +253,12 @@ def _propagate_attributes(
         validated_metadata: Dict[str, str] = {}
 
         for key, value in metadata.items():
-            if _validate_string_value(value=value, key=f"metadata.{key}"):
-                validated_metadata[key] = value
+            # Coerce non-string values to strings per v3→v4 migration guide
+            # (LangGraph injects int/list/tuple metadata like langgraph_step)
+            str_value = str(value) if not isinstance(value, str) else value
+
+            if _validate_string_value(value=str_value, key=f"metadata.{key}"):
+                validated_metadata[key] = str_value
 
         if validated_metadata:
             context = _set_propagated_attribute(

--- a/tests/test_propagate_attributes.py
+++ b/tests/test_propagate_attributes.py
@@ -842,6 +842,52 @@ class TestPropagateAttributesEdgeCases(TestPropagateAttributesBase):
             child_span, f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.key2"
         )
 
+    def test_non_string_metadata_values_coerced(
+        self, langfuse_client, memory_exporter
+    ):
+        """Verify non-string metadata values are coerced to strings, not dropped.
+
+        LangGraph injects int/list/tuple metadata (langgraph_step, langgraph_triggers,
+        langgraph_path) which should be coerced per the v3->v4 migration guide.
+        See: https://github.com/langfuse/langfuse-python/issues/1571
+        """
+        with langfuse_client.start_as_current_observation(name="parent-span"):
+            with propagate_attributes(
+                metadata={
+                    "langgraph_step": 3,
+                    "langgraph_triggers": ["start:__start__"],
+                    "langgraph_path": ("__pregel_pull", "agent"),
+                    "string_key": "normal_value",
+                }
+            ):
+                child = langfuse_client.start_observation(name="child-span")
+                child.end()
+
+        child_span = self.get_span_by_name(memory_exporter, "child-span")
+
+        # Non-string values should be coerced to strings
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.langgraph_step",
+            "3",
+        )
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.langgraph_triggers",
+            "['start:__start__']",
+        )
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.langgraph_path",
+            "('__pregel_pull', 'agent')",
+        )
+        # String values should pass through unchanged
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.string_key",
+            "normal_value",
+        )
+
     def test_propagate_with_no_active_span(self, langfuse_client, memory_exporter):
         """Verify propagate_attributes works even with no active span."""
         # Call propagate_attributes without creating a parent span first


### PR DESCRIPTION
## Summary

- Coerce non-string metadata values via `str()` in `_propagate_attributes` instead of dropping them with a warning
- Matches the documented behavior in the v3→v4 migration guide: "Non-string values are automatically coerced to strings"
- Fixes noisy warnings when using LangGraph, which injects `langgraph_step` (int), `langgraph_triggers` (list), `langgraph_path` (tuple) into metadata on every graph step

## Changes

- `langfuse/_client/propagation.py`: Convert non-string metadata values to strings before validation (3-line change)
- `tests/test_propagate_attributes.py`: Add test for non-string metadata coercion with LangGraph-style metadata types

## Test plan

- [ ] New test `test_non_string_metadata_values_coerced` verifies int/list/tuple metadata is coerced to strings
- [ ] Existing tests should continue to pass (string values unchanged, over-200-char values still dropped)

Fixes #1571

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a noisy-warning regression introduced in the v3→v4 migration by coercing non-string metadata values to strings instead of dropping them. The change is minimal and well-targeted: a single `str(value) if not isinstance(value, str) else value` guard in `_propagate_attributes` ensures LangGraph-injected metadata (`langgraph_step: int`, `langgraph_triggers: list`, `langgraph_path: tuple`) flows through rather than being silently discarded.

**Key changes:**
- `langfuse/_client/propagation.py`: Coerce non-string metadata values before calling `_validate_string_value`, matching the v3→v4 migration guide's "Non-string values are automatically coerced to strings" promise.
- `tests/test_propagate_attributes.py`: New test `test_non_string_metadata_values_coerced` validates all three LangGraph metadata types (int, list, tuple) as well as string pass-through.

**Minor follow-ups worth addressing:**
- The public `propagate_attributes` signature still declares `metadata: Optional[Dict[str, str]]`; updating it to `Optional[Dict[str, Any]]` would prevent spurious type-checker errors for callers passing LangGraph metadata.
- The docstring Note still says metadata values "must be strings", which contradicts the new behavior.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; the fix is a targeted 3-line change with a clear motivation, correct logic, and adequate test coverage.
- The core logic change is minimal and correct — coercing before validation rather than dropping. The two remaining items (type annotation and docstring) are non-blocking style/doc cleanups that don't affect runtime behavior. No existing tests are broken and the new test covers the intended cases.
- No files require special attention beyond the minor type annotation and docstring updates noted above.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| langfuse/_client/propagation.py | Core fix coerces non-string metadata values via str() before validation. Logic is correct and minimal. Two minor follow-ups: the public function's type annotation (Dict[str, str]) and the docstring Note no longer match the new behavior. |
| tests/test_propagate_attributes.py | New test covers int, list, and tuple coercion with realistic LangGraph metadata keys, and verifies string values pass through unchanged. Adequate coverage for the change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["propagate_attributes(metadata=...)"] --> B{"metadata is not None?"}
    B -- No --> G["Skip metadata block"]
    B -- Yes --> C["Iterate key, value in metadata.items()"]
    C --> D{"isinstance(value, str)"}
    D -- Yes --> E["str_value = value"]
    D -- No --> F["str_value = str(value) — NEW: coerce"]
    E --> H{"len(str_value) <= 200"}
    F --> H
    H -- Pass --> I["validated_metadata[key] = str_value"]
    H -- Fail --> J["warn + drop value"]
    I --> K["_set_propagated_attribute with validated_metadata"]
```

<sub>Reviews (1): Last reviewed commit: ["fix: coerce non-string metadata values i..."](https://github.com/langfuse/langfuse-python/commit/2ac10d8244b21be4f2d6a9d06a7e1b83a57c81ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26280120)</sub>

<!-- /greptile_comment -->