### PR TITLE
chore(ci): pin action version comments to immutable patch tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   linting:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install uv and set Python version
@@ -37,7 +37,7 @@ jobs:
   type-checking:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install uv and set Python version
@@ -78,7 +78,7 @@ jobs:
 
     name: Unit tests on Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install uv and set Python version
@@ -141,7 +141,7 @@ jobs:
 
     name: ${{ matrix.job_name }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install uv and set Python version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/package-availability-check.yml
+++ b/.github/workflows/package-availability-check.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies using pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           INPUTS_CONFIRM_MAJOR: ${{ inputs.confirm_major }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -321,7 +321,7 @@ jobs:
 
       - name: Notify Slack on success
         if: success()
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
           webhook-type: incoming-webhook
@@ -405,7 +405,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_ENGINEERING }}
           webhook-type: incoming-webhook

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Run zizmor


### PR DESCRIPTION
## Summary
Tightens the `# v6` / `# v3` floating-major comments on SHA-pinned actions to their exact patch-level tags:
- `actions/checkout` → `# v6.0.2` (ci.yml, codeql.yml, zizmor.yml, release.yml)
- `actions/setup-python` → `# v6.2.0` (package-availability-check.yml)
- `slackapi/slack-github-action` → `# v3.0.1` (release.yml ×2)

Same SHAs, zero behavior change. The point is to keep the version comment truthful even if upstream moves the `v6` / `v3` floating tag — we just ran into exactly that in langfuse-js (#792), where `actions/setup-node # v6` became stale after upstream released `v6.3.0`.

`orange-buffalo/dependabot-auto-rebase # v1` is intentionally left alone — its pin resolves to a `v1` *branch* head (not a tag), and switching off a mutable ref is a separate decision.

Verified locally with `zizmor --min-severity medium --persona regular` — no findings.

## Test plan
- [ ] zizmor security workflow passes
- [ ] CI still green (no functional change to any action invocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR tightens the version comments on all SHA-pinned GitHub Actions from floating major tags (`# v6`, `# v3`) to exact patch-level tags (`# v6.0.2`, `# v6.2.0`, `# v3.0.1`) across five workflow files. No SHA hashes are changed, so there is zero functional impact — this is purely a documentation hygiene fix to keep comments truthful as upstream repos advance their floating tags.

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only change, all pinned SHAs verified against their claimed tags.

All changes are version-comment updates with no SHA modifications. Web searches confirmed the three tag mappings are accurate. No logic, configuration, or behavior is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Updated 4 `actions/checkout` comment pins from `# v6` to `# v6.0.2`; SHA unchanged, no functional change |
| .github/workflows/codeql.yml | Updated 1 `actions/checkout` comment pin from `# v6` to `# v6.0.2`; SHA unchanged |
| .github/workflows/package-availability-check.yml | Updated `actions/setup-python` comment pin from `# v6` to `# v6.2.0`; SHA unchanged |
| .github/workflows/release.yml | Updated `actions/checkout` to `# v6.0.2` and both `slackapi/slack-github-action` pins to `# v3.0.1`; all SHAs unchanged |
| .github/workflows/zizmor.yml | Updated `actions/checkout` comment pin from `# v6` to `# v6.0.2`; SHA unchanged |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SHA-pinned Action] --> B{Comment before PR}
    B --> C["# v6 (floating major)"]
    C --> D["Could drift if upstream\nmoves the tag"]
    A --> E{Comment after PR}
    E --> F["# v6.0.2 / # v6.2.0 / # v3.0.1\n(exact patch tag)"]
    F --> G["Comment stays truthful\neven as upstream advances"]
    style C fill:#f9c74f
    style F fill:#90be6d
    style D fill:#f94144,color:#fff
    style G fill:#43aa8b,color:#fff
```

<sub>Reviews (1): Last reviewed commit: ["chore(ci): pin action version comments t..."](https://github.com/langfuse/langfuse-python/commit/eb7fc6da1af9a19d847601317d56269d910053c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29151341)</sub>

<!-- /greptile_comment -->