### PR TITLE
fix(serializer): traverse full MRO when serialising objects with __slots__

### DIFF
--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -151,9 +151,18 @@ class EventSerializer(JSONEncoder):
                 return [self.default(item) for item in obj]
 
             if hasattr(obj, "__slots__"):
+                # Collect slots from the entire MRO so that attributes defined
+                # on parent classes are not silently dropped.  Accessing
+                # obj.__slots__ only returns the slots of the *immediate* class;
+                # inherited slots live on their respective base classes.
+                all_slots = [
+                    slot
+                    for cls in type(obj).__mro__
+                    for slot in getattr(cls, "__slots__", ())
+                ]
                 return {
                     slot: self.default(getattr(obj, slot, None))
-                    for slot in obj.__slots__
+                    for slot in all_slots
                 }
             elif hasattr(obj, "__dict__"):
                 obj_id = id(obj)

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -298,3 +298,70 @@ def test_dict_with_non_string_keys_is_serialized(input_obj, expected):
     result = json.loads(EventSerializer().encode(input_obj))
 
     assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: __slots__ MRO traversal
+#
+# EventSerializer previously only iterated obj.__slots__, which returns the
+# slots of the immediate class only.  Attributes defined on parent classes via
+# __slots__ were silently dropped.
+# ---------------------------------------------------------------------------
+
+
+class _SlotBase:
+    __slots__ = ("base_attr",)
+
+    def __init__(self):
+        self.base_attr = "from_base"
+
+
+class _SlotChild(_SlotBase):
+    __slots__ = ("child_attr",)
+
+    def __init__(self):
+        super().__init__()
+        self.child_attr = "from_child"
+
+
+class _SlotGrandchild(_SlotChild):
+    __slots__ = ("grandchild_attr",)
+
+    def __init__(self):
+        super().__init__()
+        self.grandchild_attr = "from_grandchild"
+
+
+def test_slots_immediate_class_serialised():
+    """Child-class slots must appear in the serialised output."""
+    serializer = EventSerializer()
+    obj = _SlotChild()
+    result = json.loads(serializer.encode(obj))
+    assert result.get("child_attr") == "from_child", (
+        f"child_attr must be serialised; got: {result}"
+    )
+
+
+def test_slots_inherited_from_parent_serialised():
+    """Parent-class slots must not be silently dropped during serialisation.
+
+    Before the fix, obj.__slots__ returned only ('child_attr',), so
+    base_attr was completely absent from the output.
+    """
+    serializer = EventSerializer()
+    obj = _SlotChild()
+    result = json.loads(serializer.encode(obj))
+    assert result.get("base_attr") == "from_base", (
+        "base_attr is defined in the parent class's __slots__ and must appear "
+        f"in the serialised output; got: {result}"
+    )
+
+
+def test_slots_deep_inheritance_chain():
+    """All slots across a 3-level MRO must be serialised."""
+    serializer = EventSerializer()
+    obj = _SlotGrandchild()
+    result = json.loads(serializer.encode(obj))
+    assert result.get("base_attr") == "from_base", f"base_attr missing from: {result}"
+    assert result.get("child_attr") == "from_child", f"child_attr missing from: {result}"
+    assert result.get("grandchild_attr") == "from_grandchild", f"grandchild_attr missing from: {result}"


### PR DESCRIPTION
## Bug

`EventSerializer._default_inner` iterated `obj.__slots__` when serialising an object that has `__slots__`.  `obj.__slots__` is a class attribute that contains **only the slots of the immediate class** — slots defined on parent classes live on each respective base class and are not included.

As a result, any attribute stored in a parent's `__slots__` was silently dropped from the serialised event payload, causing silent data loss whenever a slotted class hierarchy was used (e.g., protobuf messages, dataclasses-like objects, custom slotted models).

### Minimal repro

```python
class Base:
    __slots__ = ('base_attr',)

class Child(Base):
    __slots__ = ('child_attr',)

from langfuse._utils.serializer import EventSerializer
import json

obj = Child()
obj.base_attr = 'from_base'
obj.child_attr = 'from_child'

result = json.loads(EventSerializer().encode(obj))
# Before fix: {'child_attr': 'from_child'}   ← base_attr is missing!
# After fix:  {'child_attr': 'from_child', 'base_attr': 'from_base'}
```

Note: This bug is **distinct** from the cycle-detection fix in PR #1657, which guards the `__slots__` branch against infinite recursion on cyclic graphs. This PR corrects the scope of slot traversal itself.

## Fix

Use the standard Python idiom for collecting all slots across an MRO:

```python
# Before
return {slot: self.default(getattr(obj, slot, None)) for slot in obj.__slots__}

# After
all_slots = [
    slot
    for cls in type(obj).__mro__
    for slot in getattr(cls, '__slots__', ())
]
return {slot: self.default(getattr(obj, slot, None)) for slot in all_slots}
```

`getattr(cls, '__slots__', ())` handles:
- Classes in the MRO that don't define `__slots__` (returns the empty tuple default)
- `object` at the end of every MRO (no `__slots__`)

## Tests

Three regression tests added to `tests/unit/test_serializer.py`:

| Test | Verifies |
|------|----------|
| `test_slots_immediate_class_serialised` | Child-class slots still appear |
| `test_slots_inherited_from_parent_serialised` | Parent-class slots are no longer dropped (**fails before fix**) |
| `test_slots_deep_inheritance_chain` | 3-level MRO: grandparent, parent, and child slots all present (**fails before fix**) |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent data-loss bug in `EventSerializer._default_inner` where slotted objects only had their immediate class's slots serialised; slots defined on any ancestor class were silently dropped. The fix correctly traverses the full MRO via `type(obj).__mro__` to collect all slots before serialising.

- **`langfuse/_utils/serializer.py`**: Replaces `obj.__slots__` iteration with a two-level list comprehension over `type(obj).__mro__`, using `getattr(cls, '__slots__', ())` to handle classes that don't define `__slots__` (including `object`). The fix is minimal and idiomatic.
- **`tests/unit/test_serializer.py`**: Adds three targeted regression tests — immediate-class slots, parent-class slots, and a three-level deep inheritance chain — each of which would have failed against the pre-fix code.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core fix is correct and well-tested. One minor follow-up worth considering: filtering __weakref__ and __dict__ from the collected slot list prevents those implementation-detail entries from leaking into serialised payloads.

The MRO traversal fix is idiomatic and closes the described data-loss gap. The only open edge case is that special pseudo-slots (__weakref__, __dict__) that appear in ancestor __slots__ definitions will now show up in serialised output — harmless for __weakref__ (serialises to null) but potentially confusing for __dict__ (nests the whole instance dict under a __dict__ key). This was a pre-existing quirk for the immediate class and is now slightly more reachable via inheritance.

langfuse/_utils/serializer.py — specifically the slot-filtering step in the new MRO loop.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_default_inner called with obj] --> B{hasattr obj __slots__?}
    B -- Yes --> C[Collect all_slots via MRO traversal]
    C --> D[getattr each cls for __slots__]
    D --> E[Build dict slot to self.default value]
    B -- No --> F{hasattr obj __dict__?}
    F -- Yes --> G[Cycle check via self.seen]
    G --> H[Serialize vars as dict]
    F -- No --> I[Return type name string]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/_utils/serializer.py:158-162
Special-purpose slots like `__weakref__` and `__dict__` can appear in a class's (or ancestor's) `__slots__` definition. With the full MRO traversal these slots are now included in the serialised output for every slotted object that inherits from such a base class. `__weakref__` serialises to `None` (harmless but noisy), while `__dict__` serialises to the entire instance attribute dict nested under a `"__dict__"` key — that conflicts with the existing `__dict__`-branch logic and can produce duplicate or mis-shaped data. Filtering them out is the standard idiom.

```suggestion
                _SKIP_SLOTS = frozenset({"__dict__", "__weakref__"})
                all_slots = [
                    slot
                    for cls in type(obj).__mro__
                    for slot in getattr(cls, "__slots__", ())
                    if slot not in _SKIP_SLOTS
                ]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(serializer): traverse full MRO when ..."](https://github.com/langfuse/langfuse-python/commit/d3847012912bf405e1e0cd7a2913ff57f032c6a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34218565)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->