### PR TITLE
ci: use explicit version for `fetch-metadata` version comment

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR updates the human-readable version comment on the `dependabot/fetch-metadata` action from `# v3` to `# v3.0.0`. The underlying SHA pin (`ffa630c65fa7e0ecfa0625b5ceda64399aea1b36`) is unchanged, so there is no functional impact.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only a comment change, no logic or pin modifications.

The change is purely cosmetic (comment text), with the actual SHA pin left intact. No P0/P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dependabot-merge.yml | Updates the version comment on the pinned `dependabot/fetch-metadata` action from `# v3` to `# v3.0.0`; the SHA pin itself is unchanged. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub
    participant WF as dependabot-merge.yml
    participant FM as dependabot/fetch-metadata@SHA
    participant GH_CLI as gh CLI

    GH->>WF: pull_request event (dependabot[bot])
    WF->>FM: Fetch PR metadata (github-token)
    FM-->>WF: update-type output
    alt update-type == version-update:semver-patch
        WF->>GH_CLI: gh pr merge --auto --squash $PR_URL
        GH_CLI-->>GH: Auto-merge enabled
    end
```

<sub>Reviews (1): Last reviewed commit: ["ci: use explicit version"](https://github.com/langfuse/langfuse-python/commit/f4a7ae7cc77729247aa528223c253176764c7ba8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28980435)</sub>

<!-- /greptile_comment -->