### PR TITLE
feat(langchain): add generation metadata hook

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -18,6 +18,7 @@ from uuid import UUID
 import pydantic
 from opentelemetry import context, trace
 from opentelemetry.util._decorator import _AgnosticContextManager
+from typing_extensions import Protocol
 
 from langfuse import propagate_attributes
 from langfuse._client.attributes import LangfuseOtelSpanAttributes
@@ -142,12 +143,26 @@ class _PendingResumeTraceContextStore:
         return list(self._contexts.keys())
 
 
+class LangchainGenerationMetadataExtractor(Protocol):
+    def __call__(
+        self,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]: ...
+
+
 class LangchainCallbackHandler(LangchainBaseCallbackHandler):
     def __init__(
         self,
         *,
         public_key: Optional[str] = None,
         trace_context: Optional[TraceContext] = None,
+        generation_metadata_extractor: Optional[
+            LangchainGenerationMetadataExtractor
+        ] = None,
     ) -> None:
         """Initialize the LangchainCallbackHandler.
 
@@ -157,6 +172,9 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                 setting a custom trace id for the root LangChain run. Pass a `TraceContext` dict, e.g.
                 `{"trace_id": "<trace_id>"}` (and optionally `{"parent_span_id": "<span_id>"}`) to link
                 the trace to an upstream system.
+            generation_metadata_extractor: Optional callable that receives the LangChain `LLMResult`,
+                `run_id`, `parent_run_id`, and callback kwargs, and returns metadata to merge with
+                the ended Langfuse generation observation.
 
         Example:
             Use a custom trace id without context managers:
@@ -183,6 +201,8 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
         self._prompt_to_parent_run_map: Dict[UUID, Any] = {}
         self._updated_completion_start_time_memo: Set[UUID] = set()
         self._trace_context = trace_context
+        self._generation_metadata_extractor = generation_metadata_extractor
+        self._generation_metadata_by_run_id: Dict[UUID, Dict[str, Any]] = {}
         self._pending_resume_trace_contexts = _PendingResumeTraceContextStore(
             MAX_PENDING_RESUME_TRACE_CONTEXTS
         )
@@ -190,6 +210,25 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
         self._root_run_states: Dict[UUID, _RootRunState] = {}
 
         self.last_trace_id: Optional[str] = None
+
+    def get_generation_metadata(
+        self,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """Return response-derived metadata for a LangChain generation observation."""
+        if self._generation_metadata_extractor is None:
+            return None
+
+        return self._generation_metadata_extractor(
+            response,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            **kwargs,
+        )
 
     def on_llm_new_token(
         self,
@@ -1191,18 +1230,18 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                         current_parent_run_id
                     )
 
+            observation_metadata = self._get_langchain_observation_metadata(
+                parent_run_id=parent_run_id,
+                tags=tags,
+                metadata=metadata,
+                # If llm is run isolated and outside chain, keep trace attributes
+                keep_langfuse_trace_attributes=True if parent_run_id is None else False,
+            )
+
             content = {
                 "name": self.get_langchain_run_name(serialized, **kwargs),
                 "input": prompts,
-                "metadata": self._get_langchain_observation_metadata(
-                    parent_run_id=parent_run_id,
-                    tags=tags,
-                    metadata=metadata,
-                    # If llm is run isolated and outside chain, keep trace attributes
-                    keep_langfuse_trace_attributes=True
-                    if parent_run_id is None
-                    else False,
-                ),
+                "metadata": observation_metadata,
                 "model": model_name,
                 "model_parameters": self._parse_model_parameters(kwargs),
                 "prompt": registered_prompt,
@@ -1220,6 +1259,8 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                     as_type="generation", **content
                 )  # type: ignore
             self._attach_observation(run_id, generation)
+            if observation_metadata is not None:
+                self._generation_metadata_by_run_id[run_id] = observation_metadata
 
             self.last_trace_id = self._runs[run_id].trace_id
 
@@ -1314,14 +1355,30 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
             model = _parse_model(response)
 
             generation = self._detach_observation(run_id)
+            initial_metadata = self._generation_metadata_by_run_id.pop(run_id, {})
 
             if generation is not None:
+                try:
+                    generation_metadata = self.get_generation_metadata(
+                        response,
+                        run_id=run_id,
+                        parent_run_id=parent_run_id,
+                        **kwargs,
+                    )
+                except Exception as e:
+                    langfuse_logger.exception(e)
+                    generation_metadata = None
+
                 generation.update(
                     output=extracted_response,
                     usage=llm_usage,
                     usage_details=llm_usage,
                     input=kwargs.get("inputs"),
                     model=model,
+                    metadata={
+                        **initial_metadata,
+                        **(generation_metadata or {}),
+                    },
                 ).end()
 
         except Exception as e:
@@ -1346,6 +1403,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
             self._log_debug_event("on_llm_error", run_id, parent_run_id, error=error)
 
             generation = self._detach_observation(run_id)
+            self._generation_metadata_by_run_id.pop(run_id, None)
 
             if generation is not None:
                 level, status_message = self._get_error_level_and_status_message(error)
@@ -1380,10 +1438,12 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
         root_run_state = self._root_run_states.pop(run_state.root_run_id, None)
         if root_run_state is None:
             self._run_states.pop(root_run_id, None)
+            self._generation_metadata_by_run_id.pop(root_run_id, None)
             return
 
         for run_id in root_run_state.run_ids:
             self._run_states.pop(run_id, None)
+            self._generation_metadata_by_run_id.pop(run_id, None)
 
     def _exit_propagation_context(self, run_id: UUID) -> None:
         root_run_state = self._get_root_run_state(run_id)

--- a/tests/unit/test_langchain.py
+++ b/tests/unit/test_langchain.py
@@ -97,6 +97,150 @@ def test_chat_model_callback_exports_generation_span(
     }
 
 
+def test_chat_model_callback_adds_response_derived_generation_metadata(
+    langfuse_memory_client, get_span
+):
+    response = ChatResult(
+        generations=[
+            ChatGeneration(
+                message=AIMessage(
+                    content="bonjour",
+                    response_metadata={
+                        "headers": {
+                            "x-request-id": "req_123",
+                        },
+                    },
+                ),
+                text="bonjour",
+            )
+        ],
+        llm_output={"model_name": "gpt-4o-mini"},
+    )
+
+    def generation_metadata_extractor(
+        response, *, run_id, parent_run_id=None, **kwargs
+    ):
+        generation = response.generations[-1][-1]
+        headers = generation.message.response_metadata.get("headers", {})
+
+        return {
+            "provider_request_id": headers.get("x-request-id"),
+            "run_id": str(run_id),
+            "run_has_value": run_id is not None,
+        }
+
+    with patch.object(ChatOpenAI, "_generate", return_value=response):
+        handler = CallbackHandler(
+            generation_metadata_extractor=generation_metadata_extractor
+        )
+
+        with langfuse_memory_client.start_as_current_observation(name="parent"):
+            ChatOpenAI(api_key="test", temperature=0).invoke(
+                [HumanMessage(content="hello")],
+                config={
+                    "callbacks": [handler],
+                    "metadata": {"initial_metadata": "kept"},
+                },
+            )
+
+    langfuse_memory_client.flush()
+    generation_span = get_span("ChatOpenAI")
+
+    assert (
+        generation_span.attributes[
+            f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.initial_metadata"
+        ]
+        == "kept"
+    )
+    assert (
+        generation_span.attributes[
+            f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.provider_request_id"
+        ]
+        == "req_123"
+    )
+    assert (
+        generation_span.attributes[
+            f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.run_has_value"
+        ]
+        is True
+    )
+
+
+def test_chat_model_callback_supports_generation_metadata_subclass_hook(
+    langfuse_memory_client, get_span
+):
+    class CustomCallbackHandler(CallbackHandler):
+        def get_generation_metadata(
+            self, response, *, run_id, parent_run_id=None, **kwargs
+        ):
+            return {"provider_request_id": "subclass_req_123"}
+
+    response = ChatResult(
+        generations=[
+            ChatGeneration(message=AIMessage(content="bonjour"), text="bonjour")
+        ],
+        llm_output={"model_name": "gpt-4o-mini"},
+    )
+
+    with patch.object(ChatOpenAI, "_generate", return_value=response):
+        handler = CustomCallbackHandler()
+
+        with langfuse_memory_client.start_as_current_observation(name="parent"):
+            ChatOpenAI(api_key="test", temperature=0).invoke(
+                [HumanMessage(content="hello")],
+                config={"callbacks": [handler]},
+            )
+
+    langfuse_memory_client.flush()
+    generation_span = get_span("ChatOpenAI")
+
+    assert (
+        generation_span.attributes[
+            f"{LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.provider_request_id"
+        ]
+        == "subclass_req_123"
+    )
+
+
+def test_chat_model_callback_ends_generation_when_metadata_hook_fails(
+    langfuse_memory_client, get_span, json_attr
+):
+    response = ChatResult(
+        generations=[
+            ChatGeneration(message=AIMessage(content="bonjour"), text="bonjour")
+        ],
+        llm_output={"model_name": "gpt-4o-mini"},
+    )
+
+    def generation_metadata_extractor(response, *, run_id, parent_run_id=None, **kwargs):
+        raise RuntimeError("metadata unavailable")
+
+    with patch.object(ChatOpenAI, "_generate", return_value=response):
+        handler = CallbackHandler(
+            generation_metadata_extractor=generation_metadata_extractor
+        )
+
+        with langfuse_memory_client.start_as_current_observation(name="parent"):
+            ChatOpenAI(api_key="test", temperature=0).invoke(
+                [HumanMessage(content="hello")],
+                config={"callbacks": [handler]},
+            )
+
+    langfuse_memory_client.flush()
+    generation_span = get_span("ChatOpenAI")
+
+    assert (
+        generation_span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE]
+        == "generation"
+    )
+    assert json_attr(
+        generation_span, LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT
+    ) == {
+        "role": "assistant",
+        "content": "bonjour",
+    }
+
+
 def test_llm_callback_exports_generation_span(langfuse_memory_client, get_span):
     response = LLMResult(
         generations=[[Generation(text="sockzilla")]],


### PR DESCRIPTION
## What does this PR do?

Adds a public LangChain `CallbackHandler` extension point for response-derived generation metadata, addressing https://github.com/orgs/langfuse/discussions/14015.

Users can now either pass `generation_metadata_extractor` to `CallbackHandler` or override `get_generation_metadata(...)` in a subclass. The hook receives the LangChain `LLMResult` and can return metadata that is merged into the ended Langfuse generation observation, while preserving existing run-start metadata.

Fixes https://github.com/orgs/langfuse/discussions/14015

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash
uv run --frozen pytest tests/unit/test_langchain.py::test_chat_model_callback_adds_response_derived_generation_metadata tests/unit/test_langchain.py::test_chat_model_callback_supports_generation_metadata_subclass_hook tests/unit/test_langchain.py::test_chat_model_callback_ends_generation_when_metadata_hook_fails
uv run --frozen pytest tests/unit/test_langchain.py
uv run --frozen ruff check langfuse/langchain/CallbackHandler.py tests/unit/test_langchain.py
uv run --frozen mypy langfuse/langchain/CallbackHandler.py --no-error-summary
git diff --check
```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a response-derived generation metadata hook to the LangChain `CallbackHandler`, letting users inject custom metadata (e.g., provider request IDs from response headers) into Langfuse generation observations after the LLM responds. Users can supply a `generation_metadata_extractor` callable at construction time or override the new `get_generation_metadata` method in a subclass.

- Adds `LangchainGenerationMetadataExtractor` Protocol and `get_generation_metadata` public override point; the hook result is merged with start-time metadata in `on_llm_end`.
- Introduces `_generation_metadata_by_run_id` to carry the start-time observation metadata forward to the end event so it can be re-applied alongside response-derived fields; cleanup is wired into `on_llm_error` and `_reset`.
- Three new unit tests cover the extractor path, the subclass-override path, and the resilience path (hook raises → generation still ends correctly).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The new hook is well-isolated behind a try/except so a failing extractor never blocks generation completion, and the internal state dict is cleaned up on all exit paths.

The logic is straightforward and the three new tests cover the critical new paths. Two minor gaps hold the score below 5: the LangchainGenerationMetadataExtractor Protocol is not re-exported from the public package entry point, and on_llm_end now unconditionally passes a metadata argument to update() even when both the extractor and initial metadata are absent — a behavioural change from before the PR that no existing test exercises directly.

langfuse/langchain/__init__.py — the new Protocol should be exported here alongside CallbackHandler.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant LC as LangChain
    participant CB as LangchainCallbackHandler
    participant Meta as _generation_metadata_by_run_id
    participant Obs as LangfuseObservation

    LC->>CB: on_chat_model_start / on_llm_start
    CB->>CB: __on_llm_action → compute observation_metadata
    CB->>Obs: "start_observation(metadata=observation_metadata)"
    CB->>Meta: "store[run_id] = observation_metadata (if not None)"

    LC->>CB: on_llm_end(response)
    CB->>Meta: "pop initial_metadata (default {})"
    CB->>CB: get_generation_metadata(response, run_id, ...)
    note over CB: try/except – hook failure is logged, generation still ends
    CB->>Obs: "update(metadata={**initial_metadata, **generation_metadata})"
    CB->>Obs: end()

    alt LLM error path
        LC->>CB: on_llm_error(error)
        CB->>Meta: pop(run_id, None) – discard stored metadata
        CB->>Obs: update(level, status_message).end()
    end

    alt Chain reset path
        CB->>Meta: pop all run_ids in root_run_state
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
langfuse/langchain/__init__.py:1-5
**`LangchainGenerationMetadataExtractor` not re-exported from the public package**

`LangchainGenerationMetadataExtractor` is the typed interface users need to annotate their extractor functions, but it is only reachable through the internal path `langfuse.langchain.CallbackHandler`. Any user who wants to type-annotate an extractor (e.g. `extractor: LangchainGenerationMetadataExtractor`) must reach into the private module instead of using `from langfuse.langchain import ...`. Adding it to the `__init__.py` import and `__all__` list makes the public API complete.

### Issue 2 of 2
langfuse/langchain/CallbackHandler.py:1378-1382
**`metadata` always passed to `update()` even without an extractor**

Before this PR, `on_llm_end` never passed a `metadata` argument to `generation.update()`. Now it always does, even for the no-extractor / no-initial-metadata path where both `initial_metadata` and `generation_metadata` are empty, resulting in `update(metadata={})`. While the current OTel attribute implementation treats an empty dict as a no-op and existing span attributes are unaffected, this is a silent behavioural change. Consider guarding the `metadata` keyword with a truthiness check so the argument is omitted when there is nothing to set — this makes the intent explicit and avoids surprising interactions if the serialisation layer changes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(langchain): add generation metadata..."](https://github.com/langfuse/langfuse-python/commit/580dd9805af2daa3134ac534380f7cdac807181b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35342184)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->