### PR TITLE
fix: update env template to use LANGFUSE_BASE_URL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,5 @@
 # Langfuse
 LANGFUSE_BASE_URL=http://localhost:3000
-LANGFUSE_HOST=http://localhost:3000  # deprecated alias for LANGFUSE_BASE_URL
 LANGFUSE_PUBLIC_KEY=pk-lf-1234567890
 LANGFUSE_SECRET_KEY=sk-lf-1234567890
 

--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 # Langfuse
-LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_BASE_URL=http://localhost:3000
+LANGFUSE_HOST=http://localhost:3000  # deprecated alias for LANGFUSE_BASE_URL
 LANGFUSE_PUBLIC_KEY=pk-lf-1234567890
 LANGFUSE_SECRET_KEY=sk-lf-1234567890
 


### PR DESCRIPTION
Closes LFE-10249

## What does this PR do?

A contributor who follows CONTRIBUTING.md set up langfuse-python and to run the E2E test suite hits a KeyError before any test runs, because .env.template does not include LANGFUSE_BASE_URL, which the test infrastructure hard-requires.

Root cause

LANGFUSE_BASE_URL is the canonical env var in v4; LANGFUSE_HOST is deprecated ([AGENTS.md:131](http://agents.md:131/), code_review.md:14).

The SDK client itself works with either — reads LANGFUSE_BASE_URL first, falls back to LANGFUSE_HOST (langfuse/_client/client.py:258-263).

But the test infra has no fallback: tests/support/api_wrapper.py:19 uses os.environ["LANGFUSE_BASE_URL"] (subscript → KeyError if unset). tests/support/utils.py:72 passes os.environ.get("LANGFUSE_BASE_URL") (→ None), which then hits that subscript.

.env.template ships only LANGFUSE_HOST, never LANGFUSE_BASE_URL.

[CONTRIBUTING.md:39](http://contributing.md:39/) tells contributors to set up E2E env vars "based on .env.template".

5 of 8 files in tests/e2e/ call get_api() / LangfuseAPI, so all of them fail without the var.

Steps to reproduce

cp .env.template .env and fill in keys (per CONTRIBUTING).

Start a local Langfuse server.

Run uv run --frozen pytest -n 4 --dist worksteal tests/e2e -m "not serial_e2e".

Result: errors/failures originating from KeyError('LANGFUSE_BASE_URL').

Minimal repro (no server needed):

$ env -i LANGFUSE_HOST=http://localhost:3000/ \

    LANGFUSE_PUBLIC_KEY=pk-lf-... LANGFUSE_SECRET_KEY=sk-lf-... \
    python -c "from tests.support.api_wrapper import LangfuseAPI; LangfuseAPI(base_url=None)"

KeyError: 'LANGFUSE_BASE_URL'

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a contributor-facing DX issue: `.env.template` was missing `LANGFUSE_BASE_URL` (the canonical v4 env var), causing a `KeyError` before any E2E test ran when following the CONTRIBUTING.md setup steps. The fix adds `LANGFUSE_BASE_URL` as the primary entry and retains `LANGFUSE_HOST` with a deprecation comment.

- Adds `LANGFUSE_BASE_URL=http://localhost:3000` to `.env.template`, matching what `tests/support/api_wrapper.py:19` requires via `os.environ["LANGFUSE_BASE_URL"]`.
- Keeps `LANGFUSE_HOST` in the template with an inline comment marking it deprecated, which preserves backward-compat awareness but introduces a minor risk (see comment).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line template addition that unblocks E2E tests for new contributors without touching any runtime code.

The change is confined to `.env.template`, adds exactly the missing variable that `tests/support/api_wrapper.py` hard-requires, and introduces no logic changes. The only minor concern is the inline comment on the deprecated `LANGFUSE_HOST` line, which could confuse non-python-dotenv tooling.

No files require special attention; `.env.template` is the only changed file and the fix is straightforward.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.env.template:3
Inline comments in `.env` files are handled inconsistently across tooling. `python-dotenv` strips them correctly, but `source .env` in bash or `export $(cat .env | xargs)` would set `LANGFUSE_HOST` to the literal string `http://localhost:3000  # deprecated alias for LANGFUSE_BASE_URL`, breaking any fallback path that reads `LANGFUSE_HOST`. Since `LANGFUSE_BASE_URL` is now in the template and is the canonical var, moving the deprecation note to its own comment line avoids this entirely.

```suggestion
# LANGFUSE_HOST is a deprecated alias for LANGFUSE_BASE_URL
LANGFUSE_HOST=http://localhost:3000
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add LANGFUSE\_BASE\_URL to .env.template s..."](https://github.com/langfuse/langfuse-python/commit/3d20207952d3f92938e0df9b36e3dd9cc41dc70b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36777259)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->