### PR TITLE
ci: allow prerelease branch releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,39 @@ jobs:
     runs-on: ubuntu-latest
     environment: protected branches
     steps:
-      - name: Verify branch
+      - name: Verify release ref
         run: |
-          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-            echo "❌ Error: Releases can only be triggered from main branch"
+          if [ "${GITHUB_REF_TYPE}" != "branch" ]; then
+            echo "❌ Error: Releases can only be triggered from branches"
             echo "Current ref: ${GITHUB_REF}"
             exit 1
           fi
+
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            echo "✅ Official and pre-release releases are allowed from main"
+            exit 0
+          fi
+
+          case "${INPUTS_VERSION}" in
+            prepatch|preminor|premajor)
+              ;;
+            *)
+              echo "❌ Error: Official releases can only be triggered from main branch"
+              echo "Current branch: ${GITHUB_REF_NAME}"
+              echo "Requested version bump: ${INPUTS_VERSION}"
+              exit 1
+              ;;
+          esac
+
+          if [ -z "${INPUTS_PRERELEASE_TYPE}" ]; then
+            echo "❌ Error: Branch releases must specify prerelease_type as alpha, beta, or rc"
+            exit 1
+          fi
+
+          echo "✅ Pre-release branch release allowed from ${GITHUB_REF_NAME}"
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_PRERELEASE_TYPE: ${{ inputs.prerelease_type }}
 
       - name: Confirm major release
         if: ${{ inputs.version == 'major' || inputs.version == 'premajor' }}
@@ -294,7 +320,7 @@ jobs:
         id: push-tag
         run: |
           git tag "v${STEPS_NEW_VERSION_OUTPUTS_VERSION}"
-          git push origin main
+          git push origin "HEAD:${GITHUB_REF_NAME}"
           git push origin "v${STEPS_NEW_VERSION_OUTPUTS_VERSION}"
         env:
           STEPS_NEW_VERSION_OUTPUTS_VERSION: ${{ steps.new-version.outputs.version }}


### PR DESCRIPTION
## Summary

- allow the release workflow to run from non-main branches only for prerelease bumps (`prepatch`, `preminor`, `premajor`) with an explicit `alpha`, `beta`, or `rc` prerelease type
- keep official `patch`, `minor`, and `major` releases restricted to `main`
- push the release commit back to the triggering branch instead of hardcoding `main`

## Root Cause

The release workflow had an early `refs/heads/main` guard and later pushed the version commit with `git push origin main`. That made branch-based prereleases impossible even when the requested release type was explicitly a prerelease.

## Verification

- `git diff --check --cached`
- Ruby YAML parse for `.github/workflows/release.yml`
- local shell harness covering allowed and rejected release-ref combinations

`actionlint` was not available in the local environment.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the release workflow to permit prerelease version bumps (`prepatch`, `preminor`, `premajor`) from non-`main` branches while keeping official releases restricted to `main`, and fixes the version-commit push to target the triggering branch dynamically instead of hardcoding `main`.

- **Branch guard reworked**: the monolithic `refs/heads/main` check is replaced with a two-stage shell conditional — `main` exits early allowing all types, non-main branches are gated to prerelease bump types with a mandatory non-empty `prerelease_type`.
- **Push target corrected**: `git push origin main` is replaced with `git push origin "HEAD:${GITHUB_REF_NAME}"`, so the version bump commit lands on the correct branch regardless of where the workflow was triggered.
- **Minor inconsistency**: the early `exit 0` for `main` skips the `prerelease_type` presence check in the verify step for prerelease bump types, but the downstream "Calculate new version" step enforces the same constraint, so no release can proceed without a valid `prerelease_type` when needed.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the workflow logic correctly enforces branch and prerelease-type constraints, and the push target change eliminates the hardcoded main ref.

The branch guard and push target changes are correct. The only nuance is that the exit 0 shortcut for main skips the prerelease_type presence check in the verify step when doing a prerelease bump, but the Calculate new version step independently enforces the same constraint, so the overall workflow behavior is unaffected.

.github/workflows/release.yml — specifically the main early-exit path and how prerelease_type is validated across the two separate steps.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[workflow_dispatch triggered] --> B{GITHUB_REF_TYPE == 'branch'?}
    B -- No --> FAIL1[❌ Exit 1: must be branch ref]
    B -- Yes --> C{GITHUB_REF_NAME == 'main'?}
    C -- Yes --> D[✅ Exit 0: all release types allowed]
    C -- No --> E{inputs.version in prepatch / preminor / premajor?}
    E -- No --> FAIL2[❌ Exit 1: official releases restricted to main]
    E -- Yes --> F{inputs.prerelease_type is non-empty?}
    F -- No --> FAIL3[❌ Exit 1: branch releases must specify prerelease_type]
    F -- Yes --> G[✅ Pre-release branch release allowed]
    D & G --> H[Confirm major release check if major/premajor]
    H --> I[Checkout, configure git, compute version]
    I --> J[Build, verify, publish to PyPI]
    J --> K["git push origin HEAD:GITHUB_REF_NAME"]
    K --> L[git push tag]
    L --> M[GitHub Release + Slack notify]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: allow prerelease branch releases"](https://github.com/langfuse/langfuse-python/commit/e203deabfc7215643e2e696b33e8999ec24f1d86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31308459)</sub>

<!-- /greptile_comment -->