### PR TITLE
fix(propagation): coerce propagated metadata values

### DIFF
--- a/langfuse/_client/propagation.py
+++ b/langfuse/_client/propagation.py
@@ -95,7 +95,7 @@ def propagate_attributes(
     *,
     user_id: Optional[str] = None,
     session_id: Optional[str] = None,
-    metadata: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,
     tags: Optional[List[str]] = None,
     trace_name: Optional[str] = None,
@@ -125,10 +125,11 @@ def propagate_attributes(
             Must be US-ASCII string, ≤200 characters. Use this to group related traces
             within a user session (e.g., a conversation thread, multi-turn interaction).
         metadata: Additional key-value metadata to propagate to all spans.
-            - Keys and values must be US-ASCII strings
-            - All values must be ≤200 characters
+            - Keys must be US-ASCII strings
+            - Values are coerced to strings
+            - Coerced values must be ≤200 characters
             - Use for dimensions like internal correlating identifiers
-            - AVOID: large payloads, sensitive data, non-string values (will be dropped with warning)
+            - AVOID: large payloads or sensitive data
         version: Version identfier for parts of your application that are independently versioned, e.g. agents
         tags: List of tags to categorize the group of observations
         trace_name: Name to assign to the trace. Must be US-ASCII string, ≤200 characters.
@@ -204,9 +205,10 @@ def propagate_attributes(
         ```
 
     Note:
-        - **Validation**: All attribute values (user_id, session_id, metadata values)
-          must be strings ≤200 characters. Invalid values will be dropped with a
-          warning logged. Ensure values meet constraints before calling.
+        - **Validation**: Attribute values (user_id, session_id, version, tags,
+          trace_name) must be strings ≤200 characters. Metadata values are
+          coerced to strings before the 200 character limit is applied. Invalid
+          values will be dropped with a warning logged.
         - **OpenTelemetry**: This uses OpenTelemetry context propagation under the hood,
           making it compatible with other OTel-instrumented libraries.
 
@@ -229,7 +231,7 @@ def _propagate_attributes(
     *,
     user_id: Optional[str] = None,
     session_id: Optional[str] = None,
-    metadata: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     version: Optional[str] = None,
     tags: Optional[List[str]] = None,
     trace_name: Optional[str] = None,
@@ -247,7 +249,7 @@ def _propagate_attributes(
         "trace_name": trace_name,
     }
 
-    propagated_metadata_attributes: Dict[str, Optional[Dict[str, str]]] = {
+    propagated_metadata_attributes: Dict[str, Optional[Dict[str, Any]]] = {
         "metadata": metadata,
     }
 
@@ -286,8 +288,10 @@ def _propagate_attributes(
         validated_metadata: Dict[str, str] = {}
 
         for key, value in metadata_value.items():
-            if _validate_string_value(value=value, key=f"{metadata_key}.{key}"):
-                validated_metadata[key] = value
+            coerced_value = value if isinstance(value, str) else str(value)
+
+            if _validate_string_value(value=coerced_value, key=f"{metadata_key}.{key}"):
+                validated_metadata[key] = coerced_value
 
         if validated_metadata:
             context = _set_propagated_attribute(

--- a/tests/unit/test_propagate_attributes.py
+++ b/tests/unit/test_propagate_attributes.py
@@ -461,6 +461,35 @@ class TestPropagateAttributesValidation(TestPropagateAttributesBase):
             child_span, LangfuseOtelSpanAttributes.TRACE_USER_ID
         )
 
+    def test_non_string_metadata_values_coerced(
+        self, langfuse_client, memory_exporter, caplog
+    ):
+        """Verify non-string metadata values are coerced instead of dropped."""
+
+        caplog.set_level("WARNING", logger="langfuse")
+        metadata = {
+            "langgraph_step": 1,
+            "langgraph_triggers": ["branch:agent"],
+            "langgraph_path": ("root", "agent"),
+            "max_search_results": 5,
+        }
+
+        with langfuse_client.start_as_current_observation(name="parent-span"):
+            with propagate_attributes(metadata=metadata):
+                child = langfuse_client.start_observation(name="child-span")
+                child.end()
+
+        child_span = self.get_span_by_name(memory_exporter, "child-span")
+
+        for key, value in metadata.items():
+            self.verify_span_attribute(
+                child_span,
+                f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.{key}",
+                str(value),
+            )
+
+        assert "value is not a string. Dropping value." not in caplog.text
+
     def test_mixed_valid_invalid_metadata(self, langfuse_client, memory_exporter):
         """Verify mixed valid/invalid metadata - valid entries kept, invalid dropped."""
         with langfuse_client.start_as_current_observation(name="parent-span"):


### PR DESCRIPTION
## Summary

- Coerce propagated metadata values to strings before applying the existing 200-character validation.
- Keep non-metadata propagated fields on the existing strict string validation path.
- Add regression coverage for LangGraph-style metadata values (`int`, `list`, `tuple`) and the absence of the old non-string warning.

## Root Cause

`_propagate_attributes` validated metadata values with `_validate_string_value` before conversion. LangGraph injects non-string metadata such as `langgraph_step`, `langgraph_triggers`, and `langgraph_path`, so those values were dropped and warned on every root callback invocation despite the v4 migration docs promising string coercion.

## Linear

Fixes LFE-8935

## Verification

- `uv run --frozen pytest tests/unit/test_propagate_attributes.py::TestPropagateAttributesValidation`
- `uv run --frozen pytest tests/unit/test_propagate_attributes.py`
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check langfuse/_client/propagation.py tests/unit/test_propagate_attributes.py`
- `uv run --frozen mypy langfuse --no-error-summary`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes the silent dropping of non-string metadata values (such as those injected by LangGraph — `langgraph_step: int`, `langgraph_triggers: list`, `langgraph_path: tuple`) during attribute propagation by coercing them to strings before the existing 200-character validation rather than validating the raw value and warning.

- `_propagate_attributes` now converts any non-string metadata value via `str(value)` before calling `_validate_string_value`, so LangGraph-style `int`/`list`/`tuple` values are preserved rather than dropped.
- `propagate_attributes` and `_propagate_attributes` public signatures updated from `Dict[str, str]` to `Dict[str, Any]` for the `metadata` parameter to match the new coercion behaviour.
- A regression test verifies that `int`, `list`, and `tuple` metadata values are stored as their `str()` representations and that no "not a string" warning is emitted.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped to the metadata coercion path and does not touch string-validated fields (user_id, session_id, version, tags, trace_name).

The fix is a one-liner coercion (str(value)) applied only to metadata values before the existing length check, leaving all other validation paths intact. The public type signature update is consistent with the runtime behavior. The new test exercises all three non-string categories called out in the root cause (int, list, tuple) and also asserts the absence of the old spurious warning. No edge cases appear to be missed.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(propagation): coerce propagated meta..."](https://github.com/langfuse/langfuse-python/commit/f7a242963929c30ddc5137e689c45cab3b770fe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37604182)</sub>

<!-- /greptile_comment -->