### PR TITLE
fix(openai): preserve native v1 stream contract

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -1195,6 +1195,7 @@ class LangfuseResponseGeneratorSync:
         self.response = response
         self.generation = generation
         self.completion_start_time: Optional[datetime] = None
+        self._is_finalized = False
 
     def __iter__(self) -> Any:
         try:
@@ -1230,6 +1231,10 @@ class LangfuseResponseGeneratorSync:
         pass
 
     def _finalize(self) -> None:
+        if self._is_finalized:
+            return
+
+        self._is_finalized = True
         _finalize_stream_response(
             resource=self.resource,
             items=self.items,
@@ -1252,6 +1257,7 @@ class LangfuseResponseGeneratorAsync:
         self.response = response
         self.generation = generation
         self.completion_start_time: Optional[datetime] = None
+        self._is_finalized = False
 
     async def __aiter__(self) -> Any:
         try:
@@ -1287,6 +1293,10 @@ class LangfuseResponseGeneratorAsync:
         pass
 
     async def _finalize(self) -> None:
+        if self._is_finalized:
+            return
+
+        self._is_finalized = True
         _finalize_stream_response(
             resource=self.resource,
             items=self.items,

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -21,7 +21,7 @@ import types
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
-from inspect import isclass
+from inspect import isawaitable, isclass
 from typing import Any, Optional, cast
 
 from openai._types import NotGiven
@@ -841,6 +841,7 @@ def _install_openai_stream_iteration_hooks() -> None:
 
     if not _openai_stream_iter_hook_installed:
         original_iter = openai.Stream.__iter__
+        original_aiter = openai.AsyncStream.__aiter__
 
         def traced_iter(self: Any) -> Any:
             try:
@@ -850,7 +851,17 @@ def _install_openai_stream_iteration_hooks() -> None:
                 if finalize_once is not None:
                     finalize_once()
 
+        async def traced_aiter(self: Any) -> Any:
+            try:
+                async for item in original_aiter(self):
+                    yield item
+            finally:
+                finalize_once = getattr(self, "_langfuse_finalize_once", None)
+                if finalize_once is not None:
+                    await finalize_once()
+
         setattr(openai.Stream, "__iter__", traced_iter)
+        setattr(openai.AsyncStream, "__aiter__", traced_aiter)
         _openai_stream_iter_hook_installed = True
 
 
@@ -972,6 +983,8 @@ def _instrument_openai_async_stream(
             generation=generation,
             completion_start_time=completion_start_time,
         )
+
+    response._langfuse_finalize_once = finalize_once  # type: ignore[attr-defined]
 
     async def traced_iterator() -> Any:
         nonlocal completion_start_time
@@ -1228,7 +1241,16 @@ class LangfuseResponseGeneratorSync:
         return self.__iter__()
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        pass
+        self.close()
+
+    def close(self) -> None:
+        close = getattr(self.response, "close", None)
+
+        try:
+            if callable(close):
+                close()
+        finally:
+            self._finalize()
 
     def _finalize(self) -> None:
         if self._is_finalized:
@@ -1290,7 +1312,7 @@ class LangfuseResponseGeneratorAsync:
         return self.__aiter__()
 
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        pass
+        await self.aclose()
 
     async def _finalize(self) -> None:
         if self._is_finalized:
@@ -1309,11 +1331,37 @@ class LangfuseResponseGeneratorAsync:
 
         Automatically called if the response body is read to completion.
         """
-        await self.response.close()
+        close = getattr(self.response, "close", None)
+        aclose = getattr(self.response, "aclose", None)
+
+        try:
+            if callable(close):
+                result = close()
+                if isawaitable(result):
+                    await result
+            elif callable(aclose):
+                result = aclose()
+                if isawaitable(result):
+                    await result
+        finally:
+            await self._finalize()
 
     async def aclose(self) -> None:
         """Close the response and release the connection.
 
         Automatically called if the response body is read to completion.
         """
-        await self.response.aclose()
+        aclose = getattr(self.response, "aclose", None)
+        close = getattr(self.response, "close", None)
+
+        try:
+            if callable(aclose):
+                result = aclose()
+                if isawaitable(result):
+                    await result
+            elif callable(close):
+                result = close()
+                if isawaitable(result):
+                    await result
+        finally:
+            await self._finalize()

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -850,7 +850,7 @@ def _install_openai_stream_iteration_hooks() -> None:
                 if finalize_once is not None:
                     finalize_once()
 
-        openai.Stream.__iter__ = traced_iter
+        setattr(openai.Stream, "__iter__", traced_iter)
         _openai_stream_iter_hook_installed = True
 
 

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -830,6 +830,167 @@ def _is_streaming_response(response: Any) -> bool:
     )
 
 
+def _finalize_stream_response(
+    *,
+    resource: OpenAiDefinition,
+    items: list[Any],
+    generation: LangfuseGeneration,
+    completion_start_time: Optional[datetime],
+) -> None:
+    try:
+        model, completion, usage, metadata = (
+            _extract_streamed_response_api_response(items)
+            if resource.object == "Responses" or resource.object == "AsyncResponses"
+            else _extract_streamed_openai_response(resource, items)
+        )
+
+        _create_langfuse_update(
+            completion,
+            generation,
+            completion_start_time,
+            model=model,
+            usage=usage,
+            metadata=metadata,
+        )
+    except Exception:
+        pass
+    finally:
+        generation.end()
+
+
+async def _finalize_stream_response_async(
+    *,
+    resource: OpenAiDefinition,
+    items: list[Any],
+    generation: LangfuseGeneration,
+    completion_start_time: Optional[datetime],
+) -> None:
+    _finalize_stream_response(
+        resource=resource,
+        items=items,
+        generation=generation,
+        completion_start_time=completion_start_time,
+    )
+
+
+def _instrument_openai_stream(
+    *,
+    resource: OpenAiDefinition,
+    response: Any,
+    generation: LangfuseGeneration,
+) -> Any:
+    if not hasattr(response, "_iterator"):
+        return LangfuseResponseGeneratorSync(
+            resource=resource,
+            response=response,
+            generation=generation,
+        )
+
+    items: list[Any] = []
+    raw_iterator = response._iterator
+    completion_start_time: Optional[datetime] = None
+    is_finalized = False
+    close = response.close
+
+    def finalize_once() -> None:
+        nonlocal is_finalized
+        if is_finalized:
+            return
+
+        is_finalized = True
+        _finalize_stream_response(
+            resource=resource,
+            items=items,
+            generation=generation,
+            completion_start_time=completion_start_time,
+        )
+
+    def traced_iterator() -> Any:
+        nonlocal completion_start_time
+        try:
+            for item in raw_iterator:
+                items.append(item)
+
+                if completion_start_time is None:
+                    completion_start_time = _get_timestamp()
+
+                yield item
+        finally:
+            finalize_once()
+
+    def traced_close() -> Any:
+        try:
+            return close()
+        finally:
+            finalize_once()
+
+    response._iterator = traced_iterator()
+    response.close = traced_close
+
+    return response
+
+
+def _instrument_openai_async_stream(
+    *,
+    resource: OpenAiDefinition,
+    response: Any,
+    generation: LangfuseGeneration,
+) -> Any:
+    if not hasattr(response, "_iterator"):
+        return LangfuseResponseGeneratorAsync(
+            resource=resource,
+            response=response,
+            generation=generation,
+        )
+
+    items: list[Any] = []
+    raw_iterator = response._iterator
+    completion_start_time: Optional[datetime] = None
+    is_finalized = False
+    close = response.close
+
+    async def finalize_once() -> None:
+        nonlocal is_finalized
+        if is_finalized:
+            return
+
+        is_finalized = True
+        await _finalize_stream_response_async(
+            resource=resource,
+            items=items,
+            generation=generation,
+            completion_start_time=completion_start_time,
+        )
+
+    async def traced_iterator() -> Any:
+        nonlocal completion_start_time
+        try:
+            async for item in raw_iterator:
+                items.append(item)
+
+                if completion_start_time is None:
+                    completion_start_time = _get_timestamp()
+
+                yield item
+        finally:
+            await finalize_once()
+
+    async def traced_close() -> Any:
+        try:
+            return await close()
+        finally:
+            await finalize_once()
+
+    async def traced_aclose() -> Any:
+        return await traced_close()
+
+    response._iterator = traced_iterator()
+    response.close = traced_close
+    response.aclose = traced_aclose
+
+    return response
+
+
 @_langfuse_wrapper
 def _wrap(
     open_ai_resource: OpenAiDefinition, wrapped: Any, args: Any, kwargs: Any
@@ -863,7 +1024,13 @@ def _wrap(
     try:
         openai_response = wrapped(**arg_extractor.get_openai_args())
 
-        if _is_streaming_response(openai_response):
+        if _is_openai_v1() and isinstance(openai_response, openai.Stream):
+            return _instrument_openai_stream(
+                resource=open_ai_resource,
+                response=openai_response,
+                generation=generation,
+            )
+        elif _is_streaming_response(openai_response):
             return LangfuseResponseGeneratorSync(
                 resource=open_ai_resource,
                 response=openai_response,
@@ -934,7 +1101,13 @@ async def _wrap_async(
     try:
         openai_response = await wrapped(**arg_extractor.get_openai_args())
 
-        if _is_streaming_response(openai_response):
+        if _is_openai_v1() and isinstance(openai_response, openai.AsyncStream):
+            return _instrument_openai_async_stream(
+                resource=open_ai_resource,
+                response=openai_response,
+                generation=generation,
+            )
+        elif _is_streaming_response(openai_response):
             return LangfuseResponseGeneratorAsync(
                 resource=open_ai_resource,
                 response=openai_response,
@@ -1045,26 +1218,12 @@ class LangfuseResponseGeneratorSync:
         pass
 
     def _finalize(self) -> None:
-        try:
-            model, completion, usage, metadata = (
-                _extract_streamed_response_api_response(self.items)
-                if self.resource.object == "Responses"
-                or self.resource.object == "AsyncResponses"
-                else _extract_streamed_openai_response(self.resource, self.items)
-            )
-
-            _create_langfuse_update(
-                completion,
-                self.generation,
-                self.completion_start_time,
-                model=model,
-                usage=usage,
-                metadata=metadata,
-            )
-        except Exception:
-            pass
-        finally:
-            self.generation.end()
+        _finalize_stream_response(
+            resource=self.resource,
+            items=self.items,
+            generation=self.generation,
+            completion_start_time=self.completion_start_time,
+        )
 
 
 class LangfuseResponseGeneratorAsync:
@@ -1116,26 +1275,12 @@ class LangfuseResponseGeneratorAsync:
         pass
 
     async def _finalize(self) -> None:
-        try:
-            model, completion, usage, metadata = (
-                _extract_streamed_response_api_response(self.items)
-                if self.resource.object == "Responses"
-                or self.resource.object == "AsyncResponses"
-                else _extract_streamed_openai_response(self.resource, self.items)
-            )
-
-            _create_langfuse_update(
-                completion,
-                self.generation,
-                self.completion_start_time,
-                model=model,
-                usage=usage,
-                metadata=metadata,
-            )
-        except Exception:
-            pass
-        finally:
-            self.generation.end()
+        await _finalize_stream_response_async(
+            resource=self.resource,
+            items=self.items,
+            generation=self.generation,
+            completion_start_time=self.completion_start_time,
+        )
 
     async def close(self) -> None:
         """Close the response and release the connection.

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -830,6 +830,30 @@ def _is_streaming_response(response: Any) -> bool:
     )
 
 
+_openai_stream_iter_hook_installed = False
+
+
+def _install_openai_stream_iteration_hooks() -> None:
+    global _openai_stream_iter_hook_installed
+
+    if not _is_openai_v1():
+        return
+
+    if not _openai_stream_iter_hook_installed:
+        original_iter = openai.Stream.__iter__
+
+        def traced_iter(self: Any) -> Any:
+            try:
+                yield from original_iter(self)
+            finally:
+                finalize_once = getattr(self, "_langfuse_finalize_once", None)
+                if finalize_once is not None:
+                    finalize_once()
+
+        openai.Stream.__iter__ = traced_iter
+        _openai_stream_iter_hook_installed = True
+
+
 def _finalize_stream_response(
     *,
     resource: OpenAiDefinition,
@@ -856,21 +880,6 @@ def _finalize_stream_response(
         pass
     finally:
         generation.end()
-
-
-async def _finalize_stream_response_async(
-    *,
-    resource: OpenAiDefinition,
-    items: list[Any],
-    generation: LangfuseGeneration,
-    completion_start_time: Optional[datetime],
-) -> None:
-    _finalize_stream_response(
-        resource=resource,
-        items=items,
-        generation=generation,
-        completion_start_time=completion_start_time,
-    )
 
 
 def _instrument_openai_stream(
@@ -904,6 +913,8 @@ def _instrument_openai_stream(
             generation=generation,
             completion_start_time=completion_start_time,
         )
+
+    response._langfuse_finalize_once = finalize_once  # type: ignore[attr-defined]
 
     def traced_iterator() -> Any:
         nonlocal completion_start_time
@@ -955,7 +966,7 @@ def _instrument_openai_async_stream(
             return
 
         is_finalized = True
-        await _finalize_stream_response_async(
+        _finalize_stream_response(
             resource=resource,
             items=items,
             generation=generation,
@@ -1167,6 +1178,7 @@ def register_tracing() -> None:
 
 
 register_tracing()
+_install_openai_stream_iteration_hooks()
 
 
 class LangfuseResponseGeneratorSync:
@@ -1275,7 +1287,7 @@ class LangfuseResponseGeneratorAsync:
         pass
 
     async def _finalize(self) -> None:
-        await _finalize_stream_response_async(
+        _finalize_stream_response(
             resource=self.resource,
             items=self.items,
             generation=self.generation,

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -272,6 +272,38 @@ def test_openai_stream_preserves_original_stream_contract(
     }
 
 
+def test_openai_stream_break_still_finalizes_generation(
+    langfuse_memory_client, get_span
+):
+    openai_client = lf_openai.OpenAI(api_key="test")
+    raw_response = DummySyncResponse()
+    raw_stream = DummyOpenAIStream(_make_chat_stream_chunks(), raw_response)
+
+    with patch.object(openai_client.chat.completions, "_post", return_value=raw_stream):
+        stream = openai_client.chat.completions.create(
+            name="unit-openai-native-stream-break",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "1 + 1 = ?"}],
+            temperature=0,
+            stream=True,
+        )
+
+    for chunk in stream:
+        assert chunk.choices[0].delta.content == "2"
+        break
+
+    assert raw_response.closed is False
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-native-stream-break")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] == "2"
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME]
+        is not None
+    )
+
+
 @pytest.mark.asyncio
 async def test_async_chat_completion_exports_generation_span(
     langfuse_memory_client, get_span, json_attr

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -49,6 +50,18 @@ class DummyGeneration:
 
     def end(self) -> None:
         self.end_calls += 1
+
+
+class DummyFallbackAsyncResponse:
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.aclose_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
 
 
 def _make_chat_stream_chunks():
@@ -469,6 +482,42 @@ async def test_openai_async_stream_supports_anext(
     }
 
 
+@pytest.mark.asyncio
+async def test_openai_async_stream_break_still_finalizes_generation(
+    langfuse_memory_client, get_span
+):
+    openai_client = lf_openai.AsyncOpenAI(api_key="test")
+    raw_stream = DummyOpenAIAsyncStream(
+        _make_chat_stream_chunks(), DummyAsyncResponse()
+    )
+
+    with patch.object(openai_client.chat.completions, "_post", return_value=raw_stream):
+        stream = await openai_client.chat.completions.create(
+            name="unit-openai-native-async-stream-break",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "1 + 1 = ?"}],
+            temperature=0,
+            stream=True,
+        )
+
+    async for chunk in stream:
+        assert chunk.choices[0].delta.content == "2"
+        break
+
+    # Async generator finalizers are scheduled across event-loop turns.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-native-async-stream-break")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] == "2"
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME]
+        is not None
+    )
+
+
 def test_fallback_sync_stream_finalizes_once():
     resource = SimpleNamespace(object="Completions", type="chat")
     generation = DummyGeneration()
@@ -486,6 +535,24 @@ def test_fallback_sync_stream_finalizes_once():
 
     with pytest.raises(StopIteration):
         next(wrapper)
+
+    assert generation.end_calls == 1
+
+
+def test_fallback_sync_stream_exit_finalizes_once():
+    resource = SimpleNamespace(object="Completions", type="chat")
+    generation = DummyGeneration()
+
+    def fallback_stream():
+        yield _make_single_chunk_stream()
+
+    wrapper = lf_openai_module.LangfuseResponseGeneratorSync(
+        resource=resource,
+        response=fallback_stream(),
+        generation=generation,
+    )
+
+    wrapper.__exit__(None, None, None)
 
     assert generation.end_calls == 1
 
@@ -509,6 +576,45 @@ async def test_fallback_async_stream_finalizes_once():
 
     with pytest.raises(StopAsyncIteration):
         await wrapper.__anext__()
+
+    assert generation.end_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_async_stream_close_and_exit_finalize_once():
+    resource = SimpleNamespace(object="Completions", type="chat")
+    generation = DummyGeneration()
+    response = DummyFallbackAsyncResponse()
+
+    wrapper = lf_openai_module.LangfuseResponseGeneratorAsync(
+        resource=resource,
+        response=response,
+        generation=generation,
+    )
+
+    await wrapper.close()
+    await wrapper.__aexit__(None, None, None)
+
+    assert generation.end_calls == 1
+    assert response.close_calls == 1
+    assert response.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_async_stream_aclose_finalizes_once():
+    resource = SimpleNamespace(object="Completions", type="chat")
+    generation = DummyGeneration()
+
+    async def fallback_stream():
+        yield _make_single_chunk_stream()
+
+    wrapper = lf_openai_module.LangfuseResponseGeneratorAsync(
+        resource=resource,
+        response=fallback_stream(),
+        generation=generation,
+    )
+
+    await wrapper.aclose()
 
     assert generation.end_calls == 1
 

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+import langfuse.openai as lf_openai_module
 from langfuse._client.attributes import LangfuseOtelSpanAttributes
 from langfuse.openai import openai as lf_openai
 
@@ -37,6 +38,17 @@ class DummyOpenAIAsyncStream(lf_openai.AsyncStream):
     async def _stream(self, items):
         for item in items:
             yield item
+
+
+class DummyGeneration:
+    def __init__(self) -> None:
+        self.end_calls = 0
+
+    def update(self, **kwargs):
+        return self
+
+    def end(self) -> None:
+        self.end_calls += 1
 
 
 def _make_chat_stream_chunks():
@@ -74,6 +86,24 @@ def _make_chat_stream_chunks():
             usage=usage,
         ),
     ]
+
+
+def _make_single_chunk_stream():
+    return SimpleNamespace(
+        model="gpt-4o-mini",
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    role="assistant",
+                    content="2",
+                    function_call=None,
+                    tool_calls=None,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+    )
 
 
 def test_chat_completion_exports_generation_span(
@@ -437,6 +467,50 @@ async def test_openai_async_stream_supports_anext(
         "completion_tokens": 1,
         "total_tokens": 4,
     }
+
+
+def test_fallback_sync_stream_finalizes_once():
+    resource = SimpleNamespace(object="Completions", type="chat")
+    generation = DummyGeneration()
+
+    def fallback_stream():
+        yield _make_single_chunk_stream()
+
+    wrapper = lf_openai_module.LangfuseResponseGeneratorSync(
+        resource=resource,
+        response=fallback_stream(),
+        generation=generation,
+    )
+
+    list(wrapper)
+
+    with pytest.raises(StopIteration):
+        next(wrapper)
+
+    assert generation.end_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_async_stream_finalizes_once():
+    resource = SimpleNamespace(object="Completions", type="chat")
+    generation = DummyGeneration()
+
+    async def fallback_stream():
+        yield _make_single_chunk_stream()
+
+    wrapper = lf_openai_module.LangfuseResponseGeneratorAsync(
+        resource=resource,
+        response=fallback_stream(),
+        generation=generation,
+    )
+
+    async for _ in wrapper:
+        pass
+
+    with pytest.raises(StopAsyncIteration):
+        await wrapper.__anext__()
+
+    assert generation.end_calls == 1
 
 
 def test_embedding_exports_dimensions_and_count(

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -7,6 +7,75 @@ from langfuse._client.attributes import LangfuseOtelSpanAttributes
 from langfuse.openai import openai as lf_openai
 
 
+class DummySyncResponse:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class DummyAsyncResponse:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class DummyOpenAIStream(lf_openai.Stream):
+    def __init__(self, items, response) -> None:
+        self.response = response
+        self._iterator = iter(items)
+
+
+class DummyOpenAIAsyncStream(lf_openai.AsyncStream):
+    def __init__(self, items, response) -> None:
+        self.response = response
+        self._iterator = self._stream(items)
+
+    async def _stream(self, items):
+        for item in items:
+            yield item
+
+
+def _make_chat_stream_chunks():
+    usage = SimpleNamespace(prompt_tokens=3, completion_tokens=1, total_tokens=4)
+
+    return [
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role="assistant",
+                        content="2",
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        ),
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role=None,
+                        content=None,
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=usage,
+        ),
+    ]
+
+
 def test_chat_completion_exports_generation_span(
     langfuse_memory_client, get_span, json_attr
 ):
@@ -161,6 +230,48 @@ def test_chat_completion_error_marks_generation_error(langfuse_memory_client, ge
     assert LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT not in span.attributes
 
 
+def test_openai_stream_preserves_original_stream_contract(
+    langfuse_memory_client, get_span, json_attr
+):
+    openai_client = lf_openai.OpenAI(api_key="test")
+    raw_response = DummySyncResponse()
+    raw_stream = DummyOpenAIStream(_make_chat_stream_chunks(), raw_response)
+
+    with patch.object(openai_client.chat.completions, "_post", return_value=raw_stream):
+        stream = openai_client.chat.completions.create(
+            name="unit-openai-native-stream",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "1 + 1 = ?"}],
+            temperature=0,
+            stream=True,
+        )
+
+    assert stream is raw_stream
+    assert isinstance(stream, lf_openai.Stream)
+    assert stream.response is raw_response
+
+    chunks = list(stream)
+    stream.close()
+
+    assert len(chunks) == 2
+    assert raw_response.closed is True
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-native-stream")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] == "2"
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME]
+        is not None
+    )
+    assert span.attributes["langfuse.observation.metadata.finish_reason"] == "stop"
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS) == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
+    }
+
+
 @pytest.mark.asyncio
 async def test_async_chat_completion_exports_generation_span(
     langfuse_memory_client, get_span, json_attr
@@ -203,6 +314,96 @@ async def test_async_chat_completion_exports_generation_span(
         "prompt_tokens": 5,
         "completion_tokens": 2,
         "total_tokens": 7,
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_async_stream_preserves_original_stream_contract(
+    langfuse_memory_client, get_span, json_attr
+):
+    openai_client = lf_openai.AsyncOpenAI(api_key="test")
+    raw_response = DummyAsyncResponse()
+    raw_stream = DummyOpenAIAsyncStream(_make_chat_stream_chunks(), raw_response)
+
+    with patch.object(openai_client.chat.completions, "_post", return_value=raw_stream):
+        stream = await openai_client.chat.completions.create(
+            name="unit-openai-native-async-stream",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "1 + 1 = ?"}],
+            temperature=0,
+            stream=True,
+        )
+
+    assert stream is raw_stream
+    assert isinstance(stream, lf_openai.AsyncStream)
+    assert stream.response is raw_response
+    assert hasattr(stream, "aclose")
+
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+
+    await stream.aclose()
+
+    assert len(chunks) == 2
+    assert raw_response.closed is True
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-native-async-stream")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] == "2"
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME]
+        is not None
+    )
+    assert span.attributes["langfuse.observation.metadata.finish_reason"] == "stop"
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS) == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_async_stream_supports_anext(
+    langfuse_memory_client, get_span, json_attr
+):
+    openai_client = lf_openai.AsyncOpenAI(api_key="test")
+    raw_stream = DummyOpenAIAsyncStream(
+        _make_chat_stream_chunks(), DummyAsyncResponse()
+    )
+
+    with patch.object(openai_client.chat.completions, "_post", return_value=raw_stream):
+        stream = await openai_client.chat.completions.create(
+            name="unit-openai-native-async-anext",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "1 + 1 = ?"}],
+            temperature=0,
+            stream=True,
+        )
+
+    first = await stream.__anext__()
+    second = await stream.__anext__()
+
+    assert first.choices[0].delta.content == "2"
+    assert second.choices[0].finish_reason == "stop"
+
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-native-async-anext")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] == "2"
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME]
+        is not None
+    )
+    assert span.attributes["langfuse.observation.metadata.finish_reason"] == "stop"
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS) == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
     }
 
 


### PR DESCRIPTION
## Summary

Fix OpenAI v1 streaming instrumentation to preserve the original `openai.Stream` and `openai.AsyncStream` objects instead of replacing them with Langfuse wrapper types.

This keeps the native stream contract intact for `_iterator`, `.response`, `close()` / `aclose()`, `async for`, and manual `__anext__()` while still collecting streamed chunks for Langfuse generation updates.

## Changes

- instrument native OpenAI v1 stream objects in place by wrapping their internal iterator
- keep the existing Langfuse wrapper classes as a fallback for non-OpenAI generator-style streams
- add regression tests for sync and async native stream behavior, including `async for` and `__anext__()`

## Verification

- `uv run --frozen ruff check langfuse/openai.py tests/unit/test_openai.py`
- `uv run --frozen pytest tests/unit/test_openai.py`

Refs LFE-8788.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes OpenAI v1 streaming instrumentation by patching `_iterator` and `close`/`aclose` on the native `openai.Stream` and `openai.AsyncStream` objects in place, rather than replacing them with Langfuse wrapper types. The approach is sound: `_iterator` replacement correctly intercepts all iteration paths (`__iter__`, `__next__`, `__anext__`, `async for`) as confirmed by the SDK's implementation, and the `is_finalized` flag reliably prevents double-finalization.

<h3>Confidence Score: 5/5</h3>

Safe to merge — core patching logic is correct, double-finalization is guarded, and tests cover all three iteration patterns.

All remaining findings are P2 style suggestions. The `_finalize_stream_response_async` wrapper is harmless. No P0/P1 logic bugs found; the `_iterator` replacement approach is confirmed sound by the OpenAI SDK's implementation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| langfuse/openai.py | Adds `_instrument_openai_stream` / `_instrument_openai_async_stream` to monkey-patch `_iterator` and `close`/`aclose` on native `openai.Stream` objects, preserving type identity while still collecting chunks for Langfuse; logic is sound but `_finalize_stream_response_async` is a no-op async wrapper. |
| tests/unit/test_openai.py | Adds three regression tests covering sync native stream, async native stream, and manual `__anext__` usage; `DummyOpenAIStream` / `DummyOpenAIAsyncStream` correctly bypass `super().__init__` and set `_iterator` directly, which is appropriate for unit-level testing. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant openai.Stream
    participant traced_iterator (generator)
    participant raw_iterator
    participant finalize_once
    participant LangfuseGeneration

    Note over User,LangfuseGeneration: _instrument_openai_stream patches _iterator and close in place

    User->>openai.Stream: for chunk in stream (or next())
    openai.Stream->>traced_iterator (generator): __next__() via self._iterator
    traced_iterator (generator)->>raw_iterator: next item
    raw_iterator-->>traced_iterator (generator): chunk
    traced_iterator (generator)->>traced_iterator (generator): items.append(chunk), set completion_start_time
    traced_iterator (generator)-->>openai.Stream: yield chunk
    openai.Stream-->>User: chunk

    Note over traced_iterator (generator): On exhaustion or close()

    traced_iterator (generator)->>finalize_once: finally block (is_finalized guard)
    finalize_once->>LangfuseGeneration: _finalize_stream_response → generation.end()

    alt User calls stream.close() explicitly
        User->>openai.Stream: close() [patched to traced_close]
        openai.Stream->>openai.Stream: await original_close() (closes HTTP)
        openai.Stream->>finalize_once: finally in traced_close
        finalize_once->>finalize_once: is_finalized=True → no-op if already finalized
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(openai): preserve native v1 stream c..."](https://github.com/langfuse/langfuse-python/commit/b81888599336960a0b53f33f31017b0462146208) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28500900)</sub>

<!-- /greptile_comment -->