### PR TITLE
fix(serializer): preserve Decimal values and non-primitive dict keys

### DIFF
--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -73,11 +73,13 @@ class EventSerializer(JSONEncoder):
             if np is not None and isinstance(obj, np.ndarray):
                 return obj.tolist()
 
-            # Route Decimal through float so it is preserved as a number
-            # (and Decimal("NaN")/Decimal("Infinity") reuse the handlers below)
-            # instead of falling through to the "<Decimal>" type fallback.
+            # Serialize Decimal as its exact string form rather than via float():
+            # float() would silently round high-precision values (and overflow on
+            # very large ones), and JSON numbers are parsed as doubles downstream
+            # anyway. str() preserves the exact value; NaN/Infinity render as
+            # "NaN"/"Infinity"/"-Infinity", matching the float handling below.
             if isinstance(obj, decimal.Decimal):
-                return self.default(float(obj))
+                return str(obj)
 
             if isinstance(obj, float) and math.isnan(obj):
                 return "NaN"

--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -1,6 +1,7 @@
 """@private"""
 
 import datetime as dt
+import decimal
 import enum
 import math
 from asyncio import Queue
@@ -72,6 +73,12 @@ class EventSerializer(JSONEncoder):
             if np is not None and isinstance(obj, np.ndarray):
                 return obj.tolist()
 
+            # Route Decimal through float so it is preserved as a number
+            # (and Decimal("NaN")/Decimal("Infinity") reuse the handlers below)
+            # instead of falling through to the "<Decimal>" type fallback.
+            if isinstance(obj, decimal.Decimal):
+                return self.default(float(obj))
+
             if isinstance(obj, float) and math.isnan(obj):
                 return "NaN"
 
@@ -140,7 +147,19 @@ class EventSerializer(JSONEncoder):
                 return list(obj)
 
             if isinstance(obj, dict):
-                return {self.default(k): self.default(v) for k, v in obj.items()}
+                result = {}
+                for k, v in obj.items():
+                    serialized_key = self.default(k)
+                    # JSON object keys must be scalars. If a key serializes to a
+                    # container/object (e.g. tuple, set, or custom object), fall back
+                    # to its string form so a single non-primitive key does not
+                    # discard the whole dict.
+                    if not isinstance(
+                        serialized_key, (str, int, float, bool, type(None))
+                    ):
+                        serialized_key = str(k)
+                    result[serialized_key] = self.default(v)
+                return result
 
             if isinstance(obj, list):
                 return [self.default(item) for item in obj]

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -2,6 +2,7 @@ import json
 import threading
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from decimal import Decimal
 from enum import Enum
 from pathlib import Path
 from uuid import UUID
@@ -304,3 +305,32 @@ def test_dict_with_non_string_keys_is_serialized(input_obj, expected):
     result = json.loads(EventSerializer().encode(input_obj))
 
     assert result == expected
+
+
+def test_decimal_is_preserved_as_number():
+    assert json.loads(EventSerializer().encode(Decimal("1.5"))) == 1.5
+    assert json.loads(EventSerializer().encode({"price": Decimal("19.99")})) == {
+        "price": 19.99
+    }
+
+
+def test_decimal_special_values():
+    assert EventSerializer().encode(Decimal("NaN")) == '"NaN"'
+    assert EventSerializer().encode(Decimal("Infinity")) == '"Infinity"'
+    assert EventSerializer().encode(Decimal("-Infinity")) == '"-Infinity"'
+
+
+def test_dict_with_non_primitive_keys_preserves_values():
+    # A tuple key must not discard the entire dict (previously the whole dict
+    # serialized to a "<not serializable ...>" string).
+    result = json.loads(EventSerializer().encode({(1, 2): "v", "other": "data"}))
+    assert result == {"(1, 2)": "v", "other": "data"}
+
+
+def test_dict_with_custom_object_key_uses_str():
+    class _Key:
+        def __str__(self) -> str:
+            return "custom-key"
+
+    result = json.loads(EventSerializer().encode({_Key(): "val", "k2": "x"}))
+    assert result == {"custom-key": "val", "k2": "x"}

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -307,11 +307,22 @@ def test_dict_with_non_string_keys_is_serialized(input_obj, expected):
     assert result == expected
 
 
-def test_decimal_is_preserved_as_number():
-    assert json.loads(EventSerializer().encode(Decimal("1.5"))) == 1.5
+def test_decimal_is_preserved_exactly():
+    # Serialized to its exact string form (never the "<Decimal>" fallback)
+    assert json.loads(EventSerializer().encode(Decimal("19.99"))) == "19.99"
     assert json.loads(EventSerializer().encode({"price": Decimal("19.99")})) == {
-        "price": 19.99
+        "price": "19.99"
     }
+    # High-precision values are preserved exactly (a float() conversion would
+    # silently round these).
+    assert (
+        json.loads(EventSerializer().encode(Decimal("1.0000000000000001")))
+        == "1.0000000000000001"
+    )
+    assert (
+        json.loads(EventSerializer().encode(Decimal("123456789012345678")))
+        == "123456789012345678"
+    )
 
 
 def test_decimal_special_values():


### PR DESCRIPTION
Two cases where `EventSerializer` silently dropped data in serialized trace input/output:

### 1. `decimal.Decimal` values are lost
There is no `Decimal` branch in `_default_inner`, so a `Decimal` falls through to the `"<{type}>"` fallback:
```python
EventSerializer().encode(Decimal("1.5"))            # -> "\"<Decimal>\""
EventSerializer().encode({"price": Decimal("19.99")})  # -> {"price": "<Decimal>"}
```
`Decimal` is common in financial/tool outputs. Fix serializes it via `str()` so the exact value is preserved (`float()` would silently round high-precision values and can overflow on very large ones); `Decimal("NaN")`/`Decimal("Infinity")` still render as `"NaN"`/`"Infinity"`.

### 2. A non-primitive dict key discards the whole dict
The dict branch did `{self.default(k): self.default(v) ...}`. When a key serializes to a container/object (tuple, set, custom object), the comprehension/JSON encoding raises and the `except` turns the **entire dict** into an error string:
```python
EventSerializer().encode({(1, 2): "v"})  # -> "\"<not serializable object of type: dict>\""
```
Fix stringifies such keys via `str(key)` so a single non-primitive key no longer drops every value.

### Tests
Adds 4 unit tests in `tests/unit/test_serializer.py` (verified fail-before / pass-after). Existing `datetime`/`uuid`/`enum`/`int` key behavior is unchanged (existing parametrized test still passes). `ruff check`/`ruff format` clean.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two silent data-loss bugs in `EventSerializer`: `decimal.Decimal` values were falling through to the `"<Decimal>"` opaque fallback, and a dict with any non-primitive key would discard the entire dict instead of just stringifying that key.

- **Decimal fix**: `Decimal` is now routed through `float()` before the existing `NaN`/`Infinity` handlers, so it serializes as a JSON number. Special `Decimal` values (`NaN`, `Infinity`, `-Infinity`) are handled correctly. The precision trade-off (float has ~15–17 significant digits) is an intentional design choice but is undocumented.
- **Dict key fix**: The dict branch now checks whether a serialized key is a JSON-scalar type, and falls back to `str(k)` for non-scalars (tuples, sets, custom objects), so a single exotic key no longer discards every value in the dict.
- Four new unit tests verify both fixes, including special Decimal values, tuple keys, and custom-object keys.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — both fixes address real silent-data-loss regressions, the logic is correct, and the new tests exercise the changed paths including edge cases.

The Decimal-to-float conversion works correctly for normal and special values, but silently narrows high-precision Decimal values to float precision without any documentation or warning. For a tracing library this is unlikely to cause problems in practice, but users who pass high-precision financial Decimals would see quietly rounded values in their trace data.

The Decimal precision trade-off in langfuse/_utils/serializer.py (lines 79–80) is the only area worth a second look; tests/unit/test_serializer.py is straightforward.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/_utils/serializer.py:79-80
**Decimal precision silently lost on float conversion**

`float()` can only represent ~15–17 significant digits, so any `Decimal` with higher precision is silently rounded. For example, `Decimal("1.0000000000000001")` becomes `1.0` and `Decimal("123456789012345678")` would gain rounding error. Since `Decimal` is often chosen specifically to avoid float imprecision (financial, scientific), users may find their high-precision values quietly corrupted in trace data. A comment documenting this trade-off would help, or alternatively the value could be converted to `str` instead, preserving the exact decimal representation while still avoiding the opaque `"<Decimal>"` fallback.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(serializer): preserve Decimal values..."](https://github.com/langfuse/langfuse-python/commit/ad99074df1c494060ebd8b4af8e6d38774342cae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37503538)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->