### PR TITLE
ci: add 7-day dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     rebase-strategy: "disabled" # use dependabot-rebase-stale
     commit-message:
       prefix: chore
@@ -26,6 +28,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     rebase-strategy: "disabled"
     commit-message:
       prefix: chore


### PR DESCRIPTION
## Summary
- add a 7-day Dependabot cooldown for the `uv` update config
- add the same 7-day cooldown for the `github-actions` update config

## Why
This repository's Dependabot configuration opened update PRs daily without any cooldown window. Adding a 7-day cooldown reduces churn from rapid successive version bumps across both configured ecosystems.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "yaml ok"'`
- `git diff --check`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Adds a 7-day `cooldown` (`default-days: 7`) to both the `uv` and `github-actions` Dependabot update configurations to reduce noisy daily PRs for rapid successive version bumps. The `cooldown` key and its `default-days` parameter are officially supported by Dependabot and the YAML is well-formed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — valid Dependabot configuration with no functional risks.

The change is a minimal, well-scoped CI configuration update using a documented Dependabot feature. No code logic, security, or data concerns are present.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds `cooldown: default-days: 7` to both `uv` and `github-actions` update configs; syntax is valid and the option is officially documented. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot scheduled run - daily] --> B{New version available?}
    B -- No --> C[Skip]
    B -- Yes --> D{Within 7-day cooldown window?}
    D -- Yes --> E[Skip - wait for cooldown to expire]
    D -- No --> F[Open PR for update]
    F --> G[uv ecosystem PR]
    F --> H[github-actions ecosystem PR]
```

<sub>Reviews (1): Last reviewed commit: ["chore(dependabot): add 7-day cooldown"](https://github.com/langfuse/langfuse-python/commit/35f78eddefead096310c68ff98133405d51ea45e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28002917)</sub>

<!-- /greptile_comment -->