### PR TITLE
fix: add close and aclose methods to GeneratorWrapper

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -593,6 +593,17 @@ class _ContextPreservedSyncGeneratorWrapper:
 
             raise
 
+    def close(self) -> None:
+        output: Any = self.items
+
+        if self.transform_fn is not None:
+            output = self.transform_fn(self.items)
+        elif all(isinstance(item, str) for item in self.items):
+            output = "".join(self.items)
+
+        self.span.update(output=output).end()
+        self.generator.close()
+
 
 class _ContextPreservedAsyncGeneratorWrapper:
     """Async generator wrapper that ensures each iteration runs in preserved context."""
@@ -659,3 +670,14 @@ class _ContextPreservedAsyncGeneratorWrapper:
             ).end()
 
             raise
+
+    async def aclose(self) -> None:
+        output: Any = self.items
+
+        if self.transform_fn is not None:
+            output = self.transform_fn(self.items)
+        elif all(isinstance(item, str) for item in self.items):
+            output = "".join(self.items)
+
+        self.span.update(output=output).end()
+        await self.generator.aclose()

--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -560,6 +560,26 @@ class _ContextPreservedSyncGeneratorWrapper:
         self.items: List[Any] = []
         self.span = span
         self.transform_fn = transform_fn
+        self._ended = False
+
+    def _end_span(
+        self, *, level: Optional[str] = None, status_message: Optional[str] = None
+    ) -> None:
+        if self._ended:
+            return
+        self._ended = True
+
+        output: Any = self.items
+
+        if self.transform_fn is not None:
+            output = self.transform_fn(self.items)
+        elif all(isinstance(item, str) for item in self.items):
+            output = "".join(self.items)
+
+        if level is not None:
+            self.span.update(output=output, level=level, status_message=status_message).end()
+        else:
+            self.span.update(output=output).end()
 
     def __iter__(self) -> "_ContextPreservedSyncGeneratorWrapper":
         return self
@@ -573,35 +593,19 @@ class _ContextPreservedSyncGeneratorWrapper:
             return item
 
         except StopIteration:
-            # Handle output and span cleanup when generator is exhausted
-            output: Any = self.items
-
-            if self.transform_fn is not None:
-                output = self.transform_fn(self.items)
-
-            elif all(isinstance(item, str) for item in self.items):
-                output = "".join(self.items)
-
-            self.span.update(output=output).end()
+            self._end_span()
 
             raise  # Re-raise StopIteration
 
         except (Exception, asyncio.CancelledError) as e:
-            self.span.update(
+            self._end_span(
                 level="ERROR", status_message=str(e) or type(e).__name__
-            ).end()
+            )
 
             raise
 
     def close(self) -> None:
-        output: Any = self.items
-
-        if self.transform_fn is not None:
-            output = self.transform_fn(self.items)
-        elif all(isinstance(item, str) for item in self.items):
-            output = "".join(self.items)
-
-        self.span.update(output=output).end()
+        self._end_span()
         self.generator.close()
 
 
@@ -630,6 +634,26 @@ class _ContextPreservedAsyncGeneratorWrapper:
         self.items: List[Any] = []
         self.span = span
         self.transform_fn = transform_fn
+        self._ended = False
+
+    def _end_span(
+        self, *, level: Optional[str] = None, status_message: Optional[str] = None
+    ) -> None:
+        if self._ended:
+            return
+        self._ended = True
+
+        output: Any = self.items
+
+        if self.transform_fn is not None:
+            output = self.transform_fn(self.items)
+        elif all(isinstance(item, str) for item in self.items):
+            output = "".join(self.items)
+
+        if level is not None:
+            self.span.update(output=output, level=level, status_message=status_message).end()
+        else:
+            self.span.update(output=output).end()
 
     def __aiter__(self) -> "_ContextPreservedAsyncGeneratorWrapper":
         return self
@@ -652,32 +676,16 @@ class _ContextPreservedAsyncGeneratorWrapper:
             return item
 
         except StopAsyncIteration:
-            # Handle output and span cleanup when generator is exhausted
-            output: Any = self.items
-
-            if self.transform_fn is not None:
-                output = self.transform_fn(self.items)
-
-            elif all(isinstance(item, str) for item in self.items):
-                output = "".join(self.items)
-
-            self.span.update(output=output).end()
+            self._end_span()
 
             raise  # Re-raise StopAsyncIteration
         except (Exception, asyncio.CancelledError) as e:
-            self.span.update(
+            self._end_span(
                 level="ERROR", status_message=str(e) or type(e).__name__
-            ).end()
+            )
 
             raise
 
     async def aclose(self) -> None:
-        output: Any = self.items
-
-        if self.transform_fn is not None:
-            output = self.transform_fn(self.items)
-        elif all(isinstance(item, str) for item in self.items):
-            output = "".join(self.items)
-
-        self.span.update(output=output).end()
+        self._end_span()
         await self.generator.aclose()

--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -605,8 +605,16 @@ class _ContextPreservedSyncGeneratorWrapper:
             raise
 
     def close(self) -> None:
-        self._end_span()
-        self.generator.close()
+        tokens = []
+        try:
+            if self.context:
+                for var, value in self.context.items():
+                    tokens.append((var, var.set(value)))
+            self._end_span()
+            self.generator.close()
+        finally:
+            for var, token in tokens:
+                var.reset(token)
 
 
 class _ContextPreservedAsyncGeneratorWrapper:
@@ -687,5 +695,13 @@ class _ContextPreservedAsyncGeneratorWrapper:
             raise
 
     async def aclose(self) -> None:
-        self._end_span()
-        await self.generator.aclose()
+        tokens = []
+        try:
+            if self.context:
+                for var, value in self.context.items():
+                    tokens.append((var, var.set(value)))
+            self._end_span()
+            await self.generator.aclose()
+        finally:
+            for var, token in tokens:
+                var.reset(token)


### PR DESCRIPTION
Currently, close and aclose methods are missing on GeneratorWrapper, making it impossible to close generators from client code without accessing the .generator directly, and missing span uploads in the process.

This commit adds the missing methods for this usecase.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a gap in `_ContextPreservedSyncGeneratorWrapper` and `_ContextPreservedAsyncGeneratorWrapper` where the `close()` / `aclose()` methods were absent, forcing callers to reach into `.generator` directly and bypassing Langfuse span finalisation. The change also refactors the duplicated span-teardown logic into a shared `_end_span()` helper protected by an `_ended` idempotency flag, which is a clean improvement.

Key changes:
- Adds `_ended: bool` flag and `_end_span()` helper to both wrappers, eliminating the duplicated span-finalisation block that previously lived inline in `__next__` / `__anext__`.
- Adds `close()` to `_ContextPreservedSyncGeneratorWrapper` and `aclose()` to `_ContextPreservedAsyncGeneratorWrapper`, each calling `_end_span()` before delegating to the underlying generator.
- The ordering (`_end_span()` first, then generator teardown) is intentional — the span is finalized with the items collected so far, even if generator cleanup later raises.
- Minor consistency gap: `__next__` runs the generator via `self.context.run()` / `asyncio.create_task(..., context=…)` to preserve `contextvars`, but the new `close()` / `aclose()` delegate to the underlying generator directly, so any `finally` blocks in the generator that read context variables will observe the caller's context rather than the preserved one.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — fixes a real gap with no regressions; two P2 context-preservation suggestions are edge cases that don't affect the primary fix.
- All findings are P2 style/best-practice suggestions. The primary goal (prevent missing span uploads when a generator is closed early) is correctly achieved. The `_ended` guard prevents double-finalisation. No P0 or P1 issues found.
- No files require special attention beyond the two context-preservation suggestions in `langfuse/_client/observe.py`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| langfuse/_client/observe.py | Adds `close()` / `aclose()` to sync/async generator wrappers with a shared `_end_span()` helper and idempotency guard; minor P2 gap where generator teardown doesn't run inside the preserved context, unlike `__next__`/`__anext__`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant SyncWrapper as _ContextPreservedSyncGeneratorWrapper
    participant Generator

    Client->>SyncWrapper: close()
    SyncWrapper->>SyncWrapper: _end_span() [idempotent via _ended flag]
    SyncWrapper->>SyncWrapper: span.update(output=items).end()
    SyncWrapper->>Generator: generator.close()
    Generator-->>SyncWrapper: (GeneratorExit injected)
    SyncWrapper-->>Client: returns

    note over SyncWrapper: __next__ exhaustion or error<br/>also calls _end_span() — _ended<br/>flag prevents double-finalisation
```

<sub>Reviews (1): Last reviewed commit: ["fix: add \_end\_span method to prevent dou..."](https://github.com/langfuse/langfuse-python/commit/3530d3bee838810fae01308fa2cc024a976b0b0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27153390)</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->