### PR TITLE
fix(task_manager): reinitialize consumer threads after os.fork()

### DIFF
--- a/langfuse/_task_manager/task_manager.py
+++ b/langfuse/_task_manager/task_manager.py
@@ -3,6 +3,7 @@
 import atexit
 import logging
 import queue
+import os
 from queue import Queue
 from typing import List, Optional
 
@@ -82,6 +83,47 @@ class TaskManager(object):
 
         # cleans up when the python interpreter closes
         atexit.register(self.shutdown)
+
+        # Register fork handler to reinitialize consumer threads in child process.
+        # When using Gunicorn with --preload, os.fork() copies memory but not threads.
+        # Without this, worker processes have no consumer threads and all events are lost.
+        if hasattr(os, "register_at_fork"):
+            os.register_at_fork(after_in_child=self._at_fork_reinit)
+
+    def _at_fork_reinit(self):
+        """Reinitialize consumer threads after fork in child process.
+ 
+        Called automatically by os.register_at_fork() after fork().
+        Necessary for Gunicorn --preload deployments where os.fork() is used:
+        threads are not copied to child processes (POSIX standard), so without
+        reinitialization, the child process has no consumer threads and all
+        ingestion events are silently lost.
+        """
+        self._log.debug(
+            f"[PID {os.getpid()}] Fork detected: reinitializing Langfuse consumer threads"
+        )
+ 
+        # Clear existing consumer references (threads are dead in child process)
+        self._ingestion_consumers = []
+        self._media_upload_consumers = []
+ 
+        # Recreate queues (old queues may have shared state with parent process)
+        self._ingestion_queue = queue.Queue(self._max_task_queue_size)
+        self._media_upload_queue = Queue(self._max_task_queue_size)
+ 
+        # Recreate MediaManager with new queue
+        self._media_manager = MediaManager(
+            api_client=self._api_client,
+            media_upload_queue=self._media_upload_queue,
+            max_retries=self._max_retries,
+        )
+ 
+        # Start fresh consumer threads in child process
+        self.init_resources()
+ 
+        self._log.debug(
+            f"[PID {os.getpid()}] Langfuse consumer threads reinitialized after fork"
+        )
 
     def init_resources(self):
         for i in range(self._threads):

--- a/langfuse/_task_manager/task_manager.py
+++ b/langfuse/_task_manager/task_manager.py
@@ -2,8 +2,8 @@
 
 import atexit
 import logging
-import queue
 import os
+import queue
 import weakref
 from queue import Queue
 from typing import List, Optional

--- a/langfuse/_task_manager/task_manager.py
+++ b/langfuse/_task_manager/task_manager.py
@@ -4,6 +4,7 @@ import atexit
 import logging
 import queue
 import os
+import weakref
 from queue import Queue
 from typing import List, Optional
 
@@ -36,6 +37,7 @@ class TaskManager(object):
     _sdk_integration: str
     _sample_rate: float
     _mask: Optional[MaskFunction]
+    _shutdown: bool
 
     def __init__(
         self,
@@ -78,6 +80,7 @@ class TaskManager(object):
         self._enabled = enabled
         self._sample_rate = sample_rate
         self._mask = mask
+        self._shutdown = False
 
         self.init_resources()
 
@@ -88,7 +91,10 @@ class TaskManager(object):
         # When using Gunicorn with --preload, os.fork() copies memory but not threads.
         # Without this, worker processes have no consumer threads and all events are lost.
         if hasattr(os, "register_at_fork"):
-            os.register_at_fork(after_in_child=self._at_fork_reinit)
+            weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
+            os.register_at_fork(
+                after_in_child=lambda: weak_reinit()() if weak_reinit() is not None else None
+            )
 
     def _at_fork_reinit(self):
         """Reinitialize consumer threads after fork in child process.
@@ -99,6 +105,9 @@ class TaskManager(object):
         reinitialization, the child process has no consumer threads and all
         ingestion events are silently lost.
         """
+        if self._shutdown:
+            return
+
         self._log.debug(
             f"[PID {os.getpid()}] Fork detected: reinitializing Langfuse consumer threads"
         )
@@ -232,6 +241,8 @@ class TaskManager(object):
     def shutdown(self):
         """Flush all messages and cleanly shutdown the client."""
         self._log.debug("shutdown initiated")
+
+        self._shutdown = True
 
         # Unregister the atexit handler first
         atexit.unregister(self.shutdown)


### PR DESCRIPTION
## What does this PR do?

When using Gunicorn with `--preload`, `os.fork()` copies memory but not threads (POSIX standard).
Worker processes inherit the `TaskManager` object but have no consumer threads, so all ingestion
events are silently lost and calling `flush()` blocks forever on `queue.join()` → Gunicorn worker
timeout (SIGABRT).

Fix by registering `os.register_at_fork(after_in_child=self._at_fork_reinit)` in `TaskManager.__init__`
to reinitialize consumer threads, queues, and `MediaManager` in the child process after fork.

Reproduction example: https://github.com/pyg410/langfuse-gunicorn-example

> A process shall be created with a single thread. If a multi-threaded process calls fork(), the new process shall contain a replica of the calling thread and its entire address space, possibly including the states of mutexes and other resources. Consequently, to avoid errors, the child process may only execute async-signal-safe operations until such time as one of the exec functions is called.(https://pubs.opengroup.org/onlinepubs/9699919799/functions/fork.html)

## Type of change
- [x] Bug fix

## Verification

```bash
# Reproduction example: https://github.com/pyg410/langfuse-gunicorn-example

# issue case (patched task_manager.py NOT applied)
gunicorn app:app -w 4 -k uvicorn.workers.UvicornWorker --preload

# normal case (patched task_manager.py applied)
gunicorn app:app -w 4 -k uvicorn.workers.UvicornWorker --preload
```

## Checklist
- [x] I self-reviewed the diff using `code_review.md`.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes silent data loss and `flush()` deadlocks in Gunicorn `--preload` deployments by registering an `os.register_at_fork(after_in_child=...)` callback that recreates consumer threads, queues, and `MediaManager` in each forked worker process.

- The core approach (`register_at_fork` + full reinitialization of queues and threads) correctly addresses the POSIX fork-thread problem and matches the pattern used by Python's own `threading` module.
- Two issues need attention: the fork handler stores a permanent strong reference to the bound method (preventing GC of `TaskManager` and all its resources when multiple clients are created), and there is no guard to skip reinitialization when the manager was already shut down before the fork occurred.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The fix correctly solves the Gunicorn --preload data-loss bug, but two defects in the implementation need to be addressed before merging.

The fork handler permanently pins every TaskManager instance in memory (along with its threads, queues, and API client) because os.register_at_fork holds an unbreakable strong reference to the bound method. In applications or test suites that create multiple Langfuse clients this becomes a resource leak with no way to recover. Additionally, if shutdown() is called in the master process before Gunicorn forks, _at_fork_reinit will silently restart consumer threads in the child on a manager that was intentionally stopped.

langfuse/_task_manager/task_manager.py — both the fork-handler reference lifetime and the missing shutdown-guard need to be revisited before this ships.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant MP as Master Process
    participant OS as os.fork()
    participant CP as Child Process (Worker)

    MP->>MP: TaskManager.__init__()
    MP->>MP: init_resources() — start consumer threads
    MP->>MP: atexit.register(self.shutdown)
    MP->>MP: "os.register_at_fork(after_in_child=_at_fork_reinit)"

    MP->>OS: Gunicorn calls fork()
    OS-->>CP: Child inherits memory (queues, config, atexit handlers)
    Note over CP: Consumer threads NOT inherited (POSIX)

    OS->>CP: Calls _at_fork_reinit() [after_in_child]
    CP->>CP: Clear _ingestion_consumers and _media_upload_consumers
    CP->>CP: Recreate _ingestion_queue and _media_upload_queue
    CP->>CP: Recreate MediaManager (fresh locks)
    CP->>CP: init_resources() — start new consumer threads

    CP->>CP: Process requests → add_task() → queue
    CP->>CP: Consumer threads drain queue → send to Langfuse API
    CP->>CP: On exit: atexit fires shutdown() → flush() + join()
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
langfuse/_task_manager/task_manager.py:3-7
`import os` was inserted after `import queue`, breaking PEP 8 alphabetical ordering within the stdlib import block. It should appear before `import queue`.

```suggestion
import atexit
import logging
import os
import queue
from queue import Queue
```

### Issue 2 of 3
langfuse/_task_manager/task_manager.py:91
**Fork handler accumulates strong references, preventing GC**

`os.register_at_fork` stores the callback permanently in a process-level list. Passing the bound method `self._at_fork_reinit` keeps a strong reference to each `TaskManager` instance alive for the lifetime of the process — including all its associated threads, queues, and API clients. There is no way to un-register a fork handler. If users create multiple `Langfuse()` clients (e.g. across tests or re-initializations), every `TaskManager` will be pinned in memory and its background threads will remain running indefinitely, even after the user drops all references. Using a `weakref` and skipping the callback when the object has already been collected would prevent this leak.

### Issue 3 of 3
langfuse/_task_manager/task_manager.py:93-126
**`_at_fork_reinit` restarts threads on an already-shutdown manager**

`os.register_at_fork` callbacks are never removed, so if `shutdown()` is called in the master process before Gunicorn forks, the child process will still call `_at_fork_reinit`. This restarts consumer threads on a manager that was intentionally torn down, and the child's atexit-registered `shutdown()` will then try to flush and join them — potentially generating spurious outbound API traffic or blocking on exit in a worker that was never meant to send data. Adding a guard like a `_shutdown` flag would prevent reinitialization on already-stopped instances.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(task\_manager): reinitialize consumer..."](https://github.com/langfuse/langfuse-python/commit/6d8dccd59edcaa8f9380935e7be8fa73e87f3632) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32149605)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->