### PR TITLE
fix(observe): preserve streaming context without output capture

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -290,42 +290,15 @@ class LangfuseDecorator:
 
                     try:
                         result = await func(*args, **kwargs)
-
-                        if capture_output is True:
-                            if inspect.isgenerator(result):
-                                is_return_type_generator = True
-
-                                return self._wrap_sync_generator_result(
-                                    langfuse_span_or_generation,
-                                    result,
-                                    transform_to_string,
-                                )
-
-                            if inspect.isasyncgen(result):
-                                is_return_type_generator = True
-
-                                return self._wrap_async_generator_result(
-                                    langfuse_span_or_generation,
-                                    result,
-                                    transform_to_string,
-                                )
-
-                            # handle starlette.StreamingResponse
-                            if type(result).__name__ == "StreamingResponse" and hasattr(
-                                result, "body_iterator"
-                            ):
-                                is_return_type_generator = True
-
-                                result.body_iterator = (
-                                    self._wrap_async_generator_result(
-                                        langfuse_span_or_generation,
-                                        result.body_iterator,
-                                        transform_to_string,
-                                    )
-                                )
-
-                            langfuse_span_or_generation.update(output=result)
-
+                        (
+                            is_return_type_generator,
+                            result,
+                        ) = self._handle_observe_result(
+                            langfuse_span_or_generation,
+                            result,
+                            capture_output=capture_output,
+                            transform_to_string=transform_to_string,
+                        )
                         return result
                     except (Exception, asyncio.CancelledError) as e:
                         langfuse_span_or_generation.update(
@@ -408,42 +381,15 @@ class LangfuseDecorator:
 
                     try:
                         result = func(*args, **kwargs)
-
-                        if capture_output is True:
-                            if inspect.isgenerator(result):
-                                is_return_type_generator = True
-
-                                return self._wrap_sync_generator_result(
-                                    langfuse_span_or_generation,
-                                    result,
-                                    transform_to_string,
-                                )
-
-                            if inspect.isasyncgen(result):
-                                is_return_type_generator = True
-
-                                return self._wrap_async_generator_result(
-                                    langfuse_span_or_generation,
-                                    result,
-                                    transform_to_string,
-                                )
-
-                            # handle starlette.StreamingResponse
-                            if type(result).__name__ == "StreamingResponse" and hasattr(
-                                result, "body_iterator"
-                            ):
-                                is_return_type_generator = True
-
-                                result.body_iterator = (
-                                    self._wrap_async_generator_result(
-                                        langfuse_span_or_generation,
-                                        result.body_iterator,
-                                        transform_to_string,
-                                    )
-                                )
-
-                            langfuse_span_or_generation.update(output=result)
-
+                        (
+                            is_return_type_generator,
+                            result,
+                        ) = self._handle_observe_result(
+                            langfuse_span_or_generation,
+                            result,
+                            capture_output=capture_output,
+                            transform_to_string=transform_to_string,
+                        )
                         return result
                     except (Exception, asyncio.CancelledError) as e:
                         langfuse_span_or_generation.update(
@@ -493,6 +439,7 @@ class LangfuseDecorator:
             LangfuseGuardrail,
         ],
         generator: Generator,
+        capture_output: bool,
         transform_to_string: Optional[Callable[[Iterable], str]] = None,
     ) -> Any:
         preserved_context = contextvars.copy_context()
@@ -501,6 +448,7 @@ class LangfuseDecorator:
             generator,
             preserved_context,
             langfuse_span_or_generation,
+            capture_output,
             transform_to_string,
         )
 
@@ -518,6 +466,7 @@ class LangfuseDecorator:
             LangfuseGuardrail,
         ],
         generator: AsyncGenerator,
+        capture_output: bool,
         transform_to_string: Optional[Callable[[Iterable], str]] = None,
     ) -> Any:
         preserved_context = contextvars.copy_context()
@@ -526,8 +475,60 @@ class LangfuseDecorator:
             generator,
             preserved_context,
             langfuse_span_or_generation,
+            capture_output,
             transform_to_string,
         )
+
+    def _handle_observe_result(
+        self,
+        langfuse_span_or_generation: Union[
+            LangfuseSpan,
+            LangfuseGeneration,
+            LangfuseAgent,
+            LangfuseTool,
+            LangfuseChain,
+            LangfuseRetriever,
+            LangfuseEvaluator,
+            LangfuseEmbedding,
+            LangfuseGuardrail,
+        ],
+        result: Any,
+        *,
+        capture_output: bool,
+        transform_to_string: Optional[Callable[[Iterable], str]] = None,
+    ) -> Tuple[bool, Any]:
+        if inspect.isgenerator(result):
+            return True, self._wrap_sync_generator_result(
+                langfuse_span_or_generation,
+                result,
+                capture_output,
+                transform_to_string,
+            )
+
+        if inspect.isasyncgen(result):
+            return True, self._wrap_async_generator_result(
+                langfuse_span_or_generation,
+                result,
+                capture_output,
+                transform_to_string,
+            )
+
+        # handle starlette.StreamingResponse
+        if type(result).__name__ == "StreamingResponse" and hasattr(
+            result, "body_iterator"
+        ):
+            result.body_iterator = self._wrap_async_generator_result(
+                langfuse_span_or_generation,
+                result.body_iterator,
+                capture_output,
+                transform_to_string,
+            )
+            return True, result
+
+        if capture_output is True:
+            langfuse_span_or_generation.update(output=result)
+
+        return False, result
 
 
 _decorator = LangfuseDecorator()
@@ -553,12 +554,14 @@ class _ContextPreservedSyncGeneratorWrapper:
             LangfuseEmbedding,
             LangfuseGuardrail,
         ],
+        capture_output: bool,
         transform_fn: Optional[Callable[[Iterable], str]],
     ) -> None:
         self.generator = generator
         self.context = context
         self.items: List[Any] = []
         self.span = span
+        self.capture_output = capture_output
         self.transform_fn = transform_fn
 
     def __iter__(self) -> "_ContextPreservedSyncGeneratorWrapper":
@@ -574,15 +577,18 @@ class _ContextPreservedSyncGeneratorWrapper:
 
         except StopIteration:
             # Handle output and span cleanup when generator is exhausted
-            output: Any = self.items
+            if self.capture_output:
+                output: Any = self.items
 
-            if self.transform_fn is not None:
-                output = self.transform_fn(self.items)
+                if self.transform_fn is not None:
+                    output = self.transform_fn(self.items)
 
-            elif all(isinstance(item, str) for item in self.items):
-                output = "".join(self.items)
+                elif all(isinstance(item, str) for item in self.items):
+                    output = "".join(self.items)
 
-            self.span.update(output=output).end()
+                self.span.update(output=output)
+
+            self.span.end()
 
             raise  # Re-raise StopIteration
 
@@ -612,12 +618,14 @@ class _ContextPreservedAsyncGeneratorWrapper:
             LangfuseEmbedding,
             LangfuseGuardrail,
         ],
+        capture_output: bool,
         transform_fn: Optional[Callable[[Iterable], str]],
     ) -> None:
         self.generator = generator
         self.context = context
         self.items: List[Any] = []
         self.span = span
+        self.capture_output = capture_output
         self.transform_fn = transform_fn
 
     def __aiter__(self) -> "_ContextPreservedAsyncGeneratorWrapper":
@@ -642,15 +650,18 @@ class _ContextPreservedAsyncGeneratorWrapper:
 
         except StopAsyncIteration:
             # Handle output and span cleanup when generator is exhausted
-            output: Any = self.items
+            if self.capture_output:
+                output: Any = self.items
 
-            if self.transform_fn is not None:
-                output = self.transform_fn(self.items)
+                if self.transform_fn is not None:
+                    output = self.transform_fn(self.items)
 
-            elif all(isinstance(item, str) for item in self.items):
-                output = "".join(self.items)
+                elif all(isinstance(item, str) for item in self.items):
+                    output = "".join(self.items)
 
-            self.span.update(output=output).end()
+                self.span.update(output=output)
+
+            self.span.end()
 
             raise  # Re-raise StopAsyncIteration
         except (Exception, asyncio.CancelledError) as e:

--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -571,7 +571,8 @@ class _ContextPreservedSyncGeneratorWrapper:
         try:
             # Run the generator's __next__ in the preserved context
             item = self.context.run(next, self.generator)
-            self.items.append(item)
+            if self.capture_output:
+                self.items.append(item)
 
             return item
 
@@ -644,7 +645,8 @@ class _ContextPreservedAsyncGeneratorWrapper:
                 # Python < 3.10 fallback - context parameter not supported
                 item = await self.generator.__anext__()
 
-            self.items.append(item)
+            if self.capture_output:
+                self.items.append(item)
 
             return item
 

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -1,0 +1,90 @@
+import sys
+
+import pytest
+
+from langfuse import observe
+from langfuse._client.attributes import LangfuseOtelSpanAttributes
+
+
+def _finished_spans_by_name(memory_exporter, name: str):
+    return [span for span in memory_exporter.get_finished_spans() if span.name == name]
+
+
+def test_sync_generator_preserves_context_without_output_capture(
+    langfuse_memory_client, memory_exporter
+):
+    @observe(name="child_step")
+    def child_step(index: int) -> str:
+        return f"item_{index}"
+
+    @observe(name="root", capture_output=False)
+    def root():
+        def body():
+            for index in range(2):
+                yield child_step(index)
+
+        return body()
+
+    generator = root()
+
+    assert memory_exporter.get_finished_spans() == []
+
+    assert list(generator) == ["item_0", "item_1"]
+
+    langfuse_memory_client.flush()
+
+    root_span = _finished_spans_by_name(memory_exporter, "root")[0]
+    child_spans = _finished_spans_by_name(memory_exporter, "child_step")
+
+    assert len(child_spans) == 2
+    assert all(child.parent is not None for child in child_spans)
+    assert all(
+        child.parent.span_id == root_span.context.span_id for child in child_spans
+    )
+    assert all(
+        child.context.trace_id == root_span.context.trace_id for child in child_spans
+    )
+    assert LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT not in root_span.attributes
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="requires python3.11 or higher")
+async def test_streaming_response_preserves_context_without_output_capture(
+    langfuse_memory_client, memory_exporter
+):
+    class StreamingResponse:
+        def __init__(self, body_iterator):
+            self.body_iterator = body_iterator
+
+    @observe(name="stream_step")
+    async def stream_step(index: int) -> str:
+        return f"chunk_{index}"
+
+    async def body():
+        for index in range(2):
+            yield await stream_step(index)
+
+    @observe(name="endpoint", capture_output=False)
+    async def endpoint():
+        return StreamingResponse(body())
+
+    response = await endpoint()
+
+    assert memory_exporter.get_finished_spans() == []
+
+    assert [item async for item in response.body_iterator] == ["chunk_0", "chunk_1"]
+
+    langfuse_memory_client.flush()
+
+    endpoint_span = _finished_spans_by_name(memory_exporter, "endpoint")[0]
+    step_spans = _finished_spans_by_name(memory_exporter, "stream_step")
+
+    assert len(step_spans) == 2
+    assert all(step.parent is not None for step in step_spans)
+    assert all(
+        step.parent.span_id == endpoint_span.context.span_id for step in step_spans
+    )
+    assert all(
+        step.context.trace_id == endpoint_span.context.trace_id for step in step_spans
+    )
+    assert LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT not in endpoint_span.attributes

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -30,6 +30,7 @@ def test_sync_generator_preserves_context_without_output_capture(
     assert memory_exporter.get_finished_spans() == []
 
     assert list(generator) == ["item_0", "item_1"]
+    assert generator.items == []
 
     langfuse_memory_client.flush()
 
@@ -73,6 +74,7 @@ async def test_streaming_response_preserves_context_without_output_capture(
     assert memory_exporter.get_finished_spans() == []
 
     assert [item async for item in response.body_iterator] == ["chunk_0", "chunk_1"]
+    assert response.body_iterator.items == []
 
     langfuse_memory_client.flush()
 


### PR DESCRIPTION
## Summary
- preserve generator and `StreamingResponse.body_iterator` wrapping even when `capture_output=False`
- keep deferred span finalization tied to stream consumption while still skipping output capture when disabled
- add unit regressions for sync generators and async streaming responses with disabled output capture

## Verification
- `uv run --frozen pytest tests/unit/test_observe.py`
- `uv run --frozen ruff check langfuse/_client/observe.py tests/unit/test_observe.py`
- `uv run --frozen ruff format --check langfuse/_client/observe.py tests/unit/test_observe.py`
- `uv run --frozen mypy langfuse/_client/observe.py --no-error-summary`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a regression where `capture_output=False` inadvertently skipped generator and `StreamingResponse.body_iterator` wrapping entirely, causing spans to close prematurely instead of deferring finalization until stream exhaustion and breaking context propagation for nested `@observe` calls. The fix extracts a `_handle_observe_result` helper that unconditionally wraps all streaming result types, passing `capture_output` into the wrapper classes so they skip `span.update(output=…)` without affecting `span.end()` or context preservation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is logically correct and well-targeted, with only a minor memory efficiency suggestion remaining.

All identified findings are P2: unconditional item accumulation when capture_output=False wastes memory but does not affect correctness or observable behavior, and test coverage for the direct async-generator path is a nice-to-have. No P0/P1 issues found. The core fix (unconditional wrapping, conditional output recording) is sound.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| langfuse/_client/observe.py | Extracts _handle_observe_result to unconditionally wrap generators/StreamingResponses regardless of capture_output, propagating the flag into wrapper classes to conditionally skip output recording while preserving deferred span finalization and context propagation. |
| tests/unit/test_observe.py | New unit test file with regression tests for sync generator and StreamingResponse with capture_output=False; covers context propagation, deferred span finalization, and absence of output attribute. Direct async generator path (inspect.isasyncgen) is not explicitly tested with capture_output=False. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["func returns result"] --> B["_handle_observe_result()"]
    B --> C{inspect.isgenerator?}
    C -- Yes --> D["_wrap_sync_generator_result(capture_output)"]
    D --> E["_ContextPreservedSyncGeneratorWrapper"]
    E --> F{Item yielded}
    F -- next item --> G["context.run(next, generator)\nappend to items"]
    G --> F
    F -- StopIteration --> H{capture_output?}
    H -- True --> I["span.update(output=items)\nspan.end()"]
    H -- False --> J["span.end()"]
    C -- No --> K{inspect.isasyncgen?}
    K -- Yes --> L["_wrap_async_generator_result(capture_output)"]
    L --> M["_ContextPreservedAsyncGeneratorWrapper"]
    M --> N{Item yielded}
    N -- next item --> O["create_task(__anext__, context)\nappend to items"]
    O --> N
    N -- StopAsyncIteration --> P{capture_output?}
    P -- True --> Q["span.update(output=items)\nspan.end()"]
    P -- False --> R["span.end()"]
    K -- No --> S{StreamingResponse?}
    S -- Yes --> T["wrap body_iterator\nreturn True, result"]
    S -- No --> U{capture_output?}
    U -- True --> V["span.update(output=result)\nreturn False, result"]
    U -- False --> W["return False, result"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: langfuse/_client/observe.py
Line: 574

Comment:
**Unnecessary item accumulation when `capture_output=False`**

Both `_ContextPreservedSyncGeneratorWrapper` and `_ContextPreservedAsyncGeneratorWrapper` unconditionally append every yielded item to `self.items`, even when `capture_output=False`. When output capture is disabled, `self.items` is never read, so this allocates memory proportional to the full stream size for no purpose. For large LLM streaming outputs this is wasteful.

Guard the append in both wrappers:
```python
if self.capture_output:
    self.items.append(item)
```

The same fix applies to `_ContextPreservedAsyncGeneratorWrapper.__anext__` at the equivalent line (~line 647).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observe): preserve streaming context..."](https://github.com/langfuse/langfuse-python/commit/75eec096582d66cd39017a5471a321589f0a3b5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28662484)</sub>

<!-- /greptile_comment -->