### PR TITLE
langchain: use langchain_core as version sentinel instead of umbrella

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -38,9 +38,15 @@ from langfuse.logger import langfuse_logger
 from langfuse.types import TraceContext
 
 try:
-    import langchain
+    # Use langchain_core as the version sentinel instead of the langchain
+    # umbrella package: langchain_core is the common runtime dependency of
+    # langchain, langgraph, and every langchain-* provider package, so it
+    # is present on every install that needs this handler. Importing the
+    # umbrella here previously forced langchain itself to be installed
+    # even for the v1 branch, which never uses any langchain.* import.
+    import langchain_core
 
-    if langchain.__version__.startswith("1"):
+    if langchain_core.__version__.startswith("1"):
         # Langchain v1
         from langchain_core.agents import AgentAction, AgentFinish
         from langchain_core.callbacks import (
@@ -59,7 +65,7 @@ try:
         from langchain_core.outputs import ChatGeneration, LLMResult
 
     else:
-        # Langchain v0
+        # Langchain v0 — these symbols only exist in the umbrella package
         from langchain.callbacks.base import (  # type: ignore
             BaseCallbackHandler as LangchainBaseCallbackHandler,
         )
@@ -81,7 +87,7 @@ try:
 
 except ImportError:
     raise ModuleNotFoundError(
-        "Please install langchain to use the Langfuse langchain integration: 'pip install langchain'"
+        "Please install langchain_core to use the Langfuse langchain integration: 'pip install langchain-core'"
     )
 
 LANGSMITH_TAG_HIDDEN: str = "langsmith:hidden"


### PR DESCRIPTION
`CallbackHandler` imported the `langchain` umbrella package purely to read `langchain.__version__` and pick the v1 vs v0 branch. The v1 branch then does all of its imports from `langchain_core`, never touching the umbrella. Anyone using LangGraph or any `langchain-*` provider package already pulls `langchain_core` as a transitive dependency, so requiring the umbrella here forced an unnecessary install on v1 users.

Switch the sentinel to `langchain_core.__version__` and keep the umbrella imports scoped inside the v0 branch where they are actually needed.

Fixes langfuse/langfuse#13651

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces `langchain.__version__` with `langchain_core.__version__` as the version sentinel that decides whether to use v0 or v1 LangChain imports, removing the hard dependency on the `langchain` umbrella package for users who only need v1 symbols (which all live in `langchain_core`).

- The v1 import path (`langchain_core.__version__.startswith(\"1\")`) is now entirely self-contained within `langchain_core`, which is the correct and sufficient package for those users.
- The v0 fallback branch still imports from the `langchain` umbrella, but the single `except ImportError` handler now emits \"please install langchain-core\" for any import failure — including failures from the v0 umbrella imports — giving incorrect guidance to users who already have `langchain_core` installed but are missing `langchain`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe for v1 users, but the generic catch-all error handler now gives wrong installation advice to v0 users who have langchain_core without the langchain umbrella.

The v1 happy path is correct and the motivation is sound. The catch block, however, now misleads v0 users: if langchain_core is present but the langchain umbrella is not, the ImportError from the v0 branch is caught and tells the user to reinstall the package they already have, rather than pointing them to the actual missing package.

langfuse/langchain/CallbackHandler.py — specifically the shared except ImportError block that catches errors from both the sentinel import and the v0-branch umbrella imports.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[import langchain_core] -->|ImportError| E["raise ModuleNotFoundError\n'pip install langchain-core'"]
    A -->|success| B{"langchain_core.__version__\n.startswith('1')?"}
    B -->|True - v1 path| C["Import all symbols\nfrom langchain_core.*"]
    B -->|False - v0 path| D["Import from langchain.* umbrella\n+ langchain_core.*"]
    D -->|ImportError - langchain umbrella missing| E2["raise ModuleNotFoundError\n'pip install langchain-core'\n(wrong: langchain_core is already present)"]
    C --> F[Handler available]
    D -->|success| F
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/langchain/CallbackHandler.py:88-91
**Misleading error message when `langchain` umbrella is missing on the v0 path**

A user who has `langchain_core` 0.x installed (e.g. via LangGraph) but does not have the `langchain` umbrella will enter the v0 branch and immediately hit an `ImportError` on `from langchain.callbacks.base import ...`. That error is caught here and re-raised telling them `pip install langchain-core` — but `langchain-core` is already present. The real fix is `pip install langchain`. This is exactly the class of user the PR description says will benefit from this change, so they are particularly likely to hit it on a 0.x core install.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["langchain: use langchain\_core as version..."](https://github.com/langfuse/langfuse-python/commit/3d1a6f462bbc06ed4b2116acef2476c4b157ceab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32460275)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->