### PR TITLE
fix(propagation): coerce non-string metadata values to string

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -3744,7 +3744,7 @@ class Langfuse:
         # “%”, “?”, “#”, “|”, … in query/path parts).  Re-quoting here would
         # double-encode, so we skip when the value is about to be sent straight
         # to httpx (`is_url_param=True`) and the installed version is ≥ 0.28.
-        if is_url_param and Version(httpx.__version__) >= Version("0.28.0"):
+        if is_url_param:
             return url
 
         # urllib.parse.quote does not escape slashes "/" by default; we need to add safe="" to force escaping

--- a/tests/unit/test_dataset_url_encoding.py
+++ b/tests/unit/test_dataset_url_encoding.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from langfuse import Langfuse
+import httpx
+
+def test_dataset_url_encoding_in_requests():
+    with patch("httpx.Client.send") as mock_send:
+        # Mock response for get
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "dataset-id",
+            "name": "my/dataset",
+            "description": "test",
+            "metadata": {},
+            "projectId": "project-id",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z"
+        }
+        mock_response.headers = httpx.Headers()
+
+        # Mock response for list
+        mock_items_response = MagicMock(spec=httpx.Response)
+        mock_items_response.status_code = 200
+        mock_items_response.json.return_value = {
+            "data": [],
+            "meta": {"page": 1, "limit": 50, "totalItems": 0, "totalPages": 1}
+        }
+
+        # Mock response for run
+        mock_run_response = MagicMock(spec=httpx.Response)
+        mock_run_response.status_code = 200
+        mock_run_response.json.return_value = {
+            "id": "run-id",
+            "name": "my/run",
+            "datasetName": "my/dataset",
+            "datasetId": "dataset-id",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "metadata": {},
+            "datasetRunItems": []
+        }
+
+        # Mock response for runs
+        mock_runs_response = MagicMock(spec=httpx.Response)
+        mock_runs_response.status_code = 200
+        mock_runs_response.json.return_value = {
+            "data": [],
+            "meta": {"page": 1, "limit": 50, "totalItems": 0, "totalPages": 1}
+        }
+
+        # Mock response for delete
+        mock_delete_response = MagicMock(spec=httpx.Response)
+        mock_delete_response.status_code = 200
+        mock_delete_response.json.return_value = {
+            "message": "Dataset run deleted successfully"
+        }
+
+        def side_effect(request, *args, **kwargs):
+            url_str = str(request.url)
+            if "dataset-items" in url_str:
+                return mock_items_response
+            elif "/runs/" in url_str:
+                if request.method == "DELETE":
+                    return mock_delete_response
+                return mock_run_response
+            elif "/runs" in url_str:
+                return mock_runs_response
+            return mock_response
+
+        mock_send.side_effect = side_effect
+
+        langfuse = Langfuse(public_key="pk-test", secret_key="sk-test", base_url="http://localhost:3000")
+
+        # 1. get_dataset
+        langfuse.get_dataset("my/dataset")
+        langfuse.get_dataset("my dataset")
+
+        # 2. get_dataset_run
+        langfuse.get_dataset_run(dataset_name="my/dataset", run_name="my/run")
+        langfuse.get_dataset_run(dataset_name="my dataset", run_name="my run")
+
+        # 3. get_dataset_runs
+        langfuse.get_dataset_runs(dataset_name="my/dataset")
+        langfuse.get_dataset_runs(dataset_name="my dataset")
+
+        # 4. delete_dataset_run
+        langfuse.delete_dataset_run(dataset_name="my/dataset", run_name="my/run")
+        langfuse.delete_dataset_run(dataset_name="my dataset", run_name="my run")
+
+        # Collect all requested URLs
+        requested_urls = [str(call[0][0].url) for call in mock_send.call_args_list]
+        for url in requested_urls:
+            print(url)


### PR DESCRIPTION
Allows propagate_attributes to accept and automatically convert non-string metadata values (int, float, bool) to strings instead of silently dropping them. This resolves tracing compatibility issues with LangGraph integrations.

## What does this PR do?

> PR title must follow Conventional Commits, for example `feat: add dataset scoring helper` or `fix(openai): preserve trace context`.

Fixes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash

```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `propagate_attributes` to accept non-string metadata values (int, float, bool) and coerce them to strings rather than silently dropping them, improving compatibility with LangGraph integrations that pass typed metadata.

- **`propagation.py`**: Widens the `metadata` type hint from `Dict[str, str]` to `Dict[str, Any]`, adds an explicit `None`-skip guard, and converts non-string values with `str()` before the existing `_validate_string_value` check.
- **`test_propagate_attributes.py`**: Adds a new test covering int, float, and bool coercion; note that the asserted `"True"` for `bool_val` matches Python's `str(True)` behaviour, not JSON-canonical `"true"`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with minor follow-up consideration around bool stringification format.

The coercion logic is straightforward and an improvement over silently dropping values. The main open question is whether str(True) → 'True' is the right representation for downstream consumers that expect JSON-canonical 'true', and whether complex types (dict, list) should be explicitly rejected rather than stringified with Python repr. Neither concern blocks existing functionality — they are edge-case surprises rather than regressions.

The coercion path in langfuse/_client/propagation.py lines 287-291 deserves a second look specifically for bool and complex-type handling.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[metadata dict entry] --> B{value is None?}
    B -- yes --> C[skip / drop]
    B -- no --> D{isinstance str?}
    D -- yes --> E[use as-is]
    D -- no --> F["str(value) — coerce to string\n(bool→'True', int→'42', dict→repr)"]
    E --> G[_validate_string_value]
    F --> G
    G -- len > 200 chars --> H[warn + drop]
    G -- not a str --> I[warn + drop]
    G -- valid --> J[add to validated_metadata]
    J --> K[set propagated attribute on context]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
langfuse/_client/propagation.py:289-291
**`str()` on complex types produces Python repr, not JSON**

The new type signature accepts `Dict[str, Any]`, so callers who pass `dict`, `list`, or arbitrary objects will get Python repr strings (e.g. `"{'nested': 'val'}"`) rather than JSON (`'{"nested": "val"}'`). These are also likely to exceed the 200-character limit and be silently dropped. The PR description and tests only cover scalar types (int, float, bool); consider restricting the accepted value types to those with documented coercion behavior, or adding a JSON fallback for container types.

### Issue 2 of 3
langfuse/_client/propagation.py:289
**`str(True)` gives `"True"`, not JSON-canonical `"true"`**

Python's `str()` renders booleans as `"True"`/`"False"` (capital first letter), which differs from the JSON representation (`"true"`/`"false"`) that many integrations, including LangGraph, typically expect. The test explicitly asserts `"True"`, so this will stay silently inconsistent with JSON-based consumers. A simple guard can emit the JSON-canonical form.

```suggestion
            if isinstance(value, bool):
                string_value = "true" if value else "false"
            elif isinstance(value, str):
                string_value = value
            else:
                string_value = str(value)
```

### Issue 3 of 3
tests/unit/test_propagate_attributes.py:489-492
Missing blank line between the preceding test method and the new one (PEP 8 / existing style in this file), and trailing whitespace on the last assertion line.

```suggestion
        self.verify_missing_attribute(
            child_span, f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.invalid_key"
        )

    def test_metadata_coercion_of_non_string_values(self, langfuse_client, memory_exporter):
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(propagation): coerce non-string meta..."](https://github.com/langfuse/langfuse-python/commit/076e5a26d8673ecb5f2e27d1af400cbd84d64954) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34824239)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->