### PR TITLE
fix(langchain): silence intentional placeholder warnings

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -309,6 +309,18 @@ class ChatPromptClient(BasePromptClient):
             Dict[str, Any], ChatMessageDict, ChatMessageWithPlaceholdersDict_Placeholder
         ]
     ]:
+        return self._compile(warn_on_unresolved_placeholders=True, **kwargs)
+
+    def _compile(
+        self,
+        *,
+        warn_on_unresolved_placeholders: bool,
+        **kwargs: Union[str, Any],
+    ) -> Sequence[
+        Union[
+            Dict[str, Any], ChatMessageDict, ChatMessageWithPlaceholdersDict_Placeholder
+        ]
+    ]:
         """Compile the prompt with placeholders and variables.
 
         Args:
@@ -381,7 +393,7 @@ class ChatPromptClient(BasePromptClient):
                     compiled_messages.append(chat_message)
                     unresolved_placeholders.append(chat_message["name"])  # type: ignore
 
-        if unresolved_placeholders:
+        if warn_on_unresolved_placeholders and unresolved_placeholders:
             unresolved_placeholders_message = f"Placeholders {unresolved_placeholders} have not been resolved. Pass them as keyword arguments to compile()."
             langfuse_logger.warning(unresolved_placeholders_message)
 
@@ -446,7 +458,10 @@ class ChatPromptClient(BasePromptClient):
             List of messages in the format expected by Langchain's ChatPromptTemplate:
             (role, content) tuples for regular messages or MessagesPlaceholder objects for unresolved placeholders.
         """
-        compiled_messages = self.compile(**kwargs)
+        compiled_messages = self._compile(
+            warn_on_unresolved_placeholders=False,
+            **kwargs,
+        )
         langchain_messages: List[Union[Tuple[str, str], Any]] = []
 
         for msg in compiled_messages:

--- a/tests/unit/test_prompt_compilation.py
+++ b/tests/unit/test_prompt_compilation.py
@@ -804,6 +804,8 @@ Configuration:
 
     def test_get_langchain_prompt_with_unresolved_placeholders(self):
         """Test that unresolved placeholders become MessagesPlaceholder objects."""
+        from unittest.mock import patch
+
         from langfuse.api import Prompt_Chat
         from langfuse.model import ChatPromptClient
 
@@ -826,10 +828,13 @@ Configuration:
         )
 
         # Call get_langchain_prompt without resolving placeholder
-        langchain_messages = prompt_client.get_langchain_prompt(
-            role="helpful",
-            task="coding",
-        )
+        with patch("langfuse.logger.langfuse_logger.warning") as mock_warning:
+            langchain_messages = prompt_client.get_langchain_prompt(
+                role="helpful",
+                task="coding",
+            )
+
+        mock_warning.assert_not_called()
 
         # Should have 3 items: system message, MessagesPlaceholder, user message
         assert len(langchain_messages) == 3


### PR DESCRIPTION
## Summary

- Keep unresolved-placeholder warnings for direct `ChatPromptClient.compile()` calls.
- Stop emitting that warning from `get_langchain_prompt()` when unresolved placeholders are intentionally returned as LangChain `MessagesPlaceholder` objects.
- Add regression coverage to ensure the LangChain hand-off path stays quiet while preserving the existing placeholder output.

Fixes #1667.

## Verification

- `uv run --frozen pytest tests/unit/test_prompt_compilation.py::TestLangchainPromptCompilation::test_get_langchain_prompt_with_unresolved_placeholders -q`
- `uv run --frozen pytest tests/unit/test_prompt_compilation.py -q`
- `uv run --frozen ruff check langfuse/model.py tests/unit/test_prompt_compilation.py`
- `uv run --frozen ruff format --check langfuse/model.py tests/unit/test_prompt_compilation.py`
- `uv run --frozen mypy langfuse --no-error-summary`
- `git diff --check`

I also tried `uv run --frozen pytest tests/e2e/test_prompt.py::test_warning_on_unresolved_placeholders -q`, but the local run requires Langfuse server credentials/API setup and failed before the assertion path with `Langfuse client initialized without public_key`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes spurious `langfuse_logger.warning` calls that fire during `get_langchain_prompt()` when unresolved placeholders are intentionally left for LangChain to handle as `MessagesPlaceholder` objects.

- `compile()` is refactored into a thin wrapper around a new private `_compile(warn_on_unresolved_placeholders: bool)` method; the public API is unchanged and still warns by default.
- `get_langchain_prompt()` now calls `_compile(warn_on_unresolved_placeholders=False)`, suppressing the warning only on the LangChain hand-off path.
- A regression test asserts that `langfuse_logger.warning` is never called during `get_langchain_prompt()` when a placeholder is intentionally left unresolved.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the behavioural change is narrow and well-tested.

The refactor correctly isolates warning behaviour behind a flag, public compile() is unchanged, and a targeted regression test covers the silent path. The only finding is a style-level import placed inside a test method body rather than at the module top.

No files require special attention beyond the minor import placement in the test.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["compile(kwargs)"] -->|"warn=True"| B["_compile()"]
    C["get_langchain_prompt(kwargs)"] -->|"warn=False"| B

    B --> D{placeholder resolved?}
    D -- Yes --> E[expand messages]
    D -- No --> F[keep as placeholder dict]
    F --> G{warn flag set?}
    G -- Yes --> H["langfuse_logger.warning()"]
    G -- No --> I[silent]

    A --> L[return raw dicts]
    C --> M["convert to LangChain tuples / MessagesPlaceholder"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/test_prompt_compilation.py:805-810
The `patch` import is placed inside the test method body. The project rule requires imports to be at the top of the module. The two pre-existing local imports (`Prompt_Chat`, `ChatPromptClient`) also violate this rule, but this PR actively adds a third one (`from unittest.mock import patch`) and is a good opportunity to move at least the new import to the top-level block.

```suggestion
    def test_get_langchain_prompt_with_unresolved_placeholders(self):
        """Test that unresolved placeholders become MessagesPlaceholder objects."""
        from langfuse.api import Prompt_Chat
        from langfuse.model import ChatPromptClient
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): silence intentional plac..."](https://github.com/langfuse/langfuse-python/commit/43f649f3519c2db2e6c67c172368bf7defa21f58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36088848)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->