### PR TITLE
fix(langchain): read AzureOpenAI API version from openai_api_version

### DIFF
--- a/langfuse/langchain/utils.py
+++ b/langfuse/langchain/utils.py
@@ -70,8 +70,12 @@ def _extract_model_name(
 
             serialized_kwargs = serialized.get("kwargs")
             if serialized_kwargs and isinstance(serialized_kwargs, dict):
+                # LangChain's AzureOpenAI exposes the API version under
+                # `openai_api_version`, not `deployment_version` — the latter
+                # is never populated, so previously the version suffix was
+                # dropped from the resulting model name.
                 if serialized_kwargs.get("openai_api_version"):
-                    deployment_version = serialized_kwargs.get("deployment_version")
+                    deployment_version = serialized_kwargs.get("openai_api_version")
 
                 if serialized_kwargs.get("deployment_name"):
                     deployment_name = serialized_kwargs.get("deployment_name")

--- a/tests/unit/test_extract_model_name.py
+++ b/tests/unit/test_extract_model_name.py
@@ -1,0 +1,47 @@
+"""Unit tests for ``langfuse.langchain.utils._extract_model_name``."""
+
+from langfuse.langchain.utils import _extract_model_name
+
+
+def _azure_openai_serialized(
+    *, deployment_name: str, openai_api_version: str | None
+) -> dict:
+    """Build a minimal ``serialized`` dict mirroring what LangChain emits for AzureOpenAI."""
+    kwargs: dict = {"deployment_name": deployment_name}
+    if openai_api_version is not None:
+        kwargs["openai_api_version"] = openai_api_version
+    return {"id": ["langchain", "llms", "openai", "AzureOpenAI"], "kwargs": kwargs}
+
+
+def test_azure_openai_returns_deployment_name_with_api_version_suffix():
+    """Regression: ``openai_api_version`` should be appended to the deployment name.
+
+    Previously the code read the value from a non-existent ``deployment_version``
+    key after checking that ``openai_api_version`` was set, so the suffix was
+    silently dropped.
+    """
+    serialized = _azure_openai_serialized(
+        deployment_name="my-deployment",
+        openai_api_version="2024-02-15-preview",
+    )
+    assert _extract_model_name(serialized) == "my-deployment-2024-02-15-preview"
+
+
+def test_azure_openai_returns_bare_deployment_name_when_no_api_version():
+    serialized = _azure_openai_serialized(
+        deployment_name="my-deployment",
+        openai_api_version=None,
+    )
+    assert _extract_model_name(serialized) == "my-deployment"
+
+
+def test_azure_openai_no_duplicate_version_suffix():
+    """If the deployment_name already contains the version, don't append it again.
+
+    This guards the existing behavior introduced in PR #1203.
+    """
+    serialized = _azure_openai_serialized(
+        deployment_name="my-deployment-2024-02-15-preview",
+        openai_api_version="2024-02-15-preview",
+    )
+    assert _extract_model_name(serialized) == "my-deployment-2024-02-15-preview"


### PR DESCRIPTION
## Summary

`_extract_model_name` for `AzureOpenAI` checks
`serialized_kwargs[\"openai_api_version\"]` to decide whether a version is
available, then reads the value from `serialized_kwargs[\"deployment_version\"]`
(`langfuse/langchain/utils.py:73-74`):

```python
if serialized_kwargs.get(\"openai_api_version\"):
    deployment_version = serialized_kwargs.get(\"deployment_version\")
```

LangChain's `AzureOpenAI` doesn't expose a `deployment_version` field — only
`openai_api_version` and `deployment_name`. So `deployment_version` is always
`None`, the `isinstance(deployment_version, str)` check at line 82 fails, and
the function returns the bare deployment name with no version suffix even
when the API version is available.

This makes the version suffix that PR #1203 (\"fix(langchain): deployment
version in azure model\") was trying to keep deduplicated effectively
unreachable for callers who set `openai_api_version` but use a
deployment_name without an embedded version.

## Fix

Read the value from the same key that gates the branch (`openai_api_version`).
Combined with the dedup logic from #1203, deployments now produce
`<deployment_name>-<api_version>` while still collapsing if the
deployment_name already embeds the version.

```diff
 if serialized_kwargs.get(\"openai_api_version\"):
-    deployment_version = serialized_kwargs.get(\"deployment_version\")
+    deployment_version = serialized_kwargs.get(\"openai_api_version\")
```

## Tests

`tests/unit/test_extract_model_name.py` (new) covers three regression cases:

1. `api_version` present → `\"my-deployment-2024-02-15-preview\"` (was
   `\"my-deployment\"` before this fix).
2. `api_version` absent → `\"my-deployment\"` (unchanged).
3. `deployment_name` already contains the version → no duplication
   (preserves #1203's behavior).

I verified the function-level logic by importing `_extract_model_name`
directly and exercising all three cases against a stubbed `serialized` dict
that mirrors what LangChain emits — pre-fix the first case returns
`\"my-deployment\"`, post-fix it returns `\"my-deployment-2024-02-15-preview\"`.
The repo's full `uv` env wasn't set up in my sandbox, so CI is the canonical
end-to-end run.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a one-line key-name mistake in `_extract_model_name` for `AzureOpenAI`: the branch gated on `openai_api_version` then read from the non-existent `deployment_version`, so the version suffix was always silently dropped. The fix reads from the same key that guards the branch.

- **`langfuse/langchain/utils.py`**: Changes `serialized_kwargs.get(\"deployment_version\")` to `serialized_kwargs.get(\"openai_api_version\")`, making the version lookup consistent with the conditional that gates it.
- **`tests/unit/test_extract_model_name.py`**: Adds three focused regression tests covering: version present → appended, version absent → bare deployment name, and version already embedded in name → no duplication.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line key-name fix with no side effects on other model paths.

The fix correctly aligns the value lookup with the key already used in the conditional guard. The surrounding deduplication logic is untouched, and three targeted regression tests verify the before/after behavior. No other code paths are affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_extract_model_name called] --> B{AzureOpenAI in serialized_id?}
    B -- No --> C[Try other model matchers]
    B -- Yes --> D{invocation_params has model or model_name?}
    D -- Yes --> E[Return invocation_params value]
    D -- No --> F{openai_api_version present in serialized_kwargs?}
    F -- Yes --> G["deployment_version = openai_api_version value FIXED: was deployment_version key, always None"]
    F -- No --> H[deployment_version = None]
    G --> I{deployment_name present?}
    H --> I
    I -- No --> J[Return None]
    I -- Yes --> K[deployment_name = serialized_kwargs value]
    K --> L{deployment_version is str?}
    L -- No --> M[Return bare deployment_name]
    L -- Yes --> N{version already in deployment_name?}
    N -- Yes --> O[Return deployment_name unchanged]
    N -- No --> P[Return deployment_name + version suffix]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): read AzureOpenAI API ver..."](https://github.com/langfuse/langfuse-python/commit/fa2f6eceea7686a0db7140107187a2d8f3295576) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31428906)</sub>

<!-- /greptile_comment -->