### PR TITLE
fix(media): don't crash when media block data is raw bytes

### DIFF
--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -126,6 +126,7 @@ class MediaManager:
                 and data["type"] == "base64"
                 and "media_type" in data
                 and "data" in data
+                and isinstance(data["data"], str)
             ):
                 media = LangfuseMedia(
                     base64_data_uri=f"data:{data['media_type']};base64," + data["data"],
@@ -150,6 +151,7 @@ class MediaManager:
                 and data["type"] == "media"
                 and "mime_type" in data
                 and "data" in data
+                and isinstance(data["data"], str)
             ):
                 media = LangfuseMedia(
                     base64_data_uri=f"data:{data['mime_type']};base64," + data["data"],

--- a/tests/unit/test_media_manager.py
+++ b/tests/unit/test_media_manager.py
@@ -194,3 +194,25 @@ def test_find_and_process_media_sse_in_nested_structure_passes_through():
 
     assert result == data
     assert queue.empty()
+
+
+def test_find_and_process_media_base64_block_with_bytes_data_passes_through():
+    queue = Queue()
+    manager = MediaManager(
+        api_client=SimpleNamespace(media=Mock()),
+        httpx_client=Mock(),
+        media_upload_queue=queue,
+    )
+
+    # Anthropic/Vertex media blocks whose "data" is raw bytes rather than a
+    # base64 string must not crash media processing.
+    data = [
+        {"type": "base64", "media_type": "image/png", "data": b"\x89PNG raw"},
+        {"type": "media", "mime_type": "image/png", "data": b"\x89PNG raw"},
+    ]
+    result = manager._find_and_process_media(
+        data=data, trace_id="trace-id", observation_id=None, field="input"
+    )
+
+    assert result == data
+    assert queue.empty()


### PR DESCRIPTION
## What's broken

`MediaManager._find_and_process_media` builds a data URI for Anthropic- and Vertex-style media blocks with `f"...;base64," + data["data"]`. The branch guards only check that the `data` key exists, not that its value is a `str`. If a logged payload carries raw image bytes there, the `str + bytes` concatenation raises an uncaught `TypeError`. Because the caller runs outside the masking `try/except`, the crash propagates out of span/observation creation.

```python
payload = {"role": "user", "content": [
    {"type": "base64", "media_type": "image/png", "data": b"\x89PNG ..."}]}
mm._find_and_process_media(data=payload, trace_id="t", observation_id="o", field="input")
# -> TypeError: can only concatenate str (not "bytes") to str
```

## Why it happens

The format guards verify the dict shape but assume `data["data"]` is a base64 string.

## Fix

Add an `isinstance(data["data"], str)` check to both branches, so non-string data falls through to normal pass-through handling instead of crashing.

## Test

Processing a base64 block whose `data` is bytes passes through unchanged instead of raising.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR guards two branches in `_find_and_process_media` that build base64 data URIs by adding `isinstance(data["data"], str)` checks, preventing a `TypeError` crash when a logged payload carries raw bytes instead of a base64 string in the `"data"` field of Anthropic- or Vertex-style media blocks.

- **Anthropic block** (`type == "base64"`): now skips media processing and passes the dict through unchanged when `data["data"]` is not a `str`.
- **Vertex block** (`type == "media"`): same guard added for the `mime_type`-keyed variant.
- A new unit test covers both block shapes with `bytes` data and asserts no media is enqueued.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal two-line guard that prevents a crash without altering any existing code path for valid string data.

Both guards touch only the condition that selects a code path; the string-data path is identical to before, and the bytes-data path now falls through to the existing generic dict recursion rather than throwing. The new test directly exercises both block shapes with raw bytes and confirms pass-through with no queued uploads.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_process_data_recursively] --> B{isinstance data dict?}
    B -- No --> C[Other checks / pass-through]
    B -- Yes --> D{Anthropic block?\ntype==base64, media_type, data}
    D -- No --> E{Vertex block?\ntype==media, mime_type, data}
    D -- Yes --> F{isinstance data.data str?}
    E -- Yes --> G{isinstance data.data str?}
    F -- Yes --> H[Build base64 URI\nUpload media\nReturn copied dict with LangfuseMedia]
    F -- No --> I[Fall through to dict recursion\nPass-through unchanged]
    G -- Yes --> J[Build base64 URI\nUpload media\nReturn copied dict with LangfuseMedia]
    G -- No --> I
    E -- No --> K[Recurse into dict values]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(media): don&#39;t crash when Anthropic/V..."](https://github.com/langfuse/langfuse-python/commit/68b0a20f61c33e462a94dbcca0731a418504a44d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36527985)</sub>

<!-- /greptile_comment -->