### PR TITLE
fix(openai): handle Azure stream chunks without delta

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -640,7 +640,9 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
             chunk = chunk.__dict__
 
         model = model or chunk.get("model", None) or None
-        usage = chunk.get("usage", None)
+        chunk_usage = chunk.get("usage", None)
+        if chunk_usage is not None:
+            usage = chunk_usage
 
         choices = chunk.get("choices", [])
 
@@ -649,10 +651,15 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                 choice = choice.__dict__
             if resource.type == "chat":
                 delta = choice.get("delta", None)
-                finish_reason = choice.get("finish_reason", None)
+                choice_finish_reason = choice.get("finish_reason", None)
+                if choice_finish_reason is not None:
+                    finish_reason = choice_finish_reason
 
-                if _is_openai_v1():
+                if _is_openai_v1() and delta is not None:
                     delta = delta.__dict__
+
+                if delta is None:
+                    delta = {}
 
                 if delta.get("role", None) is not None:
                     completion["role"] = delta["role"]

--- a/tests/e2e/test_core_sdk.py
+++ b/tests/e2e/test_core_sdk.py
@@ -2069,8 +2069,9 @@ def test_create_trace_sampling_zero():
     }
 
 
-def test_mask_function():
+def test_mask_function(request):
     LangfuseResourceManager.reset()
+    request.addfinalizer(LangfuseResourceManager.reset)
 
     def mask_func(data):
         if isinstance(data, dict):

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -101,6 +101,64 @@ def _make_chat_stream_chunks():
     ]
 
 
+def _make_chat_stream_chunks_with_trailing_content_filter_chunk():
+    usage = SimpleNamespace(prompt_tokens=3, completion_tokens=1, total_tokens=4)
+
+    return [
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role="assistant",
+                        content="2",
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        ),
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role=None,
+                        content=None,
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=usage,
+        ),
+        SimpleNamespace(
+            model="",
+            choices=[
+                SimpleNamespace(
+                    delta=None,
+                    finish_reason=None,
+                    content_filter_offsets={
+                        "check_offset": 44,
+                        "start_offset": 44,
+                        "end_offset": 121,
+                    },
+                    content_filter_results={
+                        "hate": {"filtered": False, "severity": "safe"},
+                        "self_harm": {"filtered": False, "severity": "safe"},
+                        "sexual": {"filtered": False, "severity": "safe"},
+                        "violence": {"filtered": False, "severity": "safe"},
+                    },
+                )
+            ],
+            usage=None,
+        ),
+    ]
+
+
 def _make_single_chunk_stream():
     return SimpleNamespace(
         model="gpt-4o-mini",
@@ -307,6 +365,41 @@ def test_openai_stream_preserves_original_stream_contract(
         span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME]
         is not None
     )
+    assert span.attributes["langfuse.observation.metadata.finish_reason"] == "stop"
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS) == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
+    }
+
+
+def test_openai_stream_handles_trailing_azure_content_filter_chunk(
+    langfuse_memory_client, get_span, json_attr
+):
+    openai_client = lf_openai.OpenAI(api_key="test")
+    raw_stream = DummyOpenAIStream(
+        _make_chat_stream_chunks_with_trailing_content_filter_chunk(),
+        DummySyncResponse(),
+    )
+
+    with patch.object(openai_client.chat.completions, "_post", return_value=raw_stream):
+        stream = openai_client.chat.completions.create(
+            name="unit-openai-native-stream-azure-filter",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "1 + 1 = ?"}],
+            temperature=0,
+            stream=True,
+        )
+
+    chunks = list(stream)
+    stream.close()
+
+    assert len(chunks) == 3
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-native-stream-azure-filter")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] == "2"
     assert span.attributes["langfuse.observation.metadata.finish_reason"] == "stop"
     assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS) == {
         "prompt_tokens": 3,


### PR DESCRIPTION
## Summary

Fixes Azure OpenAI streaming traces when Azure emits a trailing content-filter chunk whose chat choice has `delta=None`.

The OpenAI stream extractor previously dereferenced `delta.__dict__` unconditionally for OpenAI v1 responses. In Azure deployments with custom content filters, the trailing metadata-only chunk can have no delta, causing final stream extraction to fail internally. Because finalization catches extraction errors, the generation span ended without assistant output or usage details.

This PR:
- treats `delta=None` as an empty delta while continuing to process prior streamed content
- preserves the last non-null `usage` and `finish_reason` across trailing metadata-only chunks
- adds a regression test with an Azure-style trailing content-filter chunk

## Verification

- `uv run --frozen pytest tests/unit/test_openai.py -q`
- `uv run --frozen ruff check langfuse/openai.py tests/unit/test_openai.py`
- `uv run --frozen ruff format --check langfuse/openai.py tests/unit/test_openai.py`
- `uv run --frozen mypy langfuse --no-error-summary`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a crash in Azure OpenAI streaming when Azure emits a trailing content-filter chunk with `delta=None` and `finish_reason=None`, which previously caused finalization to produce spans without output or usage data.

- Adds a `delta is not None` guard before calling `delta.__dict__` for OpenAI v1 objects, then falls back to an empty dict so downstream logic runs safely.
- Changes `usage` and `finish_reason` accumulation to a \"last non-null wins\" pattern, preserving values from earlier normal chunks when a trailing metadata-only chunk clears them.
- Adds a regression test with an Azure-style three-chunk stream (content chunk → stop chunk with usage → trailing content-filter chunk with `delta=None`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped to the stream extractor, does not alter any public API or data model, and is covered by a direct regression test.

The change is a minimal three-part defensive fix in one function, each part independently safe: a null guard on delta before dict conversion, an empty-dict fallback so the rest of the loop body runs unchanged, and a non-null-only assignment pattern for usage and finish_reason. The regression test exercises exactly the failing scenario end-to-end and checks all three affected outputs (content, finish_reason, usage).

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Azure as Azure OpenAI API
    participant Extractor as _extract_streamed_openai_response
    participant Span as Langfuse Span

    Azure->>Extractor: "chunk 1 — delta with content, finish_reason=None, usage=None"
    Note over Extractor: model set, content accumulated
    Azure->>Extractor: "chunk 2 — delta empty, finish_reason="stop", usage={tokens}"
    Note over Extractor: finish_reason preserved (non-null), usage preserved (non-null)
    Azure->>Extractor: "chunk 3 — delta=None, finish_reason=None, usage=None (content-filter)"
    Note over Extractor: delta=None → skip __dict__ → treat as {}<br/>finish_reason=None → keep "stop"<br/>usage=None → keep prior usage
    Extractor->>Span: "finalize with content, finish_reason="stop", usage={tokens}"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(openai): handle Azure stream chunks ..."](https://github.com/langfuse/langfuse-python/commit/a764fb0b792227f3ced3aabfa2c27161ac4400aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31330957)</sub>

<!-- /greptile_comment -->