### PR TITLE
chore: add CODEOWNERS for GitHub config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Currently inactive
 # * @langfuse/maintainers
+
+# Require maintainer review for GitHub configuration changes
+.github/ @langfuse/maintainers


### PR DESCRIPTION
## Summary
- add/update `.github/CODEOWNERS` to require `@langfuse/maintainers` review for `.github/` changes

Linear: https://linear.app/langfuse/issue/LFE-9760/repo-owners-for-github-actions

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an active CODEOWNERS rule requiring `@langfuse/maintainers` to review any changes under the `.github/` directory, complementing the previously inactive catch-all comment.

- Adds `.github/ @langfuse/maintainers` to `.github/CODEOWNERS`, so future modifications to GitHub Actions workflows, the CODEOWNERS file itself, and other GitHub config will require maintainer approval.
- The existing commented-out global rule (`* @langfuse/maintainers`) remains inactive; only the `.github/` subtree is covered by this addition.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a safe, minimal change to a GitHub configuration file with no code or workflow logic affected.

The change adds a single CODEOWNERS pattern covering the `.github/` directory. The syntax is correct, the team reference matches the existing commented-out rule, and no other files are touched. Future changes to GitHub Actions and the CODEOWNERS file itself will now require maintainer review.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR touches .github/ files] --> B[CODEOWNERS rule active]
    B --> C[GitHub requests review from @langfuse/maintainers]
    C --> D{Maintainer approves?}
    D -- Yes --> E[PR can be merged]
    D -- No --> F[PR blocked until approval]

    G[PR touches other files] --> H[Global rule inactive - no required reviewer]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add codeowners for github config"](https://github.com/langfuse/langfuse-python/commit/1019f8691345ccfe59d96a23aaa858d780aa7701) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31952319)</sub>

<!-- /greptile_comment -->