### PR TITLE
fix(core): support pydantic v2 on Python 3.14

### DIFF
--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -7,23 +7,33 @@ from asyncio import Queue
 from collections.abc import Sequence
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime
+from functools import lru_cache
 from json import JSONEncoder
 from logging import getLogger
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional, Type
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from langfuse.media import LangfuseMedia
 
-# Attempt to import Serializable
-try:
-    from langchain_core.load.serializable import Serializable
-except ImportError:
-    # If Serializable is not available, set it to a placeholder type
-    class Serializable:  # type: ignore
-        pass
+
+@lru_cache(maxsize=1)
+def _get_langchain_serializable_type() -> Optional[Type[Any]]:
+    """Best-effort lookup of LangChain's Serializable base class.
+
+    Import lazily to avoid import-time side effects from optional langchain
+    dependencies, including Python 3.14 warning-as-error failures triggered by
+    transitive `pydantic.v1` imports.
+    """
+
+    try:
+        from langchain_core.load.serializable import Serializable
+
+        return Serializable
+    except Exception:
+        return None
 
 
 # Attempt to import numpy
@@ -109,8 +119,8 @@ class EventSerializer(JSONEncoder):
             if isinstance(obj, Path):
                 return str(obj)
 
-            # if langchain is not available, the Serializable type is NoneType
-            if Serializable is not type(None) and isinstance(obj, Serializable):  # type: ignore
+            serializable_type = _get_langchain_serializable_type()
+            if serializable_type is not None and isinstance(obj, serializable_type):
                 return obj.to_json()
 
             # 64-bit integers might overflow the JavaScript safe integer range.

--- a/langfuse/api/core/pydantic_utilities.py
+++ b/langfuse/api/core/pydantic_utilities.py
@@ -2,6 +2,8 @@
 
 # nopycln: file
 import datetime as dt
+import types
+import typing
 from collections import defaultdict
 from typing import (
     Any,
@@ -20,21 +22,35 @@ from typing import (
 )
 
 import pydantic
+import typing_extensions
 
 IS_PYDANTIC_V2 = pydantic.VERSION.startswith("2.")
 
 if IS_PYDANTIC_V2:
-    from pydantic.v1.datetime_parse import parse_date as parse_date
-    from pydantic.v1.datetime_parse import parse_datetime as parse_datetime
-    from pydantic.v1.fields import ModelField as ModelField
-    from pydantic.v1.json import ENCODERS_BY_TYPE as encoders_by_type  # type: ignore[attr-defined]
-    from pydantic.v1.typing import get_args as get_args
-    from pydantic.v1.typing import get_origin as get_origin
-    from pydantic.v1.typing import is_literal_type as is_literal_type
-    from pydantic.v1.typing import is_union as is_union
+    from pydantic.fields import FieldInfo as FieldInfo
+
+    ModelField = FieldInfo  # type: ignore[assignment]
+    encoders_by_type: Dict[Any, Callable[[Any], Any]] = {}
+    get_args = typing_extensions.get_args
+    get_origin = typing_extensions.get_origin
+
+    def parse_date(value: Any) -> dt.date:
+        return pydantic.TypeAdapter(dt.date).validate_python(value)  # type: ignore[attr-defined]
+
+    def parse_datetime(value: Any) -> dt.datetime:
+        return pydantic.TypeAdapter(dt.datetime).validate_python(value)  # type: ignore[attr-defined]
+
+    def is_literal_type(type_: Any) -> bool:
+        origin = typing_extensions.get_origin(type_)
+        return origin in (typing.Literal, typing_extensions.Literal)
+
+    def is_union(type_: Any) -> bool:
+        origin = typing_extensions.get_origin(type_)
+        return origin in (Union, types.UnionType)
 else:
     from pydantic.datetime_parse import parse_date as parse_date  # type: ignore[no-redef]
     from pydantic.datetime_parse import parse_datetime as parse_datetime  # type: ignore[no-redef]
+    from pydantic.fields import FieldInfo as FieldInfo
     from pydantic.fields import ModelField as ModelField  # type: ignore[attr-defined, no-redef]
     from pydantic.json import ENCODERS_BY_TYPE as encoders_by_type  # type: ignore[no-redef]
     from pydantic.typing import get_args as get_args  # type: ignore[no-redef]
@@ -287,7 +303,7 @@ def universal_field_validator(
     return decorator
 
 
-PydanticField = Union[ModelField, pydantic.fields.FieldInfo]
+PydanticField = Union[ModelField, FieldInfo]
 
 
 def _get_model_fields(model: Type["Model"]) -> Mapping[str, PydanticField]:

--- a/tests/test_pydantic_compat.py
+++ b/tests/test_pydantic_compat.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+
+from langfuse.api.core.pydantic_utilities import parse_date, parse_datetime
+
+
+def test_import_langfuse_with_user_warnings_as_errors() -> None:
+    result = subprocess.run(
+        [sys.executable, "-W", "error::UserWarning", "-c", "import langfuse"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_parse_helpers_support_pydantic_v2() -> None:
+    assert parse_date("2024-01-02") == date(2024, 1, 2)
+    assert parse_datetime("2024-01-02T03:04:05Z") == datetime(
+        2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc
+    )


### PR DESCRIPTION
## Summary
- stop using `pydantic.v1` imports in `langfuse/api/core/pydantic_utilities.py` when running under Pydantic v2
- lazy-load LangChain's `Serializable` type so `import langfuse` does not eagerly trigger optional dependency import warnings on Python 3.14
- add a regression test for `python -W error::UserWarning -c "import langfuse"`

## Issue
Fixes langfuse/langfuse#12626

Original issue from: https://github.com/langfuse/langfuse/issues/9618 -- above issue referenced as a bug on original fix from langfuse v4



## Verification
- `python -m pytest tests/test_pydantic_compat.py tests/test_json.py tests/test_serializer.py -q`
- `python -W error::UserWarning -c "import langfuse"`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes two import-time issues that broke `import langfuse` on Python 3.14 under Pydantic v2: it eliminates the use of `pydantic.v1.*` compatibility shims (which no longer exist in Python 3.14's Pydantic v2 build) and lazy-loads the optional LangChain `Serializable` type to prevent transitive `pydantic.v1` imports from triggering `UserWarning`-as-error on Python 3.14.

**Key changes:**
- `langfuse/api/core/pydantic_utilities.py`: Under Pydantic v2, all `pydantic.v1.*` imports are replaced with native equivalents — `FieldInfo` for `ModelField`, `typing_extensions.get_args/get_origin` for type introspection, `pydantic.TypeAdapter` for date/datetime parsing, and inline functions for `is_literal_type`/`is_union`. The empty `encoders_by_type = {}` is intentional since Pydantic v2 handles its own JSON encoding.
- `langfuse/_utils/serializer.py`: The eager top-level import of `langchain_core.load.serializable.Serializable` is replaced with a lazy `lru_cache`-backed helper `_get_langchain_serializable_type()`, preventing import-time side effects from the optional dependency.
- `tests/test_pydantic_compat.py`: Adds a subprocess-based regression test that verifies `import langfuse` does not emit any `UserWarning` under `-W error::UserWarning`, plus a correctness test for the new `parse_date`/`parse_datetime` implementations.

**Minor notes:**
- The in-function import in `_get_langchain_serializable_type` is a deliberate trade-off for lazy loading, but it goes against the project's convention of top-level imports.
- `pydantic.TypeAdapter(dt.date/dt.datetime)` is re-instantiated on every `parse_date`/`parse_datetime` call; caching these at module level would be slightly more efficient.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are correct fixes for a real Python 3.14 / Pydantic v2 compatibility issue with no regressions identified.

All remaining findings are P2 (style/performance suggestions): one in-function import that violates the project convention but is intentionally justified by the lazy-load requirement, and one minor TypeAdapter re-instantiation pattern. No logic errors, data-integrity issues, or regressions were found. The types.UnionType usage in is_union is safe because pyproject.toml enforces python >= 3.10. The new tests directly cover the fixed scenarios.

No files require special attention; all three changed files are straightforward and well-targeted.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| langfuse/_utils/serializer.py | Replaces eager top-level import of LangChain's `Serializable` with a lazy `lru_cache`-backed helper; fixes Python 3.14 import-time `UserWarning` caused by transitive `pydantic.v1` usage in `langchain_core`. Logic is correct; one style note about in-function import per project convention. |
| langfuse/api/core/pydantic_utilities.py | Eliminates all `pydantic.v1.*` imports under Pydantic v2, replacing them with native Pydantic v2 / `typing_extensions` equivalents. `ModelField` aliased to `FieldInfo`, `encoders_by_type` set to empty dict (intentional), and `is_union` correctly includes `types.UnionType` (safe because `python >= 3.10` is enforced in pyproject.toml). Minor: `TypeAdapter` re-created on each `parse_date`/`parse_datetime` call. |
| tests/test_pydantic_compat.py | New regression test covering both the `import langfuse` under `-W error::UserWarning` condition and the correctness of `parse_date`/`parse_datetime` on Pydantic v2. Well-structured and targeted. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["import langfuse"] --> B{IS_PYDANTIC_V2?}
    B -- "Yes (v2 path)" --> C["pydantic_utilities.py\nuse native Pydantic v2 APIs\n(FieldInfo, TypeAdapter, typing_extensions)"]
    B -- "No (v1 path)" --> D["pydantic_utilities.py\npydantic v1 imports\n(ModelField, ENCODERS_BY_TYPE, etc.)"]
    A --> E["serializer.py\nEventSerializer.default(obj)"]
    E --> F{Is obj a LangChain Serializable?}
    F -- "Lazy lookup (lru_cache)" --> G["_get_langchain_serializable_type()\ntry: from langchain_core...Serializable\nexcept: return None"]
    G -- "langchain_core present" --> H["return Serializable class\n→ obj.to_json()"]
    G -- "not installed" --> I["return None\n→ skip branch"]
    F -- "type cached after first call" --> J["isinstance check using cached type"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(serializer): lazy-load langchain Ser..."](https://github.com/langfuse/langfuse-python/commit/dfa93fcd067d90ba4bf3cc4fe8bd265864d5d206) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26622226)</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learnt From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->