### PR TITLE
fix(langchain): propagate trace name metadata

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -287,6 +287,11 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
         ):
             attributes["user_id"] = metadata["langfuse_user_id"]
 
+        if "langfuse_trace_name" in metadata and isinstance(
+            metadata["langfuse_trace_name"], str
+        ):
+            attributes["trace_name"] = metadata["langfuse_trace_name"]
+
         if tags is not None or (
             "langfuse_tags" in metadata and isinstance(metadata["langfuse_tags"], list)
         ):
@@ -369,6 +374,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                     session_id=parsed_trace_attributes.get("session_id", None),
                     tags=parsed_trace_attributes.get("tags", None),
                     metadata=parsed_trace_attributes.get("metadata", None),
+                    trace_name=parsed_trace_attributes.get("trace_name", None),
                 )
 
                 self._propagation_context_manager.__enter__()
@@ -1403,6 +1409,7 @@ def _strip_langfuse_keys_from_dict(
         "langfuse_session_id",
         "langfuse_user_id",
         "langfuse_tags",
+        "langfuse_trace_name",
     ]
 
     metadata_copy = metadata.copy()

--- a/tests/unit/test_langchain.py
+++ b/tests/unit/test_langchain.py
@@ -1,4 +1,6 @@
+from contextvars import copy_context
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 from langchain.messages import HumanMessage
@@ -165,4 +167,85 @@ def test_chat_model_error_marks_generation_error(langfuse_memory_client, get_spa
     assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_LEVEL] == "ERROR"
     assert (
         "boom" in span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]
+    )
+
+
+def test_root_chain_metadata_propagates_trace_name(
+    langfuse_memory_client, get_span, find_spans
+):
+    response = ChatResult(
+        generations=[
+            ChatGeneration(
+                message=AIMessage(content="knock knock"),
+                text="knock knock",
+            )
+        ],
+        llm_output={
+            "token_usage": {
+                "prompt_tokens": 4,
+                "completion_tokens": 2,
+                "total_tokens": 6,
+            },
+            "model_name": "gpt-4o-mini",
+        },
+    )
+
+    with patch.object(ChatOpenAI, "_generate", return_value=response):
+        handler = CallbackHandler()
+        prompt = ChatPromptTemplate.from_template("tell me a joke about {topic}")
+        chain = prompt | ChatOpenAI(api_key="test", temperature=0) | StrOutputParser()
+
+        result = chain.invoke(
+            {"topic": "otters"},
+            config={
+                "callbacks": [handler],
+                "metadata": {"langfuse_trace_name": "langchain-trace-name"},
+            },
+        )
+
+    assert result == "knock knock"
+
+    langfuse_memory_client.flush()
+    root_span = get_span("RunnableSequence")
+    generation_span = get_span("ChatOpenAI")
+
+    assert (
+        root_span.attributes[LangfuseOtelSpanAttributes.TRACE_NAME]
+        == "langchain-trace-name"
+    )
+    assert (
+        generation_span.attributes[LangfuseOtelSpanAttributes.TRACE_NAME]
+        == "langchain-trace-name"
+    )
+    assert (
+        f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_trace_name"
+        not in root_span.attributes
+    )
+    assert len(find_spans("ChatOpenAI")) == 1
+
+
+def test_root_chain_exports_when_end_runs_in_copied_context(
+    langfuse_memory_client, get_span
+):
+    handler = CallbackHandler()
+    run_id = uuid4()
+
+    handler.on_chain_start(
+        {"id": ["RunnableSequence"]},
+        {"topic": "otters"},
+        run_id=run_id,
+        metadata={"langfuse_trace_name": "async-root-trace"},
+    )
+
+    copy_context().run(
+        handler.on_chain_end,
+        {"output": "knock knock"},
+        run_id=run_id,
+    )
+
+    langfuse_memory_client.flush()
+    root_span = get_span("RunnableSequence")
+
+    assert root_span.attributes[LangfuseOtelSpanAttributes.TRACE_NAME] == (
+        "async-root-trace"
     )


### PR DESCRIPTION
## Summary
- propagate `langfuse_trace_name` from LangChain root metadata into `propagate_attributes()` so root and child spans receive `langfuse.trace.name`
- strip `langfuse_trace_name` from observation metadata once it is treated as a trace-level attribute
- add regression coverage for both metadata-based trace-name propagation and root chain export when `on_chain_end` runs in a copied async context

## Verification
- `uv run --frozen pytest tests/unit/test_langchain.py -q`
- `uv run --frozen ruff check langfuse/langchain/CallbackHandler.py tests/unit/test_langchain.py`

Closes #13023
Refs LFE-9178

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds `langfuse_trace_name` to the set of root-chain trace attributes that are extracted from LangChain metadata and propagated to all spans via `propagate_attributes()`, and strips the key from raw observation metadata to avoid it leaking as a raw metadata entry. Two regression tests are added: one for the metadata-based trace-name propagation across root and child spans, and one for the scenario where `on_chain_end` fires in a copied async context.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive, well-scoped, and covered by targeted regression tests.

All three change sites (attribute extraction, propagation call, strip list) are consistent with existing patterns for `langfuse_user_id`/`langfuse_session_id`. No pre-existing logic is altered, double-exit of the propagation context manager is guarded by the null check in `_exit_propagation_context`, and both new code paths are covered by new tests. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| langfuse/langchain/CallbackHandler.py | Adds `langfuse_trace_name` extraction in `_parse_langfuse_trace_attributes`, passes `trace_name` to `propagate_attributes()` at root chain start, and adds the key to `langfuse_trace_attribute_keys` so it is stripped from raw observation metadata for all spans. |
| tests/unit/test_langchain.py | Adds two regression tests: one verifying `TRACE_NAME` attribute is set on root and child spans and `langfuse_trace_name` is stripped from root-span metadata, and one verifying correct export when `on_chain_end` runs in a copied async context. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant LC as LangChain Runtime
    participant CB as CallbackHandler
    participant PA as propagate_attributes()
    participant CS as Child Spans

    LC->>CB: on_chain_start(metadata={langfuse_trace_name: my-trace}, parent_run_id=None)
    CB->>CB: _parse_langfuse_trace_attributes() extracts trace_name
    CB->>PA: propagate_attributes(trace_name=my-trace, ...)
    PA-->>CB: context manager entered (sets langfuse.trace.name on active span)
    CB->>CB: start_observation() with metadata stripped of langfuse_trace_name
    LC->>CB: on_chain_start(metadata={langfuse_trace_name: my-trace}, parent_run_id=id)
    CB->>CS: start_observation() — inherits langfuse.trace.name via OTel context
    LC->>CB: on_chain_end(run_id=root)
    CB->>PA: __exit__() — propagation context torn down
```

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): propagate trace name met..."](https://github.com/langfuse/langfuse-python/commit/661326f76aaa77efe1ca22268714ebb58b1f92c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28500365)</sub>

<!-- /greptile_comment -->