### PR TITLE
Fix swallowed TypeError in async generator wrapper fallback

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -1,3 +1,4 @@
+import sys
 import asyncio
 import contextvars
 import inspect
@@ -695,13 +696,16 @@ class _ContextPreservedAsyncGeneratorWrapper:
             return
 
         try:
-            try:
+            if sys.version_info >= (3, 11):
                 await asyncio.create_task(
                     self.generator.aclose(),
                     context=self.context,
                 )  # type: ignore
-            except TypeError:
-                await self.context.run(asyncio.create_task, self.generator.aclose())
+            else:
+                await self.context.run(
+                    asyncio.create_task,
+                    self.generator.aclose(),
+                )
         except (Exception, asyncio.CancelledError) as error:
             self._finalize_with_error(error)
             raise
@@ -717,14 +721,12 @@ class _ContextPreservedAsyncGeneratorWrapper:
     async def __anext__(self) -> Any:
         try:
             # Run the generator's __anext__ in the preserved context
-            try:
-                # Python 3.11+ approach with explicit task context
+            if sys.version_info >= (3, 11):
                 item = await asyncio.create_task(
                     self.generator.__anext__(),  # type: ignore
                     context=self.context,
                 )  # type: ignore
-            except TypeError:
-                # Python 3.10 fallback - create the task inside the preserved context.
+            else:
                 item = await self.context.run(
                     asyncio.create_task,
                     self.generator.__anext__(),  # type: ignore


### PR DESCRIPTION
## Summary

Replaces broad `except TypeError` fallback logic with explicit `sys.version_info` checks when handling async generator task creation.

This prevents unrelated user `TypeError` exceptions from being silently swallowed inside `_ContextPreservedAsyncGeneratorWrapper.__anext__`.

## Reproduction

The issue can be reproduced using the async generator example from #12520, where a user-side `TypeError` was previously swallowed and iteration completed silently.

## Fix

- Replaced runtime `except TypeError` fallback with explicit Python version branching.
- Preserves Python 3.10 compatibility behavior.
- Allows genuine user exceptions to propagate correctly.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a long-standing bug where a broad `except TypeError` catch in `_ContextPreservedAsyncGeneratorWrapper.__anext__` and `aclose` silently swallowed any `TypeError` raised by the user's generator, replacing it with an explicit `sys.version_info >= (3, 11)` branch that reflects the true Python version boundary at which `asyncio.create_task` gained its `context` keyword argument.

- **Core fix**: User-thrown `TypeError`s inside async generators now propagate correctly instead of being silently caught and re-routed through the Python 3.10 fallback path.
- **Scope**: Both `aclose` and `__anext__` receive the same fix; the `sys` module is added at the top of the module (compliant with the repo import rule).
- **Style nit**: The version check predicate is duplicated in two methods and `import sys` is inserted ahead of `import asyncio`, breaking the existing alphabetical import order.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the changed code correctly replaces runtime exception catching with an explicit Python version check, and behavior on both code paths is preserved.

The logic change is accurate: asyncio.create_task's context keyword was introduced in Python 3.11, so the version guard is the right boundary. Error propagation through the outer except block is unchanged. The only remaining notes are style-level: the duplicated version predicate and the out-of-order import sys line.

No files require special attention; both affected methods in langfuse/_client/observe.py received the same treatment consistently.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["__anext__ called"] --> B{sys.version_info >= 3.11?}
    B -- Yes --> C["asyncio.create_task(generator.__anext__(), context=self.context)"]
    B -- No --> D["self.context.run(asyncio.create_task, generator.__anext__())"]
    C --> E{Exception?}
    D --> E
    E -- StopAsyncIteration --> F["_finalize() + re-raise"]
    E -- Exception / CancelledError --> G["_finalize_with_error(e) + re-raise"]
    E -- No exception --> H["Append item if capture_output"]
    H --> I["return item"]

    J["aclose called"] --> K{sys.version_info >= 3.11?}
    K -- Yes --> L["asyncio.create_task(generator.aclose(), context=self.context)"]
    K -- No --> M["self.context.run(asyncio.create_task, generator.aclose())"]
    L --> N{Exception?}
    M --> N
    N -- Yes --> O["_finalize_with_error(error) + re-raise"]
    N -- No --> P["_finalize()"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
langfuse/_client/observe.py:1-2
The `sys.version_info >= (3, 11)` predicate is evaluated on every `aclose` and `__anext__` call and duplicated in two places. A single module-level constant avoids both the minor repetition and makes the intent obvious to future readers.

```suggestion
import sys
import asyncio

# asyncio.create_task(context=...) was added in Python 3.11
_TASK_CONTEXT_KWARG_SUPPORTED = sys.version_info >= (3, 11)
```

### Issue 2 of 2
langfuse/_client/observe.py:1-5
Standard library imports are ordered alphabetically throughout the existing block (`asyncio`, `contextvars`, `inspect`, `os`). Inserting `sys` at position 1 breaks that ordering; it should follow `os`.

```suggestion
import asyncio
import contextvars
import inspect
import os
import sys
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix swallowed TypeError in async generat..."](https://github.com/langfuse/langfuse-python/commit/0d5739c4462787f3b4baa71a0566adb9e46e8172) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32820520)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->