### PR TITLE
fix(scores): support CORRECTION score data type

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1786,7 +1786,9 @@ class Langfuse:
         trace_id: Optional[str] = None,
         score_id: Optional[str] = None,
         observation_id: Optional[str] = None,
-        data_type: Optional[Literal["CATEGORICAL", "TEXT"]] = "CATEGORICAL",
+        data_type: Optional[
+            Literal["CATEGORICAL", "TEXT", "CORRECTION"]
+        ] = "CATEGORICAL",
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         metadata: Optional[Any] = None,
@@ -1816,13 +1818,13 @@ class Langfuse:
 
         Args:
             name: Name of the score (e.g., "relevance", "accuracy")
-            value: Score value (can be numeric for NUMERIC/BOOLEAN types or string for CATEGORICAL/TEXT)
+            value: Score value (can be numeric for NUMERIC/BOOLEAN types or string for CATEGORICAL/TEXT/CORRECTION)
             session_id: ID of the Langfuse session to associate the score with
             dataset_run_id: ID of the Langfuse dataset run to associate the score with
             trace_id: ID of the Langfuse trace to associate the score with
             observation_id: Optional ID of the specific observation to score. Trace ID must be provided too.
             score_id: Optional custom ID for the score (auto-generated if not provided)
-            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, or TEXT)
+            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, or CORRECTION)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
             metadata: Optional metadata to be attached to the score
@@ -1946,7 +1948,9 @@ class Langfuse:
         name: str,
         value: str,
         score_id: Optional[str] = None,
-        data_type: Optional[Literal["CATEGORICAL", "TEXT"]] = "CATEGORICAL",
+        data_type: Optional[
+            Literal["CATEGORICAL", "TEXT", "CORRECTION"]
+        ] = "CATEGORICAL",
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         metadata: Optional[Any] = None,
@@ -1970,9 +1974,9 @@ class Langfuse:
 
         Args:
             name: Name of the score (e.g., "relevance", "accuracy")
-            value: Score value (can be numeric for NUMERIC/BOOLEAN types or string for CATEGORICAL/TEXT)
+            value: Score value (can be numeric for NUMERIC/BOOLEAN types or string for CATEGORICAL/TEXT/CORRECTION)
             score_id: Optional custom ID for the score (auto-generated if not provided)
-            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, or TEXT)
+            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, or CORRECTION)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
             metadata: Optional metadata to be attached to the score
@@ -2010,7 +2014,7 @@ class Langfuse:
                 name=name,
                 value=cast(str, value),
                 score_id=score_id,
-                data_type=cast(Literal["CATEGORICAL", "TEXT"], data_type),
+                data_type=cast(Literal["CATEGORICAL", "TEXT", "CORRECTION"], data_type),
                 comment=comment,
                 config_id=config_id,
                 metadata=metadata,
@@ -2036,7 +2040,9 @@ class Langfuse:
         name: str,
         value: str,
         score_id: Optional[str] = None,
-        data_type: Optional[Literal["CATEGORICAL", "TEXT"]] = "CATEGORICAL",
+        data_type: Optional[
+            Literal["CATEGORICAL", "TEXT", "CORRECTION"]
+        ] = "CATEGORICAL",
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
         metadata: Optional[Any] = None,
@@ -2061,9 +2067,9 @@ class Langfuse:
 
         Args:
             name: Name of the score (e.g., "user_satisfaction", "overall_quality")
-            value: Score value (can be numeric for NUMERIC/BOOLEAN types or string for CATEGORICAL/TEXT)
+            value: Score value (can be numeric for NUMERIC/BOOLEAN types or string for CATEGORICAL/TEXT/CORRECTION)
             score_id: Optional custom ID for the score (auto-generated if not provided)
-            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, or TEXT)
+            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, or CORRECTION)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
             metadata: Optional metadata to be attached to the score
@@ -2099,7 +2105,7 @@ class Langfuse:
                 name=name,
                 value=cast(str, value),
                 score_id=score_id,
-                data_type=cast(Literal["CATEGORICAL", "TEXT"], data_type),
+                data_type=cast(Literal["CATEGORICAL", "TEXT", "CORRECTION"], data_type),
                 comment=comment,
                 config_id=config_id,
                 metadata=metadata,

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -308,7 +308,9 @@ class LangfuseObservationWrapper:
         value: str,
         score_id: Optional[str] = None,
         data_type: Optional[
-            Literal[ScoreDataType.CATEGORICAL, ScoreDataType.TEXT]
+            Literal[
+                ScoreDataType.CATEGORICAL, ScoreDataType.TEXT, ScoreDataType.CORRECTION
+            ]
         ] = ScoreDataType.CATEGORICAL,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
@@ -335,9 +337,9 @@ class LangfuseObservationWrapper:
 
         Args:
             name: Name of the score (e.g., "relevance", "accuracy")
-            value: Score value (numeric for NUMERIC/BOOLEAN, string for CATEGORICAL/TEXT)
+            value: Score value (numeric for NUMERIC/BOOLEAN, string for CATEGORICAL/TEXT/CORRECTION)
             score_id: Optional custom ID for the score (auto-generated if not provided)
-            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, or TEXT)
+            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, or CORRECTION)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
             timestamp: Optional timestamp for the score (defaults to current UTC time)
@@ -364,7 +366,7 @@ class LangfuseObservationWrapper:
             trace_id=self.trace_id,
             observation_id=self.id,
             score_id=score_id,
-            data_type=cast(Literal["CATEGORICAL", "TEXT"], data_type),
+            data_type=cast(Literal["CATEGORICAL", "TEXT", "CORRECTION"], data_type),
             comment=comment,
             config_id=config_id,
             timestamp=timestamp,
@@ -395,7 +397,9 @@ class LangfuseObservationWrapper:
         value: str,
         score_id: Optional[str] = None,
         data_type: Optional[
-            Literal[ScoreDataType.CATEGORICAL, ScoreDataType.TEXT]
+            Literal[
+                ScoreDataType.CATEGORICAL, ScoreDataType.TEXT, ScoreDataType.CORRECTION
+            ]
         ] = ScoreDataType.CATEGORICAL,
         comment: Optional[str] = None,
         config_id: Optional[str] = None,
@@ -423,9 +427,9 @@ class LangfuseObservationWrapper:
 
         Args:
             name: Name of the score (e.g., "user_satisfaction", "overall_quality")
-            value: Score value (numeric for NUMERIC/BOOLEAN, string for CATEGORICAL/TEXT)
+            value: Score value (numeric for NUMERIC/BOOLEAN, string for CATEGORICAL/TEXT/CORRECTION)
             score_id: Optional custom ID for the score (auto-generated if not provided)
-            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, or TEXT)
+            data_type: Type of score (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, or CORRECTION)
             comment: Optional comment or explanation for the score
             config_id: Optional ID of a score config defined in Langfuse
             timestamp: Optional timestamp for the score (defaults to current UTC time)
@@ -451,7 +455,7 @@ class LangfuseObservationWrapper:
             value=cast(str, value),
             trace_id=self.trace_id,
             score_id=score_id,
-            data_type=cast(Literal["CATEGORICAL", "TEXT"], data_type),
+            data_type=cast(Literal["CATEGORICAL", "TEXT", "CORRECTION"], data_type),
             comment=comment,
             config_id=config_id,
             timestamp=timestamp,

--- a/langfuse/types.py
+++ b/langfuse/types.py
@@ -35,7 +35,7 @@ from langfuse.api import MediaContentType
 
 SpanLevel = Literal["DEBUG", "DEFAULT", "WARNING", "ERROR"]
 
-ScoreDataType = Literal["NUMERIC", "CATEGORICAL", "BOOLEAN", "TEXT"]
+ScoreDataType = Literal["NUMERIC", "CATEGORICAL", "BOOLEAN", "TEXT", "CORRECTION"]
 
 # Text scores are not supported for evals and experiments
 ExperimentScoreType = Literal["NUMERIC", "CATEGORICAL", "BOOLEAN"]


### PR DESCRIPTION
## What does this PR do?

The score methods' type hints omitted the `CORRECTION` score data type, so the example in the [Corrections docs](https://langfuse.com/docs/observability/features/corrections) — `langfuse.create_score(..., value="...", data_type="CORRECTION")` — failed static type checking (`mypy`/`pyright` report `[call-overload]`), even though the runtime already accepted it.

This adds `CORRECTION` to:

- the public `ScoreDataType` alias (`langfuse/types.py`);
- the string-value `@overload`s and internal `cast`s of `create_score`, `score_current_span`, and `score_current_trace` (`langfuse/_client/client.py`);
- the string-value overloads and `cast`s of `LangfuseObservationWrapper.score` / `score_trace` (`langfuse/_client/span.py`);

and updates the corresponding `data_type:` / `value:` docstrings. `CORRECTION` is string-valued, so it is added only to the string overloads; the numeric overloads continue to reject it. There is no runtime behavior change — `data_type` already passes straight through to `ScoreBody`, whose generated `ScoreDataType` enum already includes `CORRECTION`.

Fixes: no tracking issue — corrects the documented example linked above.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash
uv run --frozen mypy langfuse --no-error-summary
uv run --frozen ruff check .
uv run --frozen ruff format --check langfuse/types.py langfuse/_client/client.py langfuse/_client/span.py
uv run --frozen pytest -n auto --dist worksteal tests/unit
```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [ ] I added or updated tests for behavior changes — N/A: type-hint-only change with no runtime behavior change. A runtime test would pass identically before and after, and a `get_args(ScoreDataType)` membership test would be a change-detector. The type checker is the effective verification: it now accepts the documented `create_score(..., data_type="CORRECTION")` example and still rejects numeric `CORRECTION`.
- [x] I updated docs, examples, or `.env.template` if needed — updated the inline `data_type:` / `value:` docstrings.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path — `langfuse/api/` untouched.
- [x] I did not commit secrets or credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `CORRECTION` to the public `ScoreDataType` alias and to all string-value `@overload`s (and their internal `cast`s) of `create_score`, `score_current_span`, `score_current_trace`, `LangfuseObservationWrapper.score`, and `score_trace`. The generated API enum in `langfuse/api/commons/types/score_data_type.py` already included `CORRECTION`, so there is no runtime behaviour change.

- **`langfuse/types.py`**: `ScoreDataType` Literal type alias now includes `"CORRECTION"`, bringing it in sync with the generated `ScoreDataType` StrEnum.
- **`langfuse/_client/client.py`** and **`langfuse/_client/span.py`**: All string-value overloads and `cast` expressions are updated consistently; numeric overloads are untouched; docstrings are refreshed to list the new type.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a type-hint-only change that brings public aliases in line with the already-shipped generated API enum; no runtime logic is altered.

All three changed files make consistent, surgical additions of `CORRECTION` to string-value overloads and casts. The underlying API enum already carried the value, so there is no surface for new runtime breakage. The single observation is a documentation comment that could be more precise.

No files require special attention; changes are localised to type annotations and docstrings.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller passes value and data_type] --> B{value type?}
    B -- float --> C["Overload: NUMERIC or BOOLEAN"]
    B -- str --> D["Overload: CATEGORICAL, TEXT, or CORRECTION"]
    C --> E[create_score / score / score_trace]
    D --> E
    E --> F[cast data_type to internal Literal]
    F --> G[ScoreBody to Langfuse API]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Caller passes value and data_type] --> B{value type?}
    B -- float --> C["Overload: NUMERIC or BOOLEAN"]
    B -- str --> D["Overload: CATEGORICAL, TEXT, or CORRECTION"]
    C --> E[create_score / score / score_trace]
    D --> E
    E --> F[cast data_type to internal Literal]
    F --> G[ScoreBody to Langfuse API]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/types.py:40-41
The comment on this line only mentions "Text scores" but `CORRECTION` is also a string-valued type that is intentionally absent from `ExperimentScoreType`. Updating the comment to cover both keeps future readers from wondering whether the omission of `CORRECTION` from `ExperimentScoreType` was accidental.

```suggestion
# Text and Correction scores are not supported for evals and experiments
ExperimentScoreType = Literal["NUMERIC", "CATEGORICAL", "BOOLEAN"]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scores): support CORRECTION score da..."](https://github.com/langfuse/langfuse-python/commit/7e402ee856cb5b09281c1625a55222ece663d11b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37791520)</sub>

<!-- /greptile_comment -->