### PR TITLE
Fix serializer negative infinity

### DIFF
--- a/langfuse/_client/propagation.py
+++ b/langfuse/_client/propagation.py
@@ -90,12 +90,11 @@ def _detach_context_token_safely(token: Any) -> None:
     except Exception:
         pass
 
-
 def propagate_attributes(
     *,
     user_id: Optional[str] = None,
     session_id: Optional[str] = None,
-    metadata: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,
     tags: Optional[List[str]] = None,
     trace_name: Optional[str] = None,
@@ -229,7 +228,7 @@ def _propagate_attributes(
     *,
     user_id: Optional[str] = None,
     session_id: Optional[str] = None,
-    metadata: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,
     tags: Optional[List[str]] = None,
     trace_name: Optional[str] = None,
@@ -247,10 +246,9 @@ def _propagate_attributes(
         "trace_name": trace_name,
     }
 
-    propagated_metadata_attributes: Dict[str, Optional[Dict[str, str]]] = {
+    propagated_metadata_attributes: Dict[str, Optional[Dict[str, Any]]] = {
         "metadata": metadata,
     }
-
     if experiment:
         for key, value in experiment.items():
             if key in ("experiment_metadata", "experiment_item_metadata"):
@@ -286,8 +284,11 @@ def _propagate_attributes(
         validated_metadata: Dict[str, str] = {}
 
         for key, value in metadata_value.items():
-            if _validate_string_value(value=value, key=f"{metadata_key}.{key}"):
-                validated_metadata[key] = value
+            if value is None:
+                continue
+            string_value = value if isinstance(value, str) else str(value)
+            if _validate_string_value(value=string_value, key=f"{metadata_key}.{key}"):
+                validated_metadata[key] = string_value
 
         if validated_metadata:
             context = _set_propagated_attribute(

--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -76,7 +76,7 @@ class EventSerializer(JSONEncoder):
                 return "NaN"
 
             if isinstance(obj, float) and math.isinf(obj):
-                return "Infinity"
+                return "-Infinity" if obj < 0 else "Infinity"
 
             if isinstance(obj, (Exception, KeyboardInterrupt)):
                 return f"{type(obj).__name__}: {str(obj)}"

--- a/tests/unit/test_propagate_attributes.py
+++ b/tests/unit/test_propagate_attributes.py
@@ -489,7 +489,36 @@ class TestPropagateAttributesValidation(TestPropagateAttributesBase):
         self.verify_missing_attribute(
             child_span, f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.invalid_key"
         )
+    def test_metadata_coercion_of_non_string_values(self, langfuse_client, memory_exporter):
+        """Verify metadata values that are not strings (int, float, bool) are coerced to strings."""
+        with langfuse_client.start_as_current_observation(name="parent-span"):
+            with propagate_attributes(
+                metadata={
+                    "int_val": 42,  # type: ignore
+                    "float_val": 3.14,  # type: ignore
+                    "bool_val": True,  # type: ignore
+                }
+            ):
+                child = langfuse_client.start_observation(name="child-span")
+                child.end()
 
+        # Verify child has all metadata keys coerced to string values
+        child_span = self.get_span_by_name(memory_exporter, "child-span")
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.int_val",
+            "42",
+        )
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.float_val",
+            "3.14",
+        )
+        self.verify_span_attribute(
+            child_span,
+            f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.bool_val",
+            "True",
+        )        
 
 class TestPropagateAttributesNesting(TestPropagateAttributesBase):
     """Tests for nested propagate_attributes contexts."""

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -14,17 +14,17 @@ from langfuse._utils.serializer import (
 )
 
 
-class TestEnum(Enum):
+class MockEnum(Enum):
     A = 1
     B = 2
 
 
 @dataclass
-class TestDataclass:
+class MockDataclass:
     field: str
 
 
-class TestBaseModel(BaseModel):
+class MockBaseModel(BaseModel):
     field: str
 
 
@@ -43,7 +43,7 @@ def test_date():
 
 def test_enum():
     serializer = EventSerializer()
-    assert serializer.encode(TestEnum.A) == "1"
+    assert serializer.encode(MockEnum.A) == "1"
 
 
 def test_uuid():
@@ -59,13 +59,12 @@ def test_bytes():
 
 
 def test_dataclass():
-    dc = TestDataclass(field="test")
+    dc = MockDataclass(field="test")
     serializer = EventSerializer()
     assert json.loads(serializer.encode(dc)) == {"field": "test"}
 
-
 def test_pydantic_model():
-    model = TestBaseModel(field="test")
+    model = MockBaseModel(field="test")
     serializer = EventSerializer()
     assert json.loads(serializer.encode(model)) == {"field": "test"}
 
@@ -298,3 +297,11 @@ def test_dict_with_non_string_keys_is_serialized(input_obj, expected):
     result = json.loads(EventSerializer().encode(input_obj))
 
     assert result == expected
+
+
+def test_float_special_values():
+    serializer = EventSerializer()
+
+    assert serializer.encode(float("inf")) == '"Infinity"'
+    assert serializer.encode(float("-inf")) == '"-Infinity"'
+    assert serializer.encode(float("nan")) == '"NaN"'


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat: add dataset scoring helper` or `fix(openai): preserve trace context`.

Fixes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash
poetry run pytest tests/unit/test_serializer.py
```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two bugs: negative infinity floats were always serialised as `"Infinity"` instead of `"-Infinity"`, and `propagate_attributes` rejected non-string metadata values instead of coercing them.

- `serializer.py`: one-line fix to return `"-Infinity"` when `math.isinf(obj)` is true and `obj < 0`.
- `propagation.py`: widens the `metadata` parameter type to `Dict[str, Any]` and adds `str(value)` coercion for non-string values; `None` values are now silently skipped rather than propagated.
- Tests: new `test_float_special_values` covers all three float special values; a new propagation test verifies `int`/`float`/`bool` coercion; test-data fixture classes renamed from `Test*` to `Mock*` to avoid unintentional pytest collection.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the serializer fix is a minimal one-liner with a clear test, and the propagation coercion change is well-covered by the new test.

Both fixes are small and targeted. The only gap is the docstring for `propagate_attributes` which still tells callers that non-string metadata values are dropped, when they are now silently coerced via `str()`. A caller relying on the old drop-with-warning behaviour could be surprised.

langfuse/_client/propagation.py — the docstring for the `metadata` parameter needs to reflect the new coercion behaviour.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EventSerializer.default called with float] --> B{math.isnan?}
    B -- yes --> C[return 'NaN']
    B -- no --> D{math.isinf?}
    D -- no --> E[normal float path]
    D -- yes --> F{obj < 0?}
    F -- yes --> G[return '-Infinity']
    F -- no --> H[return 'Infinity']

    I[propagate_attributes metadata dict] --> J{value is None?}
    J -- yes --> K[skip / continue]
    J -- no --> L{isinstance str?}
    L -- yes --> M[use as-is]
    L -- no --> N[str coerce via str value]
    M --> O[_validate_string_value]
    N --> O
    O -- valid --> P[add to validated_metadata]
    O -- invalid --> Q[drop with warning]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
langfuse/_client/propagation.py:126-130
The docstring still says non-string metadata values "will be dropped with warning" (`AVOID: ... non-string values (will be dropped with warning)`), but the new code now coerces them to strings via `str(value)`. A caller who reads the docstring before passing `int`/`float`/`bool` values will incorrectly expect them to be silently dropped.

```suggestion
        metadata: Additional key-value metadata to propagate to all spans.
            - Keys must be US-ASCII strings
            - String values must be ≤200 characters; non-string values are coerced via ``str()``
            - ``None`` values are silently skipped
            - Use for dimensions like internal correlating identifiers
            - AVOID: large payloads, sensitive data
```

### Issue 2 of 2
tests/unit/test_serializer.py:307
The file is missing a trailing newline. Most linters and editors (and git) expect text files to end with a newline character.

```suggestion
    assert serializer.encode(float("nan")) == '"NaN"'
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: serialize negative infinity as -Inf..."](https://github.com/langfuse/langfuse-python/commit/2d0f5ab0cae07a3e45166609e33d9b95ce967435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35008127)</sub>

<!-- /greptile_comment -->