### PR TITLE
fix(observe): preserve streaming context without output capture

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -563,9 +563,55 @@ class _ContextPreservedSyncGeneratorWrapper:
         self.span = span
         self.capture_output = capture_output
         self.transform_fn = transform_fn
+        self._span_ended = False
 
     def __iter__(self) -> "_ContextPreservedSyncGeneratorWrapper":
         return self
+
+    def _finalize(self) -> None:
+        if self._span_ended:
+            return
+
+        if self.capture_output:
+            output: Any = self.items
+
+            if self.transform_fn is not None:
+                output = self.transform_fn(self.items)
+
+            elif all(isinstance(item, str) for item in self.items):
+                output = "".join(self.items)
+
+            self.span.update(output=output)
+
+        self.span.end()
+        self._span_ended = True
+
+    def _finalize_with_error(self, error: BaseException) -> None:
+        if self._span_ended:
+            return
+
+        self.span.update(
+            level="ERROR", status_message=str(error) or type(error).__name__
+        ).end()
+        self._span_ended = True
+
+    def close(self) -> None:
+        if self._span_ended:
+            return
+
+        try:
+            self.generator.close()
+        except (Exception, asyncio.CancelledError) as error:
+            self._finalize_with_error(error)
+            raise
+        else:
+            self._finalize()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except BaseException:
+            pass
 
     def __next__(self) -> Any:
         try:
@@ -577,27 +623,11 @@ class _ContextPreservedSyncGeneratorWrapper:
             return item
 
         except StopIteration:
-            # Handle output and span cleanup when generator is exhausted
-            if self.capture_output:
-                output: Any = self.items
-
-                if self.transform_fn is not None:
-                    output = self.transform_fn(self.items)
-
-                elif all(isinstance(item, str) for item in self.items):
-                    output = "".join(self.items)
-
-                self.span.update(output=output)
-
-            self.span.end()
-
+            self._finalize()
             raise  # Re-raise StopIteration
 
         except (Exception, asyncio.CancelledError) as e:
-            self.span.update(
-                level="ERROR", status_message=str(e) or type(e).__name__
-            ).end()
-
+            self._finalize_with_error(e)
             raise
 
 
@@ -628,9 +658,55 @@ class _ContextPreservedAsyncGeneratorWrapper:
         self.span = span
         self.capture_output = capture_output
         self.transform_fn = transform_fn
+        self._span_ended = False
 
     def __aiter__(self) -> "_ContextPreservedAsyncGeneratorWrapper":
         return self
+
+    def _finalize(self) -> None:
+        if self._span_ended:
+            return
+
+        if self.capture_output:
+            output: Any = self.items
+
+            if self.transform_fn is not None:
+                output = self.transform_fn(self.items)
+
+            elif all(isinstance(item, str) for item in self.items):
+                output = "".join(self.items)
+
+            self.span.update(output=output)
+
+        self.span.end()
+        self._span_ended = True
+
+    def _finalize_with_error(self, error: BaseException) -> None:
+        if self._span_ended:
+            return
+
+        self.span.update(
+            level="ERROR", status_message=str(error) or type(error).__name__
+        ).end()
+        self._span_ended = True
+
+    async def aclose(self) -> None:
+        if self._span_ended:
+            return
+
+        try:
+            await self.generator.aclose()
+        except (Exception, asyncio.CancelledError) as error:
+            self._finalize_with_error(error)
+            raise
+        else:
+            self._finalize()
+
+    async def close(self) -> None:
+        await self.aclose()
+
+    def __del__(self) -> None:
+        self._finalize()
 
     async def __anext__(self) -> Any:
         try:
@@ -651,24 +727,8 @@ class _ContextPreservedAsyncGeneratorWrapper:
             return item
 
         except StopAsyncIteration:
-            # Handle output and span cleanup when generator is exhausted
-            if self.capture_output:
-                output: Any = self.items
-
-                if self.transform_fn is not None:
-                    output = self.transform_fn(self.items)
-
-                elif all(isinstance(item, str) for item in self.items):
-                    output = "".join(self.items)
-
-                self.span.update(output=output)
-
-            self.span.end()
-
+            self._finalize()
             raise  # Re-raise StopAsyncIteration
         except (Exception, asyncio.CancelledError) as e:
-            self.span.update(
-                level="ERROR", status_message=str(e) or type(e).__name__
-            ).end()
-
+            self._finalize_with_error(e)
             raise

--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -600,7 +600,7 @@ class _ContextPreservedSyncGeneratorWrapper:
             return
 
         try:
-            self.generator.close()
+            self.context.run(self.generator.close)
         except (Exception, asyncio.CancelledError) as error:
             self._finalize_with_error(error)
             raise
@@ -695,7 +695,13 @@ class _ContextPreservedAsyncGeneratorWrapper:
             return
 
         try:
-            await self.generator.aclose()
+            try:
+                await asyncio.create_task(
+                    self.generator.aclose(),
+                    context=self.context,
+                )  # type: ignore
+            except TypeError:
+                await self.generator.aclose()
         except (Exception, asyncio.CancelledError) as error:
             self._finalize_with_error(error)
             raise

--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -701,7 +701,7 @@ class _ContextPreservedAsyncGeneratorWrapper:
                     context=self.context,
                 )  # type: ignore
             except TypeError:
-                await self.generator.aclose()
+                await self.context.run(asyncio.create_task, self.generator.aclose())
         except (Exception, asyncio.CancelledError) as error:
             self._finalize_with_error(error)
             raise
@@ -718,14 +718,17 @@ class _ContextPreservedAsyncGeneratorWrapper:
         try:
             # Run the generator's __anext__ in the preserved context
             try:
-                # Python 3.10+ approach with context parameter
+                # Python 3.11+ approach with explicit task context
                 item = await asyncio.create_task(
                     self.generator.__anext__(),  # type: ignore
                     context=self.context,
                 )  # type: ignore
             except TypeError:
-                # Python < 3.10 fallback - context parameter not supported
-                item = await self.generator.__anext__()
+                # Python 3.10 fallback - create the task inside the preserved context.
+                item = await self.context.run(
+                    asyncio.create_task,
+                    self.generator.__anext__(),  # type: ignore
+                )
 
             if self.capture_output:
                 self.items.append(item)

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -137,6 +137,37 @@ def test_sync_generator_wrapper_close_ends_span_without_exhaustion() -> None:
     assert span.updates == []
 
 
+def test_sync_generator_wrapper_close_preserves_context() -> None:
+    marker = contextvars.ContextVar("marker", default="ambient")
+    seen: list[str] = []
+
+    def generator() -> Generator[str, None, None]:
+        try:
+            yield "item_0"
+            yield "item_1"
+        finally:
+            seen.append(marker.get())
+
+    span = SpanRecorder()
+    context = contextvars.copy_context()
+    context.run(marker.set, "preserved")
+    wrapper = _ContextPreservedSyncGeneratorWrapper(
+        generator(),
+        context,
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert next(wrapper) == "item_0"
+    marker.set("ambient-now")
+
+    wrapper.close()
+
+    assert seen == ["preserved"]
+    assert span.ended == 1
+
+
 def test_sync_generator_wrapper_del_ends_span_when_abandoned() -> None:
     def generator() -> Generator[str, None, None]:
         yield "item_0"
@@ -182,6 +213,38 @@ async def test_async_generator_wrapper_aclose_ends_span_without_exhaustion() -> 
 
     assert span.ended == 1
     assert span.updates == []
+
+
+@pytest.mark.asyncio
+async def test_async_generator_wrapper_aclose_preserves_context() -> None:
+    marker = contextvars.ContextVar("marker", default="ambient")
+    seen: list[str] = []
+
+    async def generator() -> AsyncGenerator[str, None]:
+        try:
+            yield "item_0"
+            yield "item_1"
+        finally:
+            seen.append(marker.get())
+
+    span = SpanRecorder()
+    context = contextvars.copy_context()
+    context.run(marker.set, "preserved")
+    wrapper = _ContextPreservedAsyncGeneratorWrapper(
+        generator(),
+        context,
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert await wrapper.__anext__() == "item_0"
+    marker.set("ambient-now")
+
+    await wrapper.aclose()
+
+    assert seen == ["preserved"]
+    assert span.ended == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -1,25 +1,47 @@
+import asyncio
+import contextvars
+import gc
 import sys
+from typing import Any, AsyncGenerator, Generator, cast
 
 import pytest
 
 from langfuse import observe
 from langfuse._client.attributes import LangfuseOtelSpanAttributes
+from langfuse._client.observe import (
+    _ContextPreservedAsyncGeneratorWrapper,
+    _ContextPreservedSyncGeneratorWrapper,
+)
 
 
-def _finished_spans_by_name(memory_exporter, name: str):
+class SpanRecorder:
+    def __init__(self) -> None:
+        self.ended = 0
+        self.updates: list[dict[str, Any]] = []
+
+    def update(self, **kwargs: Any) -> "SpanRecorder":
+        self.updates.append(kwargs)
+        return self
+
+    def end(self) -> "SpanRecorder":
+        self.ended += 1
+        return self
+
+
+def _finished_spans_by_name(memory_exporter: Any, name: str) -> list[Any]:
     return [span for span in memory_exporter.get_finished_spans() if span.name == name]
 
 
 def test_sync_generator_preserves_context_without_output_capture(
-    langfuse_memory_client, memory_exporter
-):
+    langfuse_memory_client: Any, memory_exporter: Any
+) -> None:
     @observe(name="child_step")
     def child_step(index: int) -> str:
         return f"item_{index}"
 
     @observe(name="root", capture_output=False)
-    def root():
-        def body():
+    def root() -> Generator[str, None, None]:
+        def body() -> Generator[str, None, None]:
             for index in range(2):
                 yield child_step(index)
 
@@ -30,7 +52,7 @@ def test_sync_generator_preserves_context_without_output_capture(
     assert memory_exporter.get_finished_spans() == []
 
     assert list(generator) == ["item_0", "item_1"]
-    assert generator.items == []
+    assert cast(Any, generator).items == []
 
     langfuse_memory_client.flush()
 
@@ -51,22 +73,22 @@ def test_sync_generator_preserves_context_without_output_capture(
 @pytest.mark.asyncio
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="requires python3.11 or higher")
 async def test_streaming_response_preserves_context_without_output_capture(
-    langfuse_memory_client, memory_exporter
-):
+    langfuse_memory_client: Any, memory_exporter: Any
+) -> None:
     class StreamingResponse:
-        def __init__(self, body_iterator):
+        def __init__(self, body_iterator: AsyncGenerator[str, None]) -> None:
             self.body_iterator = body_iterator
 
     @observe(name="stream_step")
     async def stream_step(index: int) -> str:
         return f"chunk_{index}"
 
-    async def body():
+    async def body() -> AsyncGenerator[str, None]:
         for index in range(2):
             yield await stream_step(index)
 
     @observe(name="endpoint", capture_output=False)
-    async def endpoint():
+    async def endpoint() -> StreamingResponse:
         return StreamingResponse(body())
 
     response = await endpoint()
@@ -74,7 +96,7 @@ async def test_streaming_response_preserves_context_without_output_capture(
     assert memory_exporter.get_finished_spans() == []
 
     assert [item async for item in response.body_iterator] == ["chunk_0", "chunk_1"]
-    assert response.body_iterator.items == []
+    assert cast(Any, response.body_iterator).items == []
 
     langfuse_memory_client.flush()
 
@@ -90,3 +112,98 @@ async def test_streaming_response_preserves_context_without_output_capture(
         step.context.trace_id == endpoint_span.context.trace_id for step in step_spans
     )
     assert LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT not in endpoint_span.attributes
+
+
+def test_sync_generator_wrapper_close_ends_span_without_exhaustion() -> None:
+    def generator() -> Generator[str, None, None]:
+        yield "item_0"
+        yield "item_1"
+
+    span = SpanRecorder()
+    wrapper = _ContextPreservedSyncGeneratorWrapper(
+        generator(),
+        contextvars.copy_context(),
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert next(wrapper) == "item_0"
+
+    wrapper.close()
+    wrapper.close()
+
+    assert span.ended == 1
+    assert span.updates == []
+
+
+def test_sync_generator_wrapper_del_ends_span_when_abandoned() -> None:
+    def generator() -> Generator[str, None, None]:
+        yield "item_0"
+        yield "item_1"
+
+    span = SpanRecorder()
+    wrapper = _ContextPreservedSyncGeneratorWrapper(
+        generator(),
+        contextvars.copy_context(),
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert next(wrapper) == "item_0"
+
+    del wrapper
+    gc.collect()
+
+    assert span.ended == 1
+    assert span.updates == []
+
+
+@pytest.mark.asyncio
+async def test_async_generator_wrapper_aclose_ends_span_without_exhaustion() -> None:
+    async def generator() -> AsyncGenerator[str, None]:
+        yield "item_0"
+        yield "item_1"
+
+    span = SpanRecorder()
+    wrapper = _ContextPreservedAsyncGeneratorWrapper(
+        generator(),
+        contextvars.copy_context(),
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert await wrapper.__anext__() == "item_0"
+
+    await wrapper.aclose()
+    await wrapper.close()
+
+    assert span.ended == 1
+    assert span.updates == []
+
+
+@pytest.mark.asyncio
+async def test_async_generator_wrapper_del_ends_span_when_abandoned() -> None:
+    async def generator() -> AsyncGenerator[str, None]:
+        yield "item_0"
+        yield "item_1"
+
+    span = SpanRecorder()
+    wrapper = _ContextPreservedAsyncGeneratorWrapper(
+        generator(),
+        contextvars.copy_context(),
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert await wrapper.__anext__() == "item_0"
+
+    del wrapper
+    gc.collect()
+    await asyncio.sleep(0)
+
+    assert span.ended == 1
+    assert span.updates == []

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -248,6 +248,49 @@ async def test_async_generator_wrapper_aclose_preserves_context() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_generator_wrapper_fallback_preserves_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    marker = contextvars.ContextVar("marker", default="ambient")
+    seen: list[str] = []
+    original_create_task = asyncio.create_task
+
+    def create_task_with_type_error(*args: Any, **kwargs: Any) -> asyncio.Task[Any]:
+        if "context" in kwargs:
+            raise TypeError("context argument unsupported")
+
+        return original_create_task(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "create_task", create_task_with_type_error)
+
+    async def generator() -> AsyncGenerator[str, None]:
+        try:
+            yield marker.get()
+            yield "item_1"
+        finally:
+            seen.append(marker.get())
+
+    span = SpanRecorder()
+    context = contextvars.copy_context()
+    context.run(marker.set, "preserved")
+    wrapper = _ContextPreservedAsyncGeneratorWrapper(
+        generator(),
+        context,
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert await wrapper.__anext__() == "preserved"
+    marker.set("ambient-now")
+
+    await wrapper.aclose()
+
+    assert seen == ["preserved"]
+    assert span.ended == 1
+
+
+@pytest.mark.asyncio
 async def test_async_generator_wrapper_del_ends_span_when_abandoned() -> None:
     async def generator() -> AsyncGenerator[str, None]:
         yield "item_0"


### PR DESCRIPTION
## Summary
- preserve generator and `StreamingResponse.body_iterator` wrapping even when `capture_output=False`
- avoid buffering yielded stream items in memory when output capture is disabled
- finalize wrapped generators on exhaustion, explicit close, and best-effort abandonment cleanup so spans do not stay open indefinitely
- add unit regressions covering sync and async streaming behavior, disabled output capture, and early-terminated wrapper cleanup

## Verification
- `uv run --frozen pytest tests/unit/test_observe.py`
- `uv run --frozen ruff check langfuse/_client/observe.py tests/unit/test_observe.py`
- `uv run --frozen ruff format --check langfuse/_client/observe.py tests/unit/test_observe.py`
- `uv run --frozen mypy langfuse/_client/observe.py tests/unit/test_observe.py --no-error-summary`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a context-propagation bug where `capture_output=False` on a generator-returning or `StreamingResponse`-returning function caused the span to be finalized immediately on function return, orphaning any child spans created during iteration. The fix moves generator detection unconditionally into the new `_handle_observe_result` helper so the span always stays open until the generator is exhausted or closed, while still skipping output buffering when `capture_output=False`. Both wrapper classes gain idempotent `close`/`aclose`/`__del__` finalizers to prevent spans from leaking on early termination or GC.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fix is well-scoped and all remaining findings are P2 suggestions.

No P0/P1 issues found. The logic correctly gates output buffering on `capture_output` while always preserving span context for generator/streaming returns. Idempotency guards prevent double-finalization. The only note is a P2 documentation suggestion about the intentional best-effort async `__del__` behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| langfuse/_client/observe.py | Refactored result-handling into `_handle_observe_result`; generators are now always wrapped (regardless of `capture_output`) so span context is preserved, with output buffering conditionally skipped; wrapper classes gain idempotent `close`/`aclose`/`__del__` finalizers. |
| tests/unit/test_observe.py | New unit tests covering sync/async generator context-preservation with `capture_output=False`, `StreamingResponse` wrapping, double-close idempotency, and `__del__`-based abandonment cleanup for both wrapper types. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Decorated function returns] --> B{_handle_observe_result}
    B -->|isgenerator| C[_wrap_sync_generator_result\ncapture_output passed through]
    B -->|isasyncgen| D[_wrap_async_generator_result\ncapture_output passed through]
    B -->|StreamingResponse| E[wrap body_iterator\ncapture_output passed through]
    B -->|plain value + capture_output=True| F[span.update output=result]
    B -->|plain value + capture_output=False| G[no output update]
    C --> H[_ContextPreservedSyncGeneratorWrapper]
    D --> I[_ContextPreservedAsyncGeneratorWrapper]
    E --> I
    H -->|exhausted / close / __del__| J{capture_output?}
    I -->|exhausted / aclose / __del__| J
    J -->|True| K[span.update output=items\nspan.end]
    J -->|False| L[span.end only\nitems list stays empty]
    F --> M[is_return_type_generator=False\nspan.end in finally]
    G --> M
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: langfuse/_client/observe.py
Line: 708-709

Comment:
**Async generator cleanup skipped in `__del__`**

`__del__` calls `_finalize()` to end the span synchronously, but it never calls `await self.generator.aclose()`. Any `finally` blocks in the underlying async generator will therefore not run when the wrapper is abandoned — only Python's asyncgen hook (installed by the event loop) would eventually close it. This is workable as best-effort cleanup, but it means the span-end time and any generator-side resource cleanup are decoupled. A brief docstring or comment noting this limitation would help future readers understand the intentional trade-off.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observe): finalize abandoned generat..."](https://github.com/langfuse/langfuse-python/commit/c18d0b4de05750187d9c07f46475edd4a8393dd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28986798)</sub>

<!-- /greptile_comment -->