### PR TITLE
fix(langchain): convert prompt variables with non-word characters

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -163,7 +163,11 @@ class BasePromptClient(ABC):
     def _get_langchain_prompt_string(content: str) -> str:
         json_escaped_content = BasePromptClient._escape_json_for_langchain(content)
 
-        return re.sub(r"{{\s*(\w+)\s*}}", r"{\g<1>}", json_escaped_content)
+        # Match any Langfuse variable name between {{ }} (Langfuse allows names
+        # with hyphens, spaces, unicode, etc.), not just \w+. The character class
+        # excludes braces and quotes so already-escaped JSON (which appears as
+        # {{"key": ...}} after _escape_json_for_langchain) is left untouched.
+        return re.sub(r'{{\s*([^{}"]+?)\s*}}', r"{\g<1>}", json_escaped_content)
 
     @staticmethod
     def _escape_json_for_langchain(text: str) -> str:

--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -165,9 +165,10 @@ class BasePromptClient(ABC):
 
         # Match any Langfuse variable name between {{ }} (Langfuse allows names
         # with hyphens, spaces, unicode, etc.), not just \w+. The character class
-        # excludes braces and quotes so already-escaped JSON (which appears as
-        # {{"key": ...}} after _escape_json_for_langchain) is left untouched.
-        return re.sub(r'{{\s*([^{}"]+?)\s*}}', r"{\g<1>}", json_escaped_content)
+        # excludes braces and both quote styles so already-escaped JSON (which
+        # _escape_json_for_langchain doubles to {{"...}} or {{'...}}) is left
+        # untouched.
+        return re.sub(r"{{\s*([^{}\"']+?)\s*}}", r"{\g<1>}", json_escaped_content)
 
     @staticmethod
     def _escape_json_for_langchain(text: str) -> str:

--- a/tests/unit/test_prompt_compilation.py
+++ b/tests/unit/test_prompt_compilation.py
@@ -255,6 +255,29 @@ class TestLangchainPromptCompilation:
 
         assert formatted_prompt == expected
 
+    def test_get_langchain_prompt_preserves_special_variable_names(self):
+        """Variable names with hyphens/spaces/unicode must convert to langchain
+        single-brace placeholders instead of being left as unusable {{...}}."""
+        prompt = TextPromptClient(
+            Prompt_Text(
+                type="text",
+                name="special_var_names",
+                version=1,
+                config={},
+                tags=[],
+                labels=[],
+                prompt="Hello {{user-name}}!",
+            )
+        )
+
+        langchain_prompt_string = prompt.get_langchain_prompt()
+
+        assert langchain_prompt_string == "Hello {user-name}!"
+
+        langchain_prompt = PromptTemplate.from_template(langchain_prompt_string)
+        assert langchain_prompt.input_variables == ["user-name"]
+        assert langchain_prompt.format(**{"user-name": "Ada"}) == "Hello Ada!"
+
     def test_mixed_variables_with_nested_json(self):
         """Test normal variables (double braces) and Langchain variables (single braces) with nested JSON."""
         prompt_string = """Normal variable: {{user_name}}

--- a/tests/unit/test_prompt_compilation.py
+++ b/tests/unit/test_prompt_compilation.py
@@ -278,6 +278,25 @@ class TestLangchainPromptCompilation:
         assert langchain_prompt.input_variables == ["user-name"]
         assert langchain_prompt.format(**{"user-name": "Ada"}) == "Hello Ada!"
 
+    def test_get_langchain_prompt_leaves_quoted_json_escaped(self):
+        """Brace-pairs wrapping JSON (single- or double-quoted) must stay doubled
+        for langchain, not be converted as if they were variables."""
+        prompt = TextPromptClient(
+            Prompt_Text(
+                type="text",
+                name="json_braces",
+                version=1,
+                config={},
+                tags=[],
+                labels=[],
+                prompt="Reply with {'key': 'value'} and {{name}}",
+            )
+        )
+
+        result = prompt.get_langchain_prompt()
+
+        assert result == "Reply with {{'key': 'value'}} and {name}"
+
     def test_mixed_variables_with_nested_json(self):
         """Test normal variables (double braces) and Langchain variables (single braces) with nested JSON."""
         prompt_string = """Normal variable: {{user_name}}


### PR DESCRIPTION
When converting a Langfuse prompt to a LangChain template, `_get_langchain_prompt_string` only matched `\w+` variable names:

```python
re.sub(r"{{\s*(\w+)\s*}}", r"{\g<1>}", json_escaped_content)
```

But Langfuse variable names are permissive (the template parser just `.strip()`s the name), so a valid prompt like `Hello {{user-name}}!` is left unchanged. LangChain then reads `{{` as a literal brace, so the variable is silently dropped and can never be filled:

```python
client.get_langchain_prompt()                     # "Hello {{user-name}}!"  (not converted)
PromptTemplate.from_template(...).input_variables  # []
.format(...)                                       # "Hello {user-name}!"   (un-fillable)
```

Fix broadens the capture to `[^{}"]+?`, so any variable name (hyphens, spaces, unicode, …) converts, while still excluding already-escaped JSON — which appears as `{{"key": ...}}` after `_escape_json_for_langchain` and must stay doubled. Verified the JSON case stays correctly escaped (the existing JSON-escaping tests still pass).

### Test
Adds a unit test in `TestLangchainPromptCompilation` for a hyphenated variable (fails before: left as `{{user-name}}`). All 33 tests in the file pass. `ruff check`/`format` clean.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent variable-drop bug in `_get_langchain_prompt_string` where Langfuse variable names containing non-word characters (hyphens, spaces, unicode) were never converted to LangChain single-brace format, leaving them as un-fillable `{{...}}` literals.

- The regex capture group is broadened from `\w+` to `[^{}"]+?`, so any variable name not containing braces or double-quotes now converts correctly.
- A new unit test (`test_get_langchain_prompt_preserves_special_variable_names`) covers the hyphen case end-to-end through `PromptTemplate.format`.
- The fix is one line in `model.py`; all existing JSON-escaping tests continue to pass per the PR description.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core regex fix is correct for double-quoted JSON content, but it introduces a regression for single-quote–prefixed content that `_escape_json_for_langchain` also escapes.

The escape function at line 213 doubles braces for both `'` and `"` prefixes, so a prompt containing `{'key': 'value'}` is escaped to `{{'key': 'value'}}`. The new `[^{}"]+?` character class excludes `"` but not `'`, so that escaped pair is still matched and incorrectly converted to a LangChain placeholder instead of being left as a literal. The old `\w+` was accidentally immune to this. The fix is one character away (`[^{}"']+?`), but as written the PR leaves this gap.

langfuse/model.py — specifically the character class in `_get_langchain_prompt_string` and whether the new test suite covers single-quote–delimited content going through `_escape_json_for_langchain`.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/model.py:170
`_escape_json_for_langchain` doubles braces for both `"` **and** `'`-prefixed content (line 213: `text[j] in {"'", '"'}`). A prompt like `The result is {'key': 'value'}` is escaped to `{{'key': 'value'}}`, but `[^{}"]+?` does not exclude `'`, so the new regex matches it and converts it to `{'key': 'value'}` — a LangChain placeholder — instead of leaving the brace-pair literal. The old `\w+` was accidentally safe here; this PR introduces a regression for single-quote–prefixed content. Adding `'` to the exclusion class keeps parity with the escaper.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): convert prompt variables..."](https://github.com/langfuse/langfuse-python/commit/f46716995a330b928d0af390df4ff626e5019479) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37515761)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->