### PR TITLE
fix: treat GraphInterrupt as default-level in @observe decorator

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -26,6 +26,7 @@ from langfuse._client.constants import (
     ObservationTypeLiteralNoEvent,
     get_observation_types_list,
 )
+from langfuse._utils.control_flow import get_error_level
 from langfuse._client.environment_variables import (
     LANGFUSE_OBSERVE_DECORATOR_IO_CAPTURE_ENABLED,
 )
@@ -302,7 +303,8 @@ class LangfuseDecorator:
                         return result
                     except (Exception, asyncio.CancelledError) as e:
                         langfuse_span_or_generation.update(
-                            level="ERROR", status_message=str(e) or type(e).__name__
+                            level=get_error_level(e),
+                            status_message=str(e) or type(e).__name__,
                         )
 
                         raise e
@@ -393,7 +395,8 @@ class LangfuseDecorator:
                         return result
                     except (Exception, asyncio.CancelledError) as e:
                         langfuse_span_or_generation.update(
-                            level="ERROR", status_message=str(e) or type(e).__name__
+                            level=get_error_level(e),
+                            status_message=str(e) or type(e).__name__,
                         )
 
                         raise e
@@ -591,7 +594,8 @@ class _ContextPreservedSyncGeneratorWrapper:
             return
 
         self.span.update(
-            level="ERROR", status_message=str(error) or type(error).__name__
+            level=get_error_level(error),
+            status_message=str(error) or type(error).__name__,
         ).end()
         self._span_ended = True
 
@@ -686,7 +690,8 @@ class _ContextPreservedAsyncGeneratorWrapper:
             return
 
         self.span.update(
-            level="ERROR", status_message=str(error) or type(error).__name__
+            level=get_error_level(error),
+            status_message=str(error) or type(error).__name__,
         ).end()
         self._span_ended = True
 

--- a/langfuse/_utils/control_flow.py
+++ b/langfuse/_utils/control_flow.py
@@ -1,0 +1,30 @@
+"""Utilities for detecting control-flow exceptions that should not be marked as errors.
+
+LangGraph uses GraphBubbleUp subclasses (e.g. GraphInterrupt, NodeInterrupt) for
+expected control flow such as human-in-the-loop interrupts and handoffs.  These are
+not real errors and should be recorded at "DEFAULT" level in Langfuse, not "ERROR".
+"""
+
+from typing import Literal, Set, Type
+
+CONTROL_FLOW_EXCEPTION_TYPES: Set[Type[BaseException]] = set()
+
+try:
+    from langgraph.errors import GraphBubbleUp
+
+    CONTROL_FLOW_EXCEPTION_TYPES.add(GraphBubbleUp)
+except ImportError:
+    pass
+
+
+def get_error_level(
+    error: BaseException,
+) -> Literal["DEFAULT", "ERROR"]:
+    """Return the appropriate Langfuse observation level for *error*.
+
+    Returns ``"DEFAULT"`` for known control-flow exceptions (e.g.
+    ``GraphInterrupt``) and ``"ERROR"`` for everything else.
+    """
+    if any(isinstance(error, t) for t in CONTROL_FLOW_EXCEPTION_TYPES):
+        return "DEFAULT"
+    return "ERROR"

--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -85,16 +85,11 @@ except ImportError:
     )
 
 LANGSMITH_TAG_HIDDEN: str = "langsmith:hidden"
-CONTROL_FLOW_EXCEPTION_TYPES: Set[Type[BaseException]] = set()
-LANGGRAPH_COMMAND_TYPE: Optional[Type[Any]] = None
 MAX_PENDING_RESUME_TRACE_CONTEXTS = 1024
 
-try:
-    from langgraph.errors import GraphBubbleUp
+from langfuse._utils.control_flow import CONTROL_FLOW_EXCEPTION_TYPES, get_error_level
 
-    CONTROL_FLOW_EXCEPTION_TYPES.add(GraphBubbleUp)
-except ImportError:
-    pass
+LANGGRAPH_COMMAND_TYPE: Optional[Type[Any]] = None
 
 try:
     from langgraph.types import Command as LangGraphCommand
@@ -358,10 +353,11 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
     ) -> tuple[Literal["DEFAULT", "ERROR"], str]:
         # LangGraph uses GraphBubbleUp subclasses for expected control flow such as
         # interrupts and handoffs, so they should stay visible without being errors.
-        if any(isinstance(error, t) for t in CONTROL_FLOW_EXCEPTION_TYPES):
-            return "DEFAULT", str(error) or type(error).__name__
+        level = get_error_level(error)
+        if level == "DEFAULT":
+            return level, str(error) or type(error).__name__
 
-        return "ERROR", str(error)
+        return level, str(error)
 
     def _get_observation_type_from_serialized(
         self, serialized: Optional[Dict[str, Any]], callback_type: str, **kwargs: Any


### PR DESCRIPTION
## Problem

LangGraph HITL interrupts (`GraphInterrupt`, `NodeInterrupt`) are incorrectly logged as `level="ERROR"` when using the `@observe` decorator. The `CallbackHandler` already handles this correctly via `CONTROL_FLOW_EXCEPTION_TYPES`, but `@observe` does not check for control flow exceptions.

## Root Cause

In `observe.py`, all 4 exception handlers unconditionally set `level="ERROR"`:
- Async wrapper (line ~303)
- Sync wrapper (line ~394)
- Sync generator wrapper (line ~592)
- Async generator wrapper (line ~687)

## Fix

1. **New shared utility** `langfuse/_utils/control_flow.py`: exports `get_error_level(error)` that returns `"DEFAULT"` for `GraphBubbleUp` subclasses, `"ERROR"` for everything else

2. **Modified** `observe.py`: all 4 handlers now use `level=get_error_level(e)` instead of hardcoded `"ERROR"`

3. **Modified** `CallbackHandler.py`: imports from shared utility instead of maintaining its own copy

## Verification

- `GraphInterrupt` → `level="DEFAULT"` ✓
- `NodeInterrupt` → `level="DEFAULT"` ✓
- `RuntimeError` → `level="ERROR"` ✓
- Both code paths use the same shared logic ✓

Fixes langfuse/langfuse#14034

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `GraphInterrupt` and `NodeInterrupt` (LangGraph HITL control-flow exceptions) being incorrectly logged at `level="ERROR"` by the `@observe` decorator. It introduces a shared `get_error_level()` utility in `langfuse/_utils/control_flow.py` and applies it to all four exception-handling paths in `observe.py`, while also refactoring `CallbackHandler.py` to use the same utility instead of its own inline copy.

- **New `langfuse/_utils/control_flow.py`**: Exports `get_error_level(error)` and `CONTROL_FLOW_EXCEPTION_TYPES`; safely optional-imports `GraphBubbleUp` from `langgraph`.
- **`observe.py`**: All four handlers (async, sync, sync-generator, async-generator) now call `get_error_level(e)` instead of hardcoding `"ERROR"`.
- **`CallbackHandler.py`**: `_get_error_level_and_status_message` delegates to `get_error_level`; `CONTROL_FLOW_EXCEPTION_TYPES` is imported but no longer referenced.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the logic change is correct and well-scoped, with only minor housekeeping issues in CallbackHandler.py.

The core fix is straightforward and correct — get_error_level is properly shared across both code paths. The only issues are in CallbackHandler.py: an import placed after module-level constants instead of at the top of the file, and CONTROL_FLOW_EXCEPTION_TYPES being imported but never actually used after the refactor.

langfuse/langchain/CallbackHandler.py — the import placement and unused symbol should be cleaned up.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Exception raised in decorated function] --> B{get_error_level}
    B --> C{Is instance of\nCONTROL_FLOW_EXCEPTION_TYPES?}
    C -- Yes\n e.g. GraphInterrupt\nNodeInterrupt --> D[level = DEFAULT]
    C -- No\n e.g. RuntimeError\nValueError --> E[level = ERROR]
    D --> F[span.update\nlevel=DEFAULT, status_message]
    E --> G[span.update\nlevel=ERROR, status_message]
    F --> H[Re-raise exception]
    G --> H

    subgraph control_flow.py
        B
        C
    end

    subgraph observe.py
        F
        G
    end

    subgraph CallbackHandler.py
        I[_get_error_level_and_status_message] --> B
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
langfuse/langchain/CallbackHandler.py:90
`CONTROL_FLOW_EXCEPTION_TYPES` is imported here but is never referenced anywhere else in `CallbackHandler.py` — the refactored `_get_error_level_and_status_message` now delegates entirely to `get_error_level()`, so only `get_error_level` is needed. The unused symbol will trigger linting/import-checker warnings.

```suggestion
from langfuse._utils.control_flow import get_error_level
```

### Issue 2 of 2
langfuse/langchain/CallbackHandler.py:90
**Import placed after module-level constants**
This import lands at line 90, after the constant definitions on lines 87–88, which breaks the convention of keeping all imports at the top of the module. It should be moved up alongside the other `langfuse._utils` and `langfuse._client` imports in the preamble.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: treat GraphInterrupt as default-lev..."](https://github.com/langfuse/langfuse-python/commit/de2bab166ae3a687524f214f05252e25cc19bdee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35694963)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->