### PR TITLE
fix(observe): preserve current span observation type

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1378,7 +1378,13 @@ class Langfuse:
         current_otel_span = self._get_current_otel_span()
 
         if current_otel_span is not None:
-            span = LangfuseSpan(
+            existing_observation_type = current_otel_span.attributes.get(  # type: ignore[attr-defined]
+                LangfuseOtelSpanAttributes.OBSERVATION_TYPE, "span"
+            )
+            span_class = self._get_span_class(
+                cast(ObservationTypeLiteral, existing_observation_type)
+            )
+            span = span_class(
                 otel_span=current_otel_span,
                 langfuse_client=self,
                 environment=self._environment,

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -114,6 +114,34 @@ async def test_streaming_response_preserves_context_without_output_capture(
     assert LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT not in endpoint_span.attributes
 
 
+def test_observe_capture_output_false_preserves_as_type_after_current_span_update(
+    langfuse_memory_client: Any, memory_exporter: Any
+) -> None:
+    @observe(
+        name="probe.with_capture_output_false",
+        as_type="guardrail",
+        capture_output=False,
+    )
+    def probe() -> dict[str, bool]:
+        langfuse_memory_client.update_current_span(output={"verdict": "manually set"})
+
+        return {"decorator_output": True}
+
+    assert probe() == {"decorator_output": True}
+
+    langfuse_memory_client.flush()
+
+    probe_span = _finished_spans_by_name(
+        memory_exporter, "probe.with_capture_output_false"
+    )[0]
+
+    assert (
+        probe_span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE]
+        == "guardrail"
+    )
+    assert LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT in probe_span.attributes
+
+
 def test_sync_generator_wrapper_close_ends_span_without_exhaustion() -> None:
     def generator() -> Generator[str, None, None]:
         yield "item_0"


### PR DESCRIPTION
## Summary

- Preserve the active observation type when `update_current_span()` wraps the current OTEL span for updates.
- Add a regression test for `@observe(as_type="guardrail", capture_output=False)` followed by `update_current_span(output=...)`.

Fixes #1676.

## Verification

- `uv run --frozen pytest tests/unit/test_observe.py::test_observe_capture_output_false_preserves_as_type_after_current_span_update -q`
- `uv run --frozen pytest tests/unit/test_observe.py -q`
- `uv run --frozen pytest tests/unit/test_otel.py::TestBasicSpans::test_update_current_span_name tests/unit/test_otel.py::TestBasicSpans::test_update_current_generation_name -q`
- `uv run --frozen ruff check langfuse/_client/client.py tests/unit/test_observe.py`
- `uv run --frozen ruff format --check langfuse/_client/client.py tests/unit/test_observe.py`
- `uv run --frozen mypy langfuse --no-error-summary`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `update_current_span()` always wrapped the active OTEL span as a `LangfuseSpan`, losing the original observation type (e.g., `"guardrail"`) set by `@observe(as_type=...)`. The fix reads the `OBSERVATION_TYPE` attribute from the current OTEL span and dispatches to `_get_span_class()` before constructing the wrapper — consistent with the pattern already used in `set_current_trace_io` and `set_current_trace_as_public`.

- **`langfuse/_client/client.py`**: `update_current_span` now reads `LangfuseOtelSpanAttributes.OBSERVATION_TYPE` from the active span's attributes and uses `_get_span_class()` to select the correct wrapper class instead of hardcoding `LangfuseSpan`.
- **`tests/unit/test_observe.py`**: Adds a regression test verifying that a `@observe(as_type=\"guardrail\", capture_output=False)` span retains its type after `update_current_span(output=...)` is called.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, one-line logical fix that matches the existing pattern used by two other methods in the same class.

The fix reads the existing OBSERVATION_TYPE attribute before constructing the wrapper span, exactly mirroring set_current_trace_io and set_current_trace_as_public which already did this correctly. The _get_span_class method has a safe fallback to LangfuseSpan for unknown types. The added regression test directly covers the reported bug scenario.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User Code
    participant D as @observe(as_type=guardrail)
    participant C as Langfuse Client
    participant OS as OTEL Span

    U->>D: call decorated function
    D->>OS: "start span, set OBSERVATION_TYPE=guardrail"
    U->>C: "update_current_span(output=...)"
    C->>OS: _get_current_otel_span()
    OS-->>C: current_otel_span
    C->>OS: attributes.get(OBSERVATION_TYPE, span)
    OS-->>C: guardrail
    C->>C: _get_span_class(guardrail) to LangfuseGuardrail
    C->>C: "LangfuseGuardrail(otel_span=current_otel_span)"
    C->>OS: "span.update(output=...)"
    Note over OS: OBSERVATION_TYPE preserved as guardrail
    D->>OS: "end span (capture_output=False)"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observe): preserve current span obse..."](https://github.com/langfuse/langfuse-python/commit/0d44ccf449a46d8e5ffd01b5e0b2a6608a8894cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36085131)</sub>

<!-- /greptile_comment -->