### PR TITLE
fix: link scores to dataset_run_id during experiment evaluation

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -2870,6 +2870,7 @@ class Langfuse:
                                 observation_id=span.id,
                                 name=evaluation.name,
                                 value=evaluation.value,  # type: ignore
+                                dataset_run_id=dataset_run_id,
                                 comment=evaluation.comment,
                                 metadata=evaluation.metadata,
                                 config_id=evaluation.config_id,


### PR DESCRIPTION
## What does this PR do?
The score entity does not receive the dataset_id parameter during creation. This PR fixes this.

Fixes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash

```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.
