### PR TITLE
feat(python-sdk): introduce LangfuseAuthException for auth_check failures

### DIFF
--- a/langfuse/__init__.py
+++ b/langfuse/__init__.py
@@ -29,6 +29,7 @@ from ._client.span import (
     LangfuseTool,
 )
 from ._version import __version__
+from ._utils.request import LangfuseAuthException
 from .span_filter import (
     KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES,
     is_default_export_span,
@@ -66,6 +67,7 @@ __all__ = [
     "RunnerContext",
     "RegressionError",
     "__version__",
+    "LangfuseAuthException",
     "is_default_export_span",
     "is_langfuse_span",
     "is_genai_span",

--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -88,6 +88,7 @@ from langfuse._utils.parse_error import handle_fern_exception
 from langfuse._utils.prompt_cache import PromptCache
 from langfuse._utils.request import LangfuseAuthException
 from langfuse.api import (
+    AccessDeniedError,
     CreateChatPromptRequest,
     CreateChatPromptType,
     CreateTextPromptRequest,
@@ -104,6 +105,7 @@ from langfuse.api import (
     Prompt_Text,
     ScoreBody,
     TraceBody,
+    UnauthorizedError,
 )
 from langfuse.batch_evaluation import (
     BatchEvaluationResult,
@@ -3167,7 +3169,10 @@ class Langfuse:
         """Check if the provided credentials (public and secret key) are valid.
 
         Raises:
-            LangfuseAuthException: If no projects were found for the provided credentials.
+            LangfuseAuthException: If authentication fails. This covers both the
+                "credentials are valid but no projects are accessible" case and
+                the "credentials are invalid" case (HTTP 401 Unauthorized /
+                HTTP 403 Forbidden returned by the Langfuse API).
 
         Note:
             This method is blocking. It is discouraged to use it in production code.
@@ -3188,6 +3193,18 @@ class Langfuse:
                 f"Auth check failed: Client not properly initialized. Error: {e}"
             )
             return False
+
+        except (UnauthorizedError, AccessDeniedError) as e:
+            # HTTP 401 / 403 from the Langfuse API: bad public/secret key or
+            # insufficient permissions. Re-raise as LangfuseAuthException so
+            # callers can catch all auth-failure modes with one except clause,
+            # not just the "zero projects" path above.
+            handle_fern_exception(e)
+            raise LangfuseAuthException(
+                f"Auth check failed: {type(e).__name__} returned by Langfuse API. "
+                "Verify your public/secret key and host. See "
+                "https://langfuse.com/docs/sdk/python#installation-and-setup."
+            ) from e
 
         except Error as e:
             handle_fern_exception(e)

--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -86,6 +86,7 @@ from langfuse._utils import _get_timestamp
 from langfuse._utils.environment import get_common_release_envs
 from langfuse._utils.parse_error import handle_fern_exception
 from langfuse._utils.prompt_cache import PromptCache
+from langfuse._utils.request import LangfuseAuthException
 from langfuse.api import (
     CreateChatPromptRequest,
     CreateChatPromptType,
@@ -3166,7 +3167,7 @@ class Langfuse:
         """Check if the provided credentials (public and secret key) are valid.
 
         Raises:
-            Exception: If no projects were found for the provided credentials.
+            LangfuseAuthException: If no projects were found for the provided credentials.
 
         Note:
             This method is blocking. It is discouraged to use it in production code.
@@ -3177,7 +3178,7 @@ class Langfuse:
                 f"Auth check successful, found {len(projects.data)} projects"
             )
             if len(projects.data) == 0:
-                raise Exception(
+                raise LangfuseAuthException(
                     "Auth check failed, no project found for the keys provided."
                 )
             return True

--- a/langfuse/_utils/request.py
+++ b/langfuse/_utils/request.py
@@ -140,9 +140,11 @@ class LangfuseAuthException(Exception):
     """Raised when Langfuse authentication fails.
 
     This exception is raised when the provided credentials (public key and
-    secret key) are valid but no projects are accessible with them. Catching
-    this specific exception type allows callers to distinguish authentication
-    failures from other errors and handle them explicitly.
+    secret key) fail authentication. This covers both invalid credentials
+    (HTTP 401 Unauthorized / HTTP 403 Forbidden) and the case where valid
+    credentials have no accessible projects. Catching this specific exception
+    type allows callers to distinguish authentication failures from other
+    errors and handle them explicitly.
 
     Example::
 

--- a/langfuse/_utils/request.py
+++ b/langfuse/_utils/request.py
@@ -134,3 +134,25 @@ class APIErrors(Exception):
         errors = ", ".join(str(error) for error in self.errors)
 
         return f"[Langfuse] {errors}"
+
+
+class LangfuseAuthException(Exception):
+    """Raised when Langfuse authentication fails.
+
+    This exception is raised when the provided credentials (public key and
+    secret key) are valid but no projects are accessible with them. Catching
+    this specific exception type allows callers to distinguish authentication
+    failures from other errors and handle them explicitly.
+
+    Example::
+
+        from langfuse import Langfuse, LangfuseAuthException
+
+        try:
+            Langfuse().auth_check()
+        except LangfuseAuthException as e:
+            # Handle auth failure cleanly without masking unrelated bugs
+            logger.warning("Langfuse auth failed: %s", e)
+    """
+
+    pass


### PR DESCRIPTION
## Summary

Closes #906 (filed in langfuse/langfuse).

Bare Exception raises are bad practice in Python because catching them also masks unrelated bugs (ImportError, NameError, SyntaxError, AttributeError, etc.). This is particularly problematic in a pattern like:

\\\python
try:
    langfuse.auth_check()
except Exception as e:
    if is_non_prod:
        logger.info('langfuse not started')
    # silently continues even if e is a SyntaxError in your code!
\\\

## Changes

- **langfuse/_utils/request.py**: Added LangfuseAuthException(Exception) — a dedicated, importable exception class for authentication failures, with a docstring and usage example.
- **langfuse/_client/client.py**: Replaced aise Exception(...) in uth_check() with aise LangfuseAuthException(...) and updated the docstring.
- **langfuse/__init__.py**: Exported LangfuseAuthException from the top-level package.

## After this change

Users can catch auth failures precisely without masking other bugs:

\\\python
from langfuse import Langfuse, LangfuseAuthException

def initialize():
    Langfuse().auth_check()  # any typo here now raises the appropriate error

try:
    initialize()
except LangfuseAuthException as e:
    if environment.is_non_prod:
        logger.info('Langfuse not started: %s', e)
    # SyntaxError, NameError, etc. will still propagate and fail loudly
\\\

## Checklist

- [x] Feature / improvement
- [x] Backward compatible (existing code catching Exception still works; LangfuseAuthException is a subclass of Exception)
- [x] New public symbol exported from langfuse package

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `LangfuseAuthException`, a dedicated exception subclass of `Exception`, to give callers a precise type to catch when `auth_check()` fails, rather than relying on bare `Exception`. The exception is defined in `langfuse/_utils/request.py`, used in `auth_check()`, and exported from the top-level `langfuse` package.

- `LangfuseAuthException` is only raised for the "valid credentials, zero projects" code path. Invalid API keys produce an HTTP 401, which is caught by the `except Error` branch and re-raised as a Fern `Error` — not as `LangfuseAuthException` — so `except LangfuseAuthException` will silently miss the most common auth-failure scenario.
- The docstring in `LangfuseAuthException` acknowledges this scope ("credentials are valid but no projects are accessible"), but the exception's name and its placement in the public API imply broader coverage, which is likely to confuse users.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge if the narrow scope of `LangfuseAuthException` (empty-projects path only) is the intended design; risky if the goal is a single catch-all type for every auth failure.

The new exception only fires in one of three failure branches inside `auth_check()`. A caller with bad API keys will receive an unwrapped Fern `Error`, not `LangfuseAuthException`, so users who adopt the new type expecting full coverage will still see unhandled exceptions in the most common failure scenario.

`langfuse/_client/client.py` — specifically the `except Error` re-raise in `auth_check()` at line 3192–3194, which bypasses the new exception type.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse
    participant API as projects.get()

    User->>Langfuse: auth_check()
    Langfuse->>API: GET /projects

    alt HTTP 401 / bad credentials
        API-->>Langfuse: Fern Error (401)
        Langfuse->>Langfuse: except Error → handle_fern_exception(e)
        Langfuse-->>User: raises Fern Error (NOT LangfuseAuthException)
    end

    alt Valid credentials, empty project list
        API-->>Langfuse: "200 OK, data=[]"
        Langfuse-->>User: raises LangfuseAuthException ✓
    end

    alt Valid credentials, project found
        API-->>Langfuse: "200 OK, data=[project]"
        Langfuse-->>User: returns True
    end

    alt Client not initialized (AttributeError)
        Langfuse->>Langfuse: except AttributeError → log warning
        Langfuse-->>User: returns False
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/_client/client.py:3192-3194
**`LangfuseAuthException` not raised on HTTP 401/403 (invalid credentials)**

The exception is only raised when the API call succeeds but returns an empty projects list. When a caller provides completely wrong API keys, `self.api.projects.get()` will throw a Fern `Error` (e.g. HTTP 401), which is caught by the `except Error` branch and re-raised as-is — **not** as `LangfuseAuthException`. A user who writes `except LangfuseAuthException` to catch all auth failures will silently miss the most common failure case (bad credentials), defeating the purpose of the new exception type.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(python-sdk): introduce LangfuseAuth..."](https://github.com/langfuse/langfuse-python/commit/04590cb97216dac3b808c5090c55ac041d487f07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31759047)</sub>

<!-- /greptile_comment -->