### PR TITLE
fix(serializer): detect cycles in dict/list/Sequence/__slots__ branches

### DIFF
--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -126,21 +126,55 @@ class EventSerializer(JSONEncoder):
             if isinstance(obj, (tuple, set, frozenset)):
                 return list(obj)
 
+            # Cycle detection for the container branches. Without these guards a
+            # cyclic dict/list/Sequence/__slots__ graph recurses until the
+            # RecursionError is swallowed inside Python's GC, leaving the asyncio
+            # loop GIL-starved (issue #1655). try/finally + discard keeps a
+            # shared object reachable from sibling subtrees (a DAG, not a cycle)
+            # from being mis-marked.
             if isinstance(obj, dict):
-                return {self.default(k): self.default(v) for k, v in obj.items()}
+                obj_id = id(obj)
+                if obj_id in self.seen:
+                    return f"<cycle:{type(obj).__name__}>"
+                self.seen.add(obj_id)
+                try:
+                    return {self.default(k): self.default(v) for k, v in obj.items()}
+                finally:
+                    self.seen.discard(obj_id)
 
             if isinstance(obj, list):
-                return [self.default(item) for item in obj]
+                obj_id = id(obj)
+                if obj_id in self.seen:
+                    return f"<cycle:{type(obj).__name__}>"
+                self.seen.add(obj_id)
+                try:
+                    return [self.default(item) for item in obj]
+                finally:
+                    self.seen.discard(obj_id)
 
             # Important: this needs to be always checked after str and bytes types
             # Useful for serializing protobuf messages
             if isinstance(obj, Sequence):
-                return [self.default(item) for item in obj]
+                obj_id = id(obj)
+                if obj_id in self.seen:
+                    return f"<cycle:{type(obj).__name__}>"
+                self.seen.add(obj_id)
+                try:
+                    return [self.default(item) for item in obj]
+                finally:
+                    self.seen.discard(obj_id)
 
             if hasattr(obj, "__slots__"):
-                return self.default(
-                    {slot: getattr(obj, slot, None) for slot in obj.__slots__}
-                )
+                obj_id = id(obj)
+                if obj_id in self.seen:
+                    return f"<cycle:{type(obj).__name__}>"
+                self.seen.add(obj_id)
+                try:
+                    return self.default(
+                        {slot: getattr(obj, slot, None) for slot in obj.__slots__}
+                    )
+                finally:
+                    self.seen.discard(obj_id)
             elif hasattr(obj, "__dict__"):
                 obj_id = id(obj)
 
@@ -149,8 +183,10 @@ class EventSerializer(JSONEncoder):
                     return type(obj).__name__
                 else:
                     self.seen.add(obj_id)
-                    result = {k: self.default(v) for k, v in vars(obj).items()}
-                    self.seen.remove(obj_id)
+                    try:
+                        result = {k: self.default(v) for k, v in vars(obj).items()}
+                    finally:
+                        self.seen.discard(obj_id)
 
                     return result
 

--- a/tests/unit/test_serializer_cycle_detection.py
+++ b/tests/unit/test_serializer_cycle_detection.py
@@ -1,0 +1,215 @@
+"""Regression tests for issue #1655 — cycle detection on the dict / list /
+Sequence / __slots__ branches of EventSerializer. Pre-fix these branches
+recursed forever, the RecursionError was swallowed inside GC, and the
+asyncio loop was GIL-starved for minutes."""
+
+import json
+import time
+from collections.abc import Sequence
+
+from langfuse._utils.serializer import EventSerializer
+
+
+def test_dict_self_cycle_does_not_recurse():
+    d = {"a": 1}
+    d["self"] = d
+
+    parsed = json.loads(EventSerializer().encode(d))
+
+    assert parsed["a"] == 1
+    assert "cycle" in parsed["self"]
+    assert "dict" in parsed["self"]
+
+
+def test_list_self_cycle_does_not_recurse():
+    lst = [1, 2, 3]
+    lst.append(lst)
+
+    parsed = json.loads(EventSerializer().encode(lst))
+
+    assert parsed[:3] == [1, 2, 3]
+    assert "cycle" in parsed[3]
+    assert "list" in parsed[3]
+
+
+def test_slots_self_cycle_does_not_recurse():
+    """__slots__-only object (no __dict__) with a self-referential slot."""
+
+    class SlotsObj:
+        __slots__ = ("name", "ref")
+
+        def __init__(self):
+            self.name = "outer"
+            self.ref = None
+
+    obj = SlotsObj()
+    obj.ref = obj
+
+    parsed = json.loads(EventSerializer().encode(obj))
+
+    assert parsed["name"] == "outer"
+    assert "cycle" in parsed["ref"]
+
+
+def test_cycle_encode_completes_quickly():
+    """Pre-fix this hung the interpreter at the recursion limit while the
+    asyncio loop sat GIL-starved. With the guard it returns instantly."""
+    d = {"a": 1}
+    d["self"] = d
+
+    start = time.monotonic()
+    EventSerializer().encode(d)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, f"encode took {elapsed:.3f}s — cycle detection regressed"
+
+
+def test_mutual_dict_cycle():
+    """a -> b -> a — cycle straddles two distinct dict ids."""
+    a = {}
+    b = {}
+    a["b"] = b
+    b["a"] = a
+
+    encoded = EventSerializer().encode(a)
+    json.loads(encoded)
+    assert "cycle" in encoded
+
+
+def test_mixed_container_cycle_dict_through_list():
+    """dict -> list -> dict_self — both the dict and list guards must fire."""
+    d = {}
+    d["children"] = [d]
+
+    encoded = EventSerializer().encode(d)
+    json.loads(encoded)
+    assert "cycle" in encoded
+
+
+def test_object_cycle_through_dict_attribute():
+    """__dict__ object whose attribute is a cyclic dict — the __dict__
+    branch hands off to the new dict branch's guard."""
+
+    class Holder:
+        def __init__(self):
+            self.cfg = {"holder": None}
+            self.cfg["holder"] = self.cfg
+
+    parsed = json.loads(EventSerializer().encode(Holder()))
+
+    assert "holder" in parsed["cfg"]
+    assert "cycle" in parsed["cfg"]["holder"]
+
+
+def test_shared_dict_in_siblings_is_not_marked_as_cycle():
+    """DAG, not cycle. try/finally + discard is what makes this pass —
+    a stay-forever `seen` set would falsely flag the second visit."""
+    shared = {"value": 42}
+    container = {"left": shared, "right": shared}
+
+    encoded = EventSerializer().encode(container)
+    parsed = json.loads(encoded)
+
+    assert parsed["left"] == {"value": 42}
+    assert parsed["right"] == {"value": 42}
+    assert "cycle" not in encoded
+
+
+def test_shared_list_in_siblings_is_not_marked_as_cycle():
+    shared = [1, 2, 3]
+    container = {"first": shared, "second": shared}
+
+    encoded = EventSerializer().encode(container)
+    parsed = json.loads(encoded)
+
+    assert parsed["first"] == [1, 2, 3]
+    assert parsed["second"] == [1, 2, 3]
+    assert "cycle" not in encoded
+
+
+def test_deeply_nested_non_cyclic_serialises_fully():
+    """50-level linear chain — depth alone must not trip the guard."""
+    cur = {"depth": 50}
+    for i in range(49, 0, -1):
+        cur = {"depth": i, "child": cur}
+
+    parsed = json.loads(EventSerializer().encode(cur))
+
+    walked = parsed
+    for expected in range(1, 51):
+        assert walked["depth"] == expected
+        walked = walked.get("child", walked)
+
+
+def test_dict_attribute_self_cycle_preserves_existing_marker():
+    """Back-compat: the existing __dict__ branch marker is the bare class
+    name, not the new <cycle:Type> form. Left untouched — the fix is
+    purely additive on the previously unprotected branches."""
+
+    class Node:
+        def __init__(self, name):
+            self.name = name
+            self.parent = None
+
+    node = Node("root")
+    node.parent = node
+
+    parsed = json.loads(EventSerializer().encode(node))
+
+    assert parsed["name"] == "root"
+    assert parsed["parent"] == "Node"
+
+
+def test_encode_called_twice_does_not_leak_seen_state():
+    """encode() clears `seen` at the top; the new try/finally also
+    discards mid-walk. Two back-to-back cyclic encodes on the same
+    instance must both succeed independently."""
+    serializer = EventSerializer()
+
+    first = {"x": 1}
+    first["self"] = first
+    second = {"y": 2}
+    second["self"] = second
+
+    parsed_first = json.loads(serializer.encode(first))
+    parsed_second = json.loads(serializer.encode(second))
+
+    assert parsed_first["x"] == 1 and "cycle" in parsed_first["self"]
+    assert parsed_second["y"] == 2 and "cycle" in parsed_second["self"]
+
+
+class _CycleSequence(Sequence):
+    """Minimal user-defined Sequence (not a list) — exercises the
+    Sequence-only branch's new guard."""
+
+    def __init__(self):
+        self._items = []
+
+    def __getitem__(self, index):
+        return self._items[index]
+
+    def __len__(self):
+        return len(self._items)
+
+    def append(self, item):
+        self._items.append(item)
+
+
+def test_custom_sequence_self_cycle_does_not_recurse():
+    seq = _CycleSequence()
+    seq.append("x")
+    seq.append(seq)
+
+    # _CycleSequence has __dict__, so the __dict__ branch is hit first;
+    # either way the encode must terminate and produce valid JSON.
+    json.loads(EventSerializer().encode(seq))
+
+
+def test_empty_containers_unchanged():
+    assert EventSerializer().encode({}) == "{}"
+    assert EventSerializer().encode([]) == "[]"
+
+
+def test_non_cyclic_dict_passthrough():
+    data = {"name": "alice", "age": 30, "tags": ["a", "b"]}
+    assert json.loads(EventSerializer().encode(data)) == data


### PR DESCRIPTION
## Summary

Fixes #1655.

`EventSerializer.default` only guarded the `__dict__` branch against cyclic object graphs. Cycles through the `dict`, `list`, `Sequence`, or `__slots__` branches recursed until the resulting `RecursionError` was swallowed inside Python's GC machinery, leaving the asyncio event loop GIL-starved for minutes (a real production symptom — repro and stack details on the issue).

The same `id()`-keyed `seen` pattern is now applied to the four uncovered branches. Each guard is wrapped in `try` / `finally` with `set.discard`, so a shared object reachable from two sibling subtrees (a DAG, not a cycle) is **not** mis-marked. The pre-existing `__dict__` branch behaviour and cycle-marker format are unchanged — the change is purely additive.

Marker format on the new branches is `"<cycle:<Type>>"` (as suggested in the issue body); the existing `__dict__` marker stays as bare `type(obj).__name__` to preserve back-compat.

### Why this matters
- Silent: the `RecursionError` is raised inside a GC finalizer and dropped — there is no exception in user code, just a stalled event loop.
- Triggers in real workloads via the `@observe` decorator when a logged payload happens to be cyclic (e.g. an OAuth token-refresh log record on FastAPI workers).

## Changes
- `langfuse/_utils/serializer.py` — id-based cycle guard added to the `dict`, `list`, `Sequence`, and `__slots__` branches (mirroring the existing `__dict__` guard). The `__dict__` branch's `set.remove` was switched to `set.discard` inside a `try` / `finally` so an exception mid-walk no longer leaks `seen` state.
- `tests/unit/test_serializer_cycle_detection.py` — 15 new regression tests covering:
  - direct self-cycles on each branch (`dict`, `list`, custom `Sequence`, `__slots__`-only object)
  - mutual cycles (`a → b → a`) and mixed-container cycles (`dict → list → dict`)
  - shared-object DAGs are **not** flagged as cycles
  - 50-level non-cyclic chains serialise fully
  - back-to-back encodes on the same instance do not leak `seen` state
  - the existing `__dict__` cycle marker (`type(obj).__name__`) is preserved
  - the encode of a cyclic dict completes in under 1 s (the GIL-starvation symptom)

## Test plan
- [x] `uv run --frozen pytest tests/unit/test_serializer_cycle_detection.py tests/unit/test_serializer.py -v` — 33 / 33 pass
- [x] `uv run --frozen pytest -n auto --dist worksteal tests/unit` — 435 pass, 2 skipped, 0 fail
- [x] `uv run --frozen ruff check .` (changed files) — clean
- [x] `uv run --frozen ruff format --check .` (changed files) — already formatted
- [x] `uv run --frozen mypy langfuse --no-error-summary` — clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent production hang (issue #1655) where cyclic object graphs passed through `@observe` could stall the asyncio event loop: the `RecursionError` was swallowed inside Python's GC, never surfacing to user code. The same `id()`-based cycle guard that already existed for the `__dict__` branch is now applied to the `dict`, `list`, `Sequence`, and `__slots__` branches, each wrapped in `try/finally` + `set.discard` so that shared-but-non-cyclic objects (DAGs) are not incorrectly flagged.

- The four previously unprotected branches (`dict`, `list`, `Sequence`, `__slots__`) now detect cycles and return a `\"<cycle:Type>\"` sentinel instead of recursing; the pre-existing `__dict__` marker format (`type(obj).__name__`) is left unchanged for back-compat.
- The `__dict__` branch is hardened: `set.remove` (which can raise `KeyError` if state is corrupt) is replaced with `set.discard` inside a `try/finally`, matching the new branches.
- 15 regression tests cover self-cycles, mutual cycles, mixed-container cycles, DAG correctness, back-to-back encode state isolation, and a timing assertion guarding against the original GIL-starvation symptom.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. Changes are additive cycle guards on four previously unprotected branches, each using the same try/finally + discard pattern so DAGs are not incorrectly flagged, and the test suite is thorough.

One test comment incorrectly describes which branch is exercised for _CycleSequence — the Sequence branch fires before __dict__, not after — which could mislead future maintainers tracing a regression. The production code itself is correct; this is a documentation gap in the test file only.

The comment at line 203 of tests/unit/test_serializer_cycle_detection.py should be corrected before merge.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["EventSerializer.default(obj)"] --> B{Type dispatch}
    B -->|tuple/set/frozenset| C["return list(obj)\nno cycle guard needed"]
    B -->|dict| D{"id in seen?"}
    B -->|list| E{"id in seen?"}
    B -->|Sequence| F{"id in seen?"}
    B -->|has slots| G{"id in seen?"}
    B -->|has dict| H{"id in seen?"}
    D -->|yes| I["return cycle:dict sentinel"]
    D -->|no| J["add id to seen\nrecurse keys+values\nfinally discard id"]
    E -->|yes| K["return cycle:list sentinel"]
    E -->|no| L["add id to seen\nrecurse items\nfinally discard id"]
    F -->|yes| M["return cycle:Sequence sentinel"]
    F -->|no| N["add id to seen\nrecurse items\nfinally discard id"]
    G -->|yes| O["return cycle:SlotType sentinel"]
    G -->|no| P["add id to seen\nrecurse slots dict\nfinally discard id"]
    H -->|yes| Q["return type name\nback-compat marker"]
    H -->|no| R["add id to seen\nrecurse __dict__\nfinally discard id"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/test_serializer_cycle_detection.py:203-204
The comment is incorrect about which branch is exercised. `_CycleSequence` inherits directly from `collections.abc.Sequence`, so `isinstance(seq, Sequence)` is `True` and the `Sequence` branch (line 157 of `serializer.py`) is reached before the `__dict__` branch is ever considered. The `__dict__` branch is only reachable via the `elif`, which is skipped once the earlier `isinstance(obj, Sequence)` guard fires. The test verifies valid behaviour regardless, but the comment misdirects future readers about which code path is under test.

```suggestion
    # _CycleSequence inherits from collections.abc.Sequence, so the
    # Sequence branch in EventSerializer.default is hit first (before __dict__);
    # either way the encode must terminate and produce valid JSON.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(serializer): detect cycles in dict/l..."](https://github.com/langfuse/langfuse-python/commit/657cc2e883aacf6391fef26380620de77ac01d0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32665350)</sub>

<!-- /greptile_comment -->