### PR TITLE
fix(propagation): coerce non-string metadata values to string

### DIFF
--- a/langfuse/_client/propagation.py
+++ b/langfuse/_client/propagation.py
@@ -90,12 +90,11 @@ def _detach_context_token_safely(token: Any) -> None:
     except Exception:
         pass
 
-
 def propagate_attributes(
     *,
     user_id: Optional[str] = None,
     session_id: Optional[str] = None,
-    metadata: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,
     tags: Optional[List[str]] = None,
     trace_name: Optional[str] = None,
@@ -229,7 +228,7 @@ def _propagate_attributes(
     *,
     user_id: Optional[str] = None,
     session_id: Optional[str] = None,
-    metadata: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,
     tags: Optional[List[str]] = None,
     trace_name: Optional[str] = None,
@@ -247,10 +246,9 @@ def _propagate_attributes(
         "trace_name": trace_name,
     }
 
-    propagated_metadata_attributes: Dict[str, Optional[Dict[str, str]]] = {
+    propagated_metadata_attributes: Dict[str, Optional[Dict[str, Any]]] = {
         "metadata": metadata,
     }
-
     if experiment:
         for key, value in experiment.items():
             if key in ("experiment_metadata", "experiment_item_metadata"):
@@ -286,8 +284,11 @@ def _propagate_attributes(
         validated_metadata: Dict[str, str] = {}
 
         for key, value in metadata_value.items():
-            if _validate_string_value(value=value, key=f"{metadata_key}.{key}"):
-                validated_metadata[key] = value
+            if value is None:
+                continue
+            string_value = value if isinstance(value, str) else str(value)
+            if _validate_string_value(value=string_value, key=f"{metadata_key}.{key}"):
+                validated_metadata[key] = string_value
 
         if validated_metadata:
             context = _set_propagated_attribute(

--- a/langfuse/_client/propagation.py
+++ b/langfuse/_client/propagation.py
@@ -287,7 +287,16 @@ def _propagate_attributes(
         for key, value in metadata_value.items():
             if value is None:
                 continue
-            string_value = value if isinstance(value, str) else ("true" if value is True else "false" if value is False else str(value))
+            if isinstance(value, str):
+                string_value = value
+            elif isinstance(value, bool):
+                string_value = "true" if value else "false"
+            elif isinstance(value, (dict, list, tuple)):
+                import json
+                string_value = json.dumps(value)
+            else:
+                string_value = str(value)
+
             if _validate_string_value(value=string_value, key=f"{metadata_key}.{key}"):
                 validated_metadata[key] = string_value
 

--- a/langfuse/_client/propagation.py
+++ b/langfuse/_client/propagation.py
@@ -204,8 +204,9 @@ def propagate_attributes(
 
     Note:
         - **Validation**: All attribute values (user_id, session_id, metadata values)
-          must be strings ≤200 characters. Invalid values will be dropped with a
-          warning logged. Ensure values meet constraints before calling.
+          must be ≤200 characters. Non-string metadata values (int, float, bool, etc.)
+          are automatically coerced to their string representation. Values exceeding
+          200 characters will be dropped with a warning logged.
         - **OpenTelemetry**: This uses OpenTelemetry context propagation under the hood,
           making it compatible with other OTel-instrumented libraries.
 

--- a/langfuse/_client/propagation.py
+++ b/langfuse/_client/propagation.py
@@ -286,7 +286,7 @@ def _propagate_attributes(
         for key, value in metadata_value.items():
             if value is None:
                 continue
-            string_value = value if isinstance(value, str) else str(value)
+            string_value = value if isinstance(value, str) else ("true" if value is True else "false" if value is False else str(value))
             if _validate_string_value(value=string_value, key=f"{metadata_key}.{key}"):
                 validated_metadata[key] = string_value
 

--- a/tests/unit/test_propagate_attributes.py
+++ b/tests/unit/test_propagate_attributes.py
@@ -491,13 +491,15 @@ class TestPropagateAttributesValidation(TestPropagateAttributesBase):
         )
 
     def test_metadata_coercion_of_non_string_values(self, langfuse_client, memory_exporter):
-        """Verify metadata values that are not strings (int, float, bool) are coerced to strings."""
+        """Verify metadata values that are not strings (int, float, bool, dict, list) are coerced to strings."""
         with langfuse_client.start_as_current_observation(name="parent-span"):
             with propagate_attributes(
                 metadata={
                     "int_val": 42,  # type: ignore
                     "float_val": 3.14,  # type: ignore
                     "bool_val": True,  # type: ignore
+                    "dict_val": {"nested": "val"},  # type: ignore
+                    "list_val": [1, 2],  # type: ignore
                 }
             ):
                 child = langfuse_client.start_observation(name="child-span")
@@ -519,6 +521,16 @@ class TestPropagateAttributesValidation(TestPropagateAttributesBase):
             child_span,
             f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.bool_val",
             "true",
+        )
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.dict_val",
+            '{"nested": "val"}',
+        )
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.list_val",
+            "[1, 2]",
         )
 
 class TestPropagateAttributesNesting(TestPropagateAttributesBase):

--- a/tests/unit/test_propagate_attributes.py
+++ b/tests/unit/test_propagate_attributes.py
@@ -489,7 +489,36 @@ class TestPropagateAttributesValidation(TestPropagateAttributesBase):
         self.verify_missing_attribute(
             child_span, f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.invalid_key"
         )
+    def test_metadata_coercion_of_non_string_values(self, langfuse_client, memory_exporter):
+        """Verify metadata values that are not strings (int, float, bool) are coerced to strings."""
+        with langfuse_client.start_as_current_observation(name="parent-span"):
+            with propagate_attributes(
+                metadata={
+                    "int_val": 42,  # type: ignore
+                    "float_val": 3.14,  # type: ignore
+                    "bool_val": True,  # type: ignore
+                }
+            ):
+                child = langfuse_client.start_observation(name="child-span")
+                child.end()
 
+        # Verify child has all metadata keys coerced to string values
+        child_span = self.get_span_by_name(memory_exporter, "child-span")
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.int_val",
+            "42",
+        )
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.float_val",
+            "3.14",
+        )
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.bool_val",
+            "True",
+        )        
 
 class TestPropagateAttributesNesting(TestPropagateAttributesBase):
     """Tests for nested propagate_attributes contexts."""

--- a/tests/unit/test_propagate_attributes.py
+++ b/tests/unit/test_propagate_attributes.py
@@ -517,7 +517,7 @@ class TestPropagateAttributesValidation(TestPropagateAttributesBase):
         self.verify_span_attribute(
             child_span,
             f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.bool_val",
-            "True",
+            "true",
         )        
 
 class TestPropagateAttributesNesting(TestPropagateAttributesBase):

--- a/tests/unit/test_propagate_attributes.py
+++ b/tests/unit/test_propagate_attributes.py
@@ -489,6 +489,7 @@ class TestPropagateAttributesValidation(TestPropagateAttributesBase):
         self.verify_missing_attribute(
             child_span, f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.invalid_key"
         )
+
     def test_metadata_coercion_of_non_string_values(self, langfuse_client, memory_exporter):
         """Verify metadata values that are not strings (int, float, bool) are coerced to strings."""
         with langfuse_client.start_as_current_observation(name="parent-span"):
@@ -518,7 +519,7 @@ class TestPropagateAttributesValidation(TestPropagateAttributesBase):
             child_span,
             f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.bool_val",
             "true",
-        )        
+        )
 
 class TestPropagateAttributesNesting(TestPropagateAttributesBase):
     """Tests for nested propagate_attributes contexts."""


### PR DESCRIPTION
Allows propagate_attributes to accept and automatically convert non-string metadata values (int, float, bool) to strings instead of silently dropping them. This resolves tracing compatibility issues with LangGraph integrations.

## What does this PR do?

> PR title must follow Conventional Commits, for example `feat: add dataset scoring helper` or `fix(openai): preserve trace context`.

Fixes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash

```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR allows `propagate_attributes` to accept non-string metadata values (`int`, `float`, `bool`, and any other type) and automatically coerces them to strings via `str()` rather than silently dropping them. The change fixes tracing compatibility with LangGraph integrations that inject non-string metadata.

- The type signature of the `metadata` parameter (and the internal `_propagate_attributes` equivalent) is widened from `Dict[str, str]` to `Dict[str, Any]`, and `None` values in the metadata dict are now explicitly skipped before the string-length validation step.
- A new unit test covers coercion of `int`, `float`, and `bool` values, verifying the resulting string representations in child spans.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is small and well-targeted; the coercion path is safe for the common cases and the existing validation guard (200-char limit) still applies after coercion.

The core logic is correct and the new test exercises int, float, and bool. The main open question is whether Python-style 'True'/'False' is the right representation for booleans — downstream consumers expecting JSON-style 'true'/'false' would silently get wrong values. The docstring also still describes the old 'must be strings' constraint, which could confuse users reading the API docs.

langfuse/_client/propagation.py — specifically the boolean coercion representation and the outdated docstring note.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["propagate_attributes called with metadata dict"] --> B{metadata is None?}
    B -- Yes --> Z[Skip metadata]
    B -- No --> C[Iterate over key-value pairs]
    C --> D{value is None?}
    D -- Yes --> C
    D -- No --> E{value is a str?}
    E -- Yes --> F[string_value = value]
    E -- No --> G["string_value = str(value)"]
    F --> H{len <= 200 chars?}
    G --> H
    H -- No --> I[Log warning and drop key]
    H -- Yes --> J[Add to validated_metadata]
    J --> C
    J --> K[Set propagated OTel attribute]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
langfuse/_client/propagation.py:206-208
The docstring still states that metadata values "must be strings ≤200 characters", but this PR explicitly relaxes that constraint by auto-coercing non-string values. Leaving the note unchanged will mislead users who read the docs.

```suggestion
        - **Validation**: All attribute values (user_id, session_id, metadata values)
          must be ≤200 characters. Non-string metadata values (int, float, bool, etc.)
          are automatically coerced to their string representation. Values exceeding
          200 characters will be dropped with a warning logged.
```

### Issue 2 of 3
langfuse/_client/propagation.py:289
`bool` in Python coerces to `"True"`/`"False"` (capital first letter) rather than the JSON-conventional `"true"`/`"false"`. Consumers that parse metadata values as JSON booleans — which is common in cross-service tracing contexts like LangGraph — will see an unexpected capitalisation. Consider using a JSON-aware coercion for `bool` specifically.

```suggestion
            string_value = value if isinstance(value, str) else ("true" if value is True else "false" if value is False else str(value))
```

### Issue 3 of 3
tests/unit/test_propagate_attributes.py:489-492
Missing blank line between the previous test method and this new one; PEP 8 requires one blank line between methods in a class. There is also trailing whitespace at the end of the last `verify_span_attribute` block.

```suggestion
        self.verify_missing_attribute(
            child_span, f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.invalid_key"
        )

    def test_metadata_coercion_of_non_string_values(self, langfuse_client, memory_exporter):
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(propagation): coerce non-string meta..."](https://github.com/langfuse/langfuse-python/commit/076e5a26d8673ecb5f2e27d1af400cbd84d64954) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34822128)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->