### PR TITLE
feat(span-processor): simplify app root state and expand LLM scopes

### DIFF
--- a/langfuse/_client/span_filter.py
+++ b/langfuse/_client/span_filter.py
@@ -12,12 +12,37 @@ KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES = frozenset(
     {
         LANGFUSE_TRACER_NAME,
         "agent_framework",
+        "autogen-core",
         "ai",
         "haystack",
         "langsmith",
         "litellm",
         "openinference",
+        "opentelemetry.instrumentation.agno",
+        "opentelemetry.instrumentation.alephalpha",
         "opentelemetry.instrumentation.anthropic",
+        "opentelemetry.instrumentation.bedrock",
+        "opentelemetry.instrumentation.cohere",
+        "opentelemetry.instrumentation.crewai",
+        "opentelemetry.instrumentation.google_generativeai",
+        "opentelemetry.instrumentation.groq",
+        "opentelemetry.instrumentation.haystack",
+        "opentelemetry.instrumentation.langchain",
+        "opentelemetry.instrumentation.llamaindex",
+        "opentelemetry.instrumentation.mistralai",
+        "opentelemetry.instrumentation.ollama",
+        "opentelemetry.instrumentation.openai",
+        "opentelemetry.instrumentation.openai_agents",
+        "opentelemetry.instrumentation.openai_v2",
+        "opentelemetry.instrumentation.replicate",
+        "opentelemetry.instrumentation.sagemaker",
+        "opentelemetry.instrumentation.together",
+        "opentelemetry.instrumentation.transformers",
+        "opentelemetry.instrumentation.vertexai",
+        "opentelemetry.instrumentation.voyageai",
+        "opentelemetry.instrumentation.watsonx",
+        "opentelemetry.instrumentation.writer",
+        "pydantic-ai",
         "strands-agents",
         "vllm",
     }
@@ -28,7 +53,7 @@ Prefix matching is boundary-aware:
 - exact match (``scope == prefix``)
 - direct descendant scopes (``scope.startswith(prefix + ".")``)
 
-Please create a Github issue in https://github.com/langfuse/langfuse if you'd like to expand this default allow list. 
+Please create a GitHub issue in https://github.com/langfuse/langfuse if you'd like to expand this default allow list.
 """
 
 

--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -14,7 +14,6 @@ Key features:
 import base64
 import os
 import threading
-from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, cast
 
 from opentelemetry import context as context_api
@@ -38,18 +37,6 @@ from langfuse._client.span_filter import is_default_export_span, is_langfuse_spa
 from langfuse._client.utils import span_formatter
 from langfuse._version import __version__ as langfuse_version
 from langfuse.logger import langfuse_logger
-
-
-@dataclass
-class _AppRootSpanState:
-    expected_exported_at_start: bool
-    ended: bool = False
-
-
-@dataclass
-class _AppRootTraceState:
-    active_count: int
-    spans: Dict[str, _AppRootSpanState]
 
 
 class LangfuseSpanProcessor(BatchSpanProcessor):
@@ -92,7 +79,7 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         self._should_export_span = should_export_span or is_default_export_span
 
         self._app_root_lock = threading.Lock()
-        self._app_root_traces: Dict[str, _AppRootTraceState] = {}
+        self._span_export_expectation_by_id: Dict[str, bool] = {}
 
         env_flush_at = os.environ.get(LANGFUSE_FLUSH_AT, None)
         flush_at = flush_at or int(env_flush_at) if env_flush_at is not None else None
@@ -220,23 +207,13 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         propagated_trace_id = _get_langfuse_trace_id_from_baggage(parent_context)
 
         with self._app_root_lock:
-            trace_state = self._app_root_traces.get(trace_id)
-
-            if trace_state is None:
-                trace_state = _AppRootTraceState(active_count=0, spans={})
-                self._app_root_traces[trace_id] = trace_state
-
-            parent_state = (
-                trace_state.spans.get(parent_span_id)
-                if parent_span_id is not None
-                else None
-            )
             parent_expected_exported = (
-                parent_state.expected_exported_at_start is True
-                if parent_state is not None
-                else False
+                parent_span_id is not None
+                and self._span_export_expectation_by_id.get(parent_span_id) is True
             )
             suppressed_by_parent_claim = propagated_trace_id == trace_id
+
+            self._span_export_expectation_by_id[span_id] = expected_exported
 
             mark_app_root = (
                 expected_exported
@@ -244,32 +221,14 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
                 and not suppressed_by_parent_claim
             )
 
-            trace_state.spans[span_id] = _AppRootSpanState(
-                expected_exported_at_start=expected_exported,
-            )
-            trace_state.active_count += 1
-
         if mark_app_root:
             span.set_attribute(LangfuseOtelSpanAttributes.IS_APP_ROOT, True)
 
     def _cleanup_app_root_state(self, span: ReadableSpan) -> None:
-        trace_id = format_trace_id(span.context.trace_id)
         span_id = format_span_id(span.context.span_id)
 
         with self._app_root_lock:
-            trace_state = self._app_root_traces.get(trace_id)
-
-            if trace_state is None:
-                return
-
-            span_state = trace_state.spans.get(span_id)
-
-            if span_state is not None and not span_state.ended:
-                span_state.ended = True
-                trace_state.active_count -= 1
-
-            if trace_state.active_count <= 0:
-                self._app_root_traces.pop(trace_id, None)
+            self._span_export_expectation_by_id.pop(span_id, None)
 
     def _is_expected_exported_at_start(self, span: Span) -> bool:
         readable_span = cast(ReadableSpan, span)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ def langfuse_memory_client(
             kwargs.get("should_export_span") or is_default_export_span
         )
         self._app_root_lock = threading.Lock()
-        self._app_root_traces = {}
+        self._span_export_expectation_by_id = {}
         BatchSpanProcessor.__init__(
             self,
             span_exporter=memory_exporter,

--- a/tests/unit/test_app_root_detection.py
+++ b/tests/unit/test_app_root_detection.py
@@ -65,7 +65,7 @@ def test_filtered_parent_marks_exported_children_as_app_roots(memory_exporter):
     assert "filtered-parent" not in spans
     assert spans["child-a"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT] is True
     assert spans["child-b"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT] is True
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_exported_parent_suppresses_exported_child_app_root(memory_exporter):
@@ -82,7 +82,7 @@ def test_exported_parent_suppresses_exported_child_app_root(memory_exporter):
 
     assert spans["parent"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT] is True
     assert LangfuseOtelSpanAttributes.IS_APP_ROOT not in spans["child"].attributes
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_grandparent_baggage_claim_suppresses_child_through_filtered_parent(
@@ -115,7 +115,7 @@ def test_grandparent_baggage_claim_suppresses_child_through_filtered_parent(
         spans["grandparent"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT] is True
     )
     assert LangfuseOtelSpanAttributes.IS_APP_ROOT not in spans["child"].attributes
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_same_trace_baggage_claim_suppresses_local_app_root(memory_exporter):
@@ -139,7 +139,7 @@ def test_same_trace_baggage_claim_suppresses_local_app_root(memory_exporter):
         LangfuseOtelSpanAttributes.IS_APP_ROOT
         not in spans["downstream-root"].attributes
     )
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_different_trace_baggage_claim_does_not_suppress_local_app_root(
@@ -165,7 +165,7 @@ def test_different_trace_baggage_claim_does_not_suppress_local_app_root(
         spans["downstream-root"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]
         is True
     )
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_local_baggage_claim_suppresses_child_even_when_parent_is_filtered(
@@ -200,7 +200,7 @@ def test_local_baggage_claim_suppresses_child_even_when_parent_is_filtered(
 
     assert "parent" not in spans
     assert LangfuseOtelSpanAttributes.IS_APP_ROOT not in spans["child"].attributes
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_start_time_false_positive_can_leave_exported_child_without_app_root(
@@ -228,7 +228,7 @@ def test_start_time_false_positive_can_leave_exported_child_without_app_root(
 
     assert "parent" not in spans
     assert LangfuseOtelSpanAttributes.IS_APP_ROOT not in spans["child"].attributes
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_active_langfuse_scope_sets_baggage_after_root_start(
@@ -272,7 +272,7 @@ def test_blocked_instrumentation_scope_parent_marks_child_as_app_root(
 
     assert "blocked-parent" not in spans
     assert spans["child"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT] is True
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_foreign_project_langfuse_parent_marks_child_as_app_root(memory_exporter):
@@ -294,7 +294,7 @@ def test_foreign_project_langfuse_parent_marks_child_as_app_root(memory_exporter
 
     assert "foreign-parent" not in spans
     assert spans["child"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT] is True
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_should_export_span_raising_does_not_mark_app_root(memory_exporter):
@@ -315,7 +315,7 @@ def test_should_export_span_raising_does_not_mark_app_root(memory_exporter):
     spans = _get_spans_by_name(memory_exporter)
 
     assert "root" not in spans
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_mark_app_root_candidate_exception_is_swallowed(memory_exporter, monkeypatch):
@@ -378,10 +378,12 @@ def test_concurrent_traces_keep_state_consistent(memory_exporter):
         LangfuseOtelSpanAttributes.IS_APP_ROOT not in span.attributes
         for span in child_spans
     )
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
 
 
-def test_multiple_interleaved_traces_track_state_independently(memory_exporter):
+def test_multiple_interleaved_traces_track_active_span_state_independently(
+    memory_exporter,
+):
     tracer_provider, processor = _create_processor(memory_exporter)
     langfuse_tracer = _langfuse_tracer(tracer_provider)
 
@@ -390,15 +392,17 @@ def test_multiple_interleaved_traces_track_state_independently(memory_exporter):
     trace_b_root = langfuse_tracer.start_span("trace-b-root")
     trace_b_ctx = trace_api.set_span_in_context(trace_b_root)
 
-    assert len(processor._app_root_traces) == 2
+    assert len(processor._span_export_expectation_by_id) == 2
 
     trace_a_child = langfuse_tracer.start_span("trace-a-child", context=trace_a_ctx)
     trace_b_child = langfuse_tracer.start_span("trace-b-child", context=trace_b_ctx)
 
+    assert len(processor._span_export_expectation_by_id) == 4
+
     trace_b_child.end()
     trace_b_root.end()
 
-    assert len(processor._app_root_traces) == 1
+    assert len(processor._span_export_expectation_by_id) == 2
 
     trace_a_child.end()
     trace_a_root.end()
@@ -419,7 +423,28 @@ def test_multiple_interleaved_traces_track_state_independently(memory_exporter):
     assert (
         LangfuseOtelSpanAttributes.IS_APP_ROOT not in spans["trace-b-child"].attributes
     )
-    assert processor._app_root_traces == {}
+    assert processor._span_export_expectation_by_id == {}
+
+
+def test_child_started_after_parent_end_is_marked_as_app_root(memory_exporter):
+    tracer_provider, processor = _create_processor(memory_exporter)
+    langfuse_tracer = _langfuse_tracer(tracer_provider)
+
+    parent = langfuse_tracer.start_span("parent")
+    parent_ctx = trace_api.set_span_in_context(parent)
+
+    parent.end()
+
+    child = langfuse_tracer.start_span("child", context=parent_ctx)
+    child.end()
+
+    processor.force_flush()
+
+    spans = _get_spans_by_name(memory_exporter)
+
+    assert spans["parent"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT] is True
+    assert spans["child"].attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT] is True
+    assert processor._span_export_expectation_by_id == {}
 
 
 def test_set_langfuse_trace_id_in_baggage_sets_value():

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -103,7 +103,7 @@ class TestOTelBase:
                 kwargs.get("should_export_span") or is_default_export_span
             )
             self._app_root_lock = threading.Lock()
-            self._app_root_traces = {}
+            self._span_export_expectation_by_id = {}
             BatchSpanProcessor.__init__(
                 self,
                 span_exporter=memory_exporter,
@@ -2005,7 +2005,7 @@ class TestMultiProjectSetup(TestOTelBase):
                 kwargs.get("should_export_span") or is_default_export_span
             )
             self._app_root_lock = threading.Lock()
-            self._app_root_traces = {}
+            self._span_export_expectation_by_id = {}
             # Use the appropriate exporter based on the project key
             if self.public_key == project1_key:
                 exporter = exporter_project1
@@ -2388,7 +2388,7 @@ class TestInstrumentationScopeFiltering(TestOTelBase):
                 kwargs.get("should_export_span") or is_default_export_span
             )
             self._app_root_lock = threading.Lock()
-            self._app_root_traces = {}
+            self._span_export_expectation_by_id = {}
 
             # For testing, use the appropriate exporter based on setup
             exporter = kwargs.get("_test_exporter", blocked_exporter)

--- a/tests/unit/test_span_filter.py
+++ b/tests/unit/test_span_filter.py
@@ -3,7 +3,10 @@
 from types import SimpleNamespace
 from typing import Any, Optional
 
+import pytest
+
 from langfuse.span_filter import (
+    KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES,
     is_default_export_span,
     is_genai_span,
     is_known_llm_instrumentor,
@@ -73,6 +76,56 @@ def test_is_known_llm_instrumentor_prefix_match():
         )
         is True
     )
+
+
+@pytest.mark.parametrize(
+    "scope_name",
+    [
+        "autogen-core",
+        "opentelemetry.instrumentation.agno",
+        "opentelemetry.instrumentation.alephalpha",
+        "opentelemetry.instrumentation.bedrock",
+        "opentelemetry.instrumentation.cohere",
+        "opentelemetry.instrumentation.crewai",
+        "opentelemetry.instrumentation.google_generativeai",
+        "opentelemetry.instrumentation.groq",
+        "opentelemetry.instrumentation.haystack",
+        "opentelemetry.instrumentation.langchain",
+        "opentelemetry.instrumentation.llamaindex",
+        "opentelemetry.instrumentation.mistralai",
+        "opentelemetry.instrumentation.ollama",
+        "opentelemetry.instrumentation.openai",
+        "opentelemetry.instrumentation.openai.v1",
+        "opentelemetry.instrumentation.openai_agents",
+        "opentelemetry.instrumentation.openai_v2",
+        "opentelemetry.instrumentation.replicate",
+        "opentelemetry.instrumentation.sagemaker",
+        "opentelemetry.instrumentation.together",
+        "opentelemetry.instrumentation.transformers",
+        "opentelemetry.instrumentation.vertexai",
+        "opentelemetry.instrumentation.voyageai",
+        "opentelemetry.instrumentation.watsonx",
+        "opentelemetry.instrumentation.writer",
+        "pydantic-ai",
+    ],
+)
+def test_is_known_llm_instrumentor_researched_scope_names(scope_name):
+    """Return true for researched OpenTelemetry LLM instrumentation scopes."""
+    assert is_known_llm_instrumentor(_make_span(scope_name=scope_name)) is True
+
+
+def test_known_llm_instrumentor_does_not_include_vector_store_only_scopes():
+    """Keep vector DB-only instrumentors out of the default LLM scope allowlist."""
+    vector_store_scopes = {
+        "opentelemetry.instrumentation.chromadb",
+        "opentelemetry.instrumentation.lancedb",
+        "opentelemetry.instrumentation.milvus",
+        "opentelemetry.instrumentation.pinecone",
+        "opentelemetry.instrumentation.qdrant",
+        "opentelemetry.instrumentation.weaviate",
+    }
+
+    assert vector_store_scopes.isdisjoint(KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES)
 
 
 def test_is_known_llm_instrumentor_unknown():


### PR DESCRIPTION
## What

- Simplify app-root detection state in `LangfuseSpanProcessor` to a single active span export-expectation map keyed by `span_id`, matching the JS SDK approach.
- Remove the per-trace app-root state dataclasses, active counters, and ended flags.
- Expand the known LLM instrumentation scope allowlist with researched OpenTelemetry/OpenLLMetry, Pydantic AI, and AutoGen scope names.
- Add focused span-filter coverage for the new scopes and keep vector DB-only scopes out of the default LLM allowlist.

## Why

The existing app-root state management was more complex than needed for the start-time heuristic. The processor only needs to know whether the direct parent span is currently expected to export. A single active-span map provides that without trace-level bookkeeping.

The default export filter also missed several LLM/framework instrumentation scopes that users can reasonably expect Langfuse to keep by default when spans do not yet carry `gen_ai.*` attributes at start time.

## Verification

- `uv run --frozen pytest tests/unit/test_span_filter.py tests/unit/test_app_root_detection.py -q`
- `uv run --frozen pytest tests/unit/test_otel.py -q`
- `uv run --frozen ruff check langfuse/_client/span_filter.py tests/unit/test_span_filter.py langfuse/_client/span_processor.py tests/unit/test_app_root_detection.py tests/conftest.py tests/unit/test_otel.py`
- `uv run --frozen ruff format --check langfuse/_client/span_filter.py tests/unit/test_span_filter.py langfuse/_client/span_processor.py tests/unit/test_app_root_detection.py tests/conftest.py tests/unit/test_otel.py`
- `uv run --frozen mypy langfuse --no-error-summary`
- Pre-commit on commit: `uv-lock` skipped, `ruff-check` passed, `ruff-format` passed, `mypy` passed
