### PR TITLE
chore: improve agent development setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,5 @@
+version = 1
+name = "langfuse-python"
+
+[setup]
+script = "bash scripts/codex/setup.sh"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## What does this PR do?
+
+> PR title must follow Conventional Commits, for example `feat: add dataset scoring helper` or `fix(openai): preserve trace context`.
+
+Fixes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor
+- [ ] Documentation update
+- [ ] Tooling, CI, or repo maintenance
+
+## Verification
+
+List the main commands you ran:
+
+```bash
+
+```
+
+## Checklist
+
+- [ ] I self-reviewed the diff using `code_review.md`.
+- [ ] I added or updated tests for behavior changes.
+- [ ] I updated docs, examples, or `.env.template` if needed.
+- [ ] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
+- [ ] I did not commit secrets or credentials.

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,45 @@
+---
+name: "Validate PR Title"
+
+on:
+  pull_request:
+    branches:
+      - "**"
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: read
+    steps:
+      - name: Validate PR title follows conventional commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            security
+          requireScope: false
+          validateSingleCommit: false
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ docs
 tests/mocks/llama-index-storage
 
 *.local.*
+
+# Codex local runtime state
+.codex/log/
+.codex/sessions/
+.codex/tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This repository contains the Langfuse Python SDK.
 - `tests/live_provider/`: live OpenAI / LangChain provider tests
 - `tests/support/`: shared helpers for e2e tests
 - `scripts/select_e2e_shard.py`: CI shard selector for `tests/e2e`
+- `scripts/codex/`: Codex cloud/worktree bootstrap and shared quick checks
 
 ## Working Style
 
@@ -34,6 +35,8 @@ This repository contains the Langfuse Python SDK.
 - Keep repo-shared instructions here. Keep personal or machine-specific notes out of version control.
 - Keep tests independent and parallel-safe by default.
 - For bug fixes, prefer writing or identifying the failing test first, confirm the failure, then implement the fix.
+- For complex or ambiguous tasks, plan first, identify the likely verification path, then implement.
+- Before final handoff, review the diff for correctness, regressions, missing tests, and accidental generated-file edits.
 
 ## Setup And Quality Commands
 
@@ -43,6 +46,7 @@ uv run pre-commit install
 uv run --frozen ruff check .
 uv run --frozen ruff format .
 uv run --frozen mypy langfuse --no-error-summary
+bash scripts/codex/quick-check.sh
 ```
 
 ## Test Commands
@@ -65,6 +69,18 @@ uv run --frozen pytest -n 4 --dist worksteal tests/live_provider -m "live_provid
 # Single test
 uv run --frozen pytest tests/unit/test_resource_manager.py::test_pause_signals_score_consumer_shutdown
 ```
+
+Minimum verification matrix:
+
+| Change scope | Minimum verification |
+| --- | --- |
+| Docs or comments only | `uv run --frozen ruff format --check .` if Python files changed |
+| Python source only | `uv run --frozen ruff check .` + `uv run --frozen mypy langfuse --no-error-summary` + targeted unit tests |
+| Unit-test-only change | targeted `uv run --frozen pytest ...` for the changed tests |
+| Shutdown, flushing, worker-thread, or OTEL-heavy change | targeted resource-manager/OTEL tests plus affected integration tests when relevant |
+| OpenAI or LangChain instrumentation | targeted unit tests using exporter-local assertions; add e2e/live-provider coverage only when unit tests cannot cover behavior |
+| Generated API client or public API contract | upstream Fern/OpenAPI regeneration path plus targeted SDK serialization/deserialization tests |
+| CI, sharding, or bootstrap | relevant script test plus CI workflow review against this file's CI contract |
 
 ## Test Topology
 
@@ -96,6 +112,7 @@ The main CI workflow currently runs:
 - `tests/unit` on a Python 3.10-3.14 matrix
 - `tests/e2e` in 2 mechanical shards plus a serial subset inside each shard
 - `tests/live_provider` as one always-on suite
+- PR title validation for Conventional Commits
 
 If you change the e2e split:
 
@@ -113,6 +130,7 @@ If you change CI bootstrap:
 - Keep changes scoped. Avoid unrelated refactors.
 - Prefer `LANGFUSE_BASE_URL`; `LANGFUSE_HOST` is deprecated and is only kept for compatibility tests.
 - If you touch `langfuse/api/`, regenerate it from the upstream Fern/OpenAPI source instead of hand-editing files.
+- If you change public SDK behavior, update examples, README snippets, or generated reference docs when they would otherwise become stale.
 - If you touch shutdown, flushing, or worker-thread behavior, run the relevant resource-manager and OTEL-heavy tests.
 - If you change OpenAI or LangChain instrumentation, keep as much coverage as possible in `tests/unit` using exporter-local assertions, and leave only the minimal necessary coverage in `tests/e2e` / `tests/live_provider`.
 - Never commit secrets or credentials.
@@ -120,9 +138,11 @@ If you change CI bootstrap:
 
 ## Commit And PR Rules
 
-- Commit messages and PR titles should follow Conventional Commits: `type(scope): description` or `type: description`.
+- Commit messages and PR titles must follow Conventional Commits: `type(scope): description` or `type: description`.
+- Allowed common types include `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, and `security`.
 - Keep commits focused and atomic.
-- In PR descriptions, list the main verification commands you ran.
+- Before opening a PR, self-review the diff and check `code_review.md` for the repo-specific review checklist.
+- In PR descriptions, list the main verification commands you ran and call out any skipped checks with the reason.
 
 ## Python-Specific Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,48 +4,100 @@
 
 ### Install dependencies
 
-```
-uv sync
+```bash
+uv sync --locked
 ```
 
-### Add Pre-commit
+### Add pre-commit
 
-```
+```bash
 uv run pre-commit install
 ```
 
-### Type Checking
+### Quality checks
 
-To run type checking on the langfuse package, run:
-```sh
-uv run mypy langfuse --no-error-summary
+```bash
+uv run --frozen ruff check .
+uv run --frozen ruff format .
+uv run --frozen mypy langfuse --no-error-summary
+```
+
+For a broad local confidence check, run:
+
+```bash
+bash scripts/codex/quick-check.sh
 ```
 
 ### Tests
 
-#### Setup
+Unit tests do not require a running Langfuse server:
 
-- Add .env based on .env.template
+```bash
+uv run --frozen pytest -n auto --dist worksteal tests/unit
+```
 
-#### Run
+E2E tests require a running Langfuse server and environment variables based on `.env.template`:
 
-- Run all
+```bash
+uv run --frozen pytest -n 4 --dist worksteal tests/e2e -m "not serial_e2e"
+uv run --frozen pytest tests/e2e -m "serial_e2e"
+```
 
-  ```
-  uv run --env-file .env pytest -s -v --log-cli-level=INFO
-  ```
+Live-provider tests make real provider calls and require provider API keys:
 
-- Run a specific test
+```bash
+uv run --frozen pytest -n 4 --dist worksteal tests/live_provider -m "live_provider"
+```
 
-  ```
-  uv run --env-file .env pytest -s -v --log-cli-level=INFO tests/test_core_sdk.py::test_flush
-  ```
+Run a specific test with:
 
-- E2E tests involving OpenAI and Serp API are usually skipped, remove skip decorators in [tests/test_langchain.py](tests/test_langchain.py) to run them.
+```bash
+uv run --frozen pytest tests/unit/test_resource_manager.py::test_pause_signals_score_consumer_shutdown
+```
 
-### Update openapi spec
+## Codex Cloud Setup
 
-A PR with the changes is automatically created upon changing the Spec in the langfuse repo.
+This repository includes repo-owned Codex setup so agents can start from a reproducible environment.
+
+Recommended Codex UI configuration:
+
+1. Create a Codex cloud environment for this repository.
+2. Set the setup script to:
+
+   ```bash
+   bash scripts/codex/setup.sh
+   ```
+
+3. Set the maintenance script to:
+
+   ```bash
+   bash scripts/codex/maintenance.sh
+   ```
+
+4. Keep agent internet access disabled by default, or allow only the domains required for the task.
+5. Add secrets and environment variables in the Codex UI instead of committing them.
+
+## Pull Requests
+
+PR titles and commit messages must follow Conventional Commits:
+
+```text
+type(scope): description
+type: description
+```
+
+Common types include `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, and `security`.
+
+Before opening a PR:
+
+- Self-review the diff and use `code_review.md` for the repo-specific checklist.
+- Keep changes focused and avoid unrelated refactors.
+- Add or update tests for behavior changes.
+- List the verification commands you ran in the PR description.
+
+### Update OpenAPI spec
+
+The generated API client in `langfuse/api/` must not be hand-edited. Regenerate it from the upstream Fern/OpenAPI source.
 
 ### Publish release
 

--- a/code_review.md
+++ b/code_review.md
@@ -1,0 +1,38 @@
+# Langfuse Python SDK Review Checklist
+
+Use this checklist for `/review`, PR review, or self-review before handoff.
+
+## Priorities
+
+- Findings first: correctness bugs, regressions, security/privacy risks, performance issues with real impact, and missing tests for risky behavior.
+- Keep line references tight and actionable.
+- If no findings, say so explicitly and mention any residual risk or unrun verification.
+
+## SDK Correctness
+
+- Public SDK behavior should remain backwards compatible unless the PR is explicitly breaking.
+- Prefer `LANGFUSE_BASE_URL`; `LANGFUSE_HOST` is deprecated and should only appear in compatibility paths or tests.
+- Check shutdown, flushing, background task, and resource-manager changes for races, dropped events/scores/media, daemon-thread leaks, and hanging interpreter shutdown.
+- OpenTelemetry changes should preserve context propagation, span parenting, exporter-local testability, and idempotent instrumentation setup.
+- OpenAI and LangChain instrumentation should avoid brittle assertions on provider internals; prefer stable exporter-local behavior in unit tests.
+
+## API And Generated Code
+
+- Do not hand-edit `langfuse/api/`; regenerate it from the upstream Fern/OpenAPI source.
+- Public API or serialization changes should include tests for request shape, response shape, and backwards-compatible aliases when relevant.
+- Update README examples, `.env.template`, or generated reference docs when changed behavior would make them stale.
+
+## Tests And CI
+
+- Unit tests must not require a running Langfuse server.
+- E2E tests should use bounded polling helpers from `tests/support/`, not raw `sleep()`.
+- New e2e files must be named `tests/e2e/test_*.py` so mechanical CI sharding includes them.
+- Use `serial_e2e` only for tests that are unsafe with shared-server concurrency.
+- Live-provider tests should assert stable provider-facing behavior, not exact observation counts unless counts are the behavior under test.
+
+## Python Style
+
+- Exception messages should not inline f-string literals in `raise` statements; build the message in a variable first.
+- Keep edits ASCII-only unless the file already uses Unicode or Unicode is clearly required.
+- Keep changes scoped; avoid opportunistic refactors.
+- Never commit secrets or credentials.

--- a/scripts/codex/maintenance.sh
+++ b/scripts/codex/maintenance.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+uv sync --locked
+uv cache prune --ci >/dev/null 2>&1 || true

--- a/scripts/codex/quick-check.sh
+++ b/scripts/codex/quick-check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+uv run --frozen ruff check .
+uv run --frozen mypy langfuse --no-error-summary
+uv run --frozen pytest -n auto --dist worksteal tests/unit

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+if ! command -v uv >/dev/null 2>&1; then
+  python3 -m pip install --user "uv==0.11.2"
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+uv sync --locked
+uv run --frozen python --version


### PR DESCRIPTION
## What does this PR do?

Improves the repo setup for productive agent-assisted development without adding project MCP servers.

Changes include:
- Add a Codex environment setup pointer plus reusable `scripts/codex/*` bootstrap, maintenance, and quick-check scripts.
- Expand `AGENTS.md` with concise agent workflow, verification, CI, and PR expectations.
- Refresh `CONTRIBUTING.md` with current `uv --locked` / `uv --frozen` commands, test topology, Codex Cloud setup, PR rules, and generated API guidance.
- Add a reusable `code_review.md` checklist for self-review and review tasks.
- Add a PR template and semantic PR title validation workflow aligned with the main Langfuse repo conventions.
- Ignore local Codex runtime state under `.codex/`.

## Verification

```bash
git diff --check
bash -n scripts/codex/setup.sh scripts/codex/maintenance.sh scripts/codex/quick-check.sh
uv run --frozen ruff check .
uv run --frozen ruff format --check .
bash scripts/codex/setup.sh
bash scripts/codex/maintenance.sh
bash scripts/codex/quick-check.sh
```

`bash scripts/codex/quick-check.sh` passed with Ruff, mypy, and unit tests (`403 passed, 2 skipped`).

## Notes

The project MCP config was intentionally not added. The only `.codex/` file committed is the environment setup pointer.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR improves the agent-assisted development setup by adding reusable Codex bootstrap scripts (`scripts/codex/`), a PR template, a Conventional Commits validation workflow, a self-review checklist (`code_review.md`), and refreshed `CONTRIBUTING.md` / `AGENTS.md` documentation. The changes are additive and do not touch any SDK source code. All three inline findings are P2 style/consistency issues in the new shell scripts.

<h3>Confidence Score: 4/5</h3>

Safe to merge — no SDK source changes; all findings are minor P2 style/consistency issues in the new shell scripts.

Only P2 findings are present (pinned uv version rationale undocumented, missing ruff format check in quick-check.sh, silently suppressed uv cache prune flag). No logic bugs in production code and no security concerns.

scripts/codex/setup.sh — pinned uv version should be validated against the project lockfile format version.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/codex/setup.sh | Bootstrap script for Codex environments; installs uv at a hardcoded version (0.11.2) which may conflict with the project's lockfile format |
| scripts/codex/quick-check.sh | Local confidence-check script; omits `ruff format --check` that is documented as a quality gate in CONTRIBUTING.md and AGENTS.md |
| scripts/codex/maintenance.sh | Sync and cache-prune script; `uv cache prune --ci` is fully suppressed, so an invalid flag would silently be a no-op |
| .github/workflows/validate-pr-title.yml | New workflow enforcing Conventional Commits on PR titles; action is pinned to a commit hash, permissions are minimal and correctly scoped |
| .github/PULL_REQUEST_TEMPLATE.md | Adds standard PR template with checklist and verification section; straightforward documentation change |
| AGENTS.md | Expanded with verification matrix, CI contract notes, and tightened PR rules; content is accurate and consistent |
| CONTRIBUTING.md | Refreshed with current uv commands, Codex Cloud setup guide, and PR expectations; significant improvement over previous sparse content |
| code_review.md | New self-review checklist covering correctness, generated-code rules, CI topology, and Python style; concise and actionable |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer / Codex Agent] --> B{uv installed?}
    B -- No --> C[pip install uv==0.11.2]
    C --> D[export PATH]
    B -- Yes --> E[uv sync --locked]
    D --> E
    E --> F[uv run --frozen python --version]
    F --> G[Environment Ready]

    G --> H[Daily Maintenance]
    H --> H1[uv sync --locked]
    H1 --> H2[uv cache prune --ci]

    G --> I[Quick Check]
    I --> I1[ruff check .]
    I1 --> I2[mypy langfuse]
    I2 --> I3[pytest tests/unit]
    I3 --> J{All Pass?}
    J -- Yes --> K[Open PR]
    J -- No --> L[Fix Issues]
    L --> I

    K --> M[validate-pr-title workflow]
    M --> N{Conventional Commits?}
    N -- Yes --> O[PR Ready for Review]
    N -- No --> P[Block merge]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/codex/setup.sh
Line: 8

Comment:
**Pinned uv version may conflict with lockfile format**

`uv==0.11.2` is installed as the fallback, but `uv sync --locked` is called immediately after with the repo's existing `uv.lock`. If the lockfile was generated with a different uv version (older or newer), the sync can fail due to lockfile format incompatibilities. Consider either pinning to the same version used to generate the lockfile, or adding a comment explaining why `0.11.2` was chosen and how it should be kept in sync with the project's own uv dependency.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/codex/quick-check.sh
Line: 7-9

Comment:
**Missing `ruff format --check` step**

`CONTRIBUTING.md` lists `ruff format .` under "Quality checks" and the AGENTS.md verification matrix calls out `ruff format --check .` for docs/Python changes, but `quick-check.sh` only runs `ruff check .`. This means formatting regressions will pass the quick-check script undetected. Adding `uv run --frozen ruff format --check .` before `ruff check` would make the script consistent with the documented quality gate.

```suggestion
uv run --frozen ruff format --check .
uv run --frozen ruff check .
uv run --frozen mypy langfuse --no-error-summary
uv run --frozen pytest -n auto --dist worksteal tests/unit
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/codex/maintenance.sh
Line: 8

Comment:
**`--ci` flag silently swallowed**

`uv cache prune --ci` is redirected to `/dev/null` and followed by `|| true`, so if `--ci` is not a recognised flag for `uv cache prune` it will fail silently and skip pruning entirely without any indication. Verify that `--ci` is a valid option; if it isn't, removing the flag (or at least not suppressing stderr) would make failures visible.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: improve agent development setup"](https://github.com/langfuse/langfuse-python/commit/2d2ffc8f9ca33afa04a0aa36d090906d876e08f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29804845)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->