### PR TITLE
docs: update README docs link to Python SDK v4 overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ pip install langfuse
 
 ## Docs
 
-Please [see our docs](https://langfuse.com/docs/sdk/python/sdk-v3) for detailed information on this SDK.
+Please [see our docs](https://langfuse.com/docs/observability/sdk/python/overview) for detailed information on this SDK.


### PR DESCRIPTION
## Summary

The README's "Docs" link still points to the legacy v3 docs slug
(`/docs/sdk/python/sdk-v3`) even though the SDK was rewritten in v4
and the current package version is 4.5.1.

This was inconsistent with the existing v4 callout right above it (the
"IMPORTANT" banner that already references `/docs/observability/sdk/...`),
and meant new users following the README landed on stale URL slugs.

## What changed

`README.md` - single link update:
- before: `https://langfuse.com/docs/sdk/python/sdk-v3`
- after:  `https://langfuse.com/docs/observability/sdk/python/overview`

The new URL matches the path style used elsewhere in this README and on
the official docs site for the current Python SDK v4.

## How to test

Open `README.md` in any markdown renderer (or directly on GitHub) and
click the "see our docs" link - it should resolve to the Python SDK v4
overview, not a 404 / legacy redirect.

## Why a 1-line fix

This is in the spirit of `AGENTS.md` Working Style: small, targeted,
preserves existing behavior, and keeps published examples / links up to
date with public SDK behavior (per Repo Rules).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR updates a single documentation link in `README.md`, replacing the stale v3 SDK URL (`/docs/sdk/python/sdk-v3`) with the current v4 path (`/docs/observability/sdk/python/overview`). The new URL is consistent with the v4 migration guide link already present in the same file's IMPORTANT callout.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a single documentation link fix with no code changes.

The change is a one-line URL update in a markdown file. The new URL follows the same path convention already used in the file's IMPORTANT callout, and web search confirms the v4 observability SDK docs exist at that URL structure. No logic, security, or correctness concerns.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Single-link update replacing the legacy v3 SDK docs URL with the current v4 observability SDK overview URL, consistent with the v4 migration guide link already in the same file. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits README.md] --> B{Clicks 'see our docs' link}
    B -- Before PR --> C["langfuse.com/docs/sdk/python/sdk-v3\n(legacy v3 slug)"]
    B -- After PR --> D["langfuse.com/docs/observability/sdk/python/overview\n(current v4 docs)"]
    C --> E["Stale / legacy content"]
    D --> F["Python SDK v4 overview"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: update README docs link to Python ..."](https://github.com/langfuse/langfuse-python/commit/06799660727c8ea90718ca7c54b42261d3fae5b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30270105)</sub>

<!-- /greptile_comment -->