### PR TITLE
test: cover dataset run item observation links

### DIFF
--- a/tests/unit/test_dataset_run_item_observation_id.py
+++ b/tests/unit/test_dataset_run_item_observation_id.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timezone
+
+from langfuse._client.datasets import DatasetClient
+from langfuse.api import Dataset, DatasetItem, DatasetRunItem, DatasetStatus
+
+
+def test_dataset_experiment_links_run_item_to_root_observation(
+    langfuse_memory_client, get_span, monkeypatch
+):
+    created_run_item = {}
+
+    def create_dataset_run_item(**kwargs):
+        created_run_item.update(kwargs)
+        return DatasetRunItem(
+            id="run-item-id",
+            dataset_run_id="dataset-run-id",
+            dataset_run_name=kwargs["run_name"],
+            dataset_item_id=kwargs["dataset_item_id"],
+            trace_id=kwargs["trace_id"],
+            observation_id=kwargs["observation_id"],
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+    monkeypatch.setattr(
+        langfuse_memory_client.api.dataset_run_items,
+        "create",
+        create_dataset_run_item,
+    )
+
+    now = datetime.now(timezone.utc)
+    dataset = DatasetClient(
+        dataset=Dataset(
+            id="dataset-id",
+            name="dataset",
+            description=None,
+            metadata=None,
+            project_id="project-id",
+            created_at=now,
+            updated_at=now,
+        ),
+        items=[
+            DatasetItem(
+                id="dataset-item-id",
+                status=DatasetStatus.ACTIVE,
+                input="input",
+                expected_output="expected",
+                metadata=None,
+                source_trace_id=None,
+                source_observation_id=None,
+                dataset_id="dataset-id",
+                dataset_name="dataset",
+                created_at=now,
+                updated_at=now,
+            )
+        ],
+        langfuse_client=langfuse_memory_client,
+    )
+
+    dataset.run_experiment(name="experiment", task=lambda *, item, **kwargs: "output")
+    langfuse_memory_client.flush()
+
+    root_span = get_span("experiment-item-run")
+    assert created_run_item["trace_id"] == format(root_span.context.trace_id, "032x")
+    assert created_run_item["observation_id"] == format(
+        root_span.context.span_id,
+        "016x",
+    )


### PR DESCRIPTION
## Summary
- Add a targeted regression test that dataset experiments create dataset run items with the root span observation id.
- Confirms the current Python SDK path already passes `observation_id=span.id`.

Linear: LFE-10352

## Verification
- Not run per request.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a targeted unit test verifying that `DatasetClient.run_experiment` correctly links each dataset run item to the root span's observation ID, guarding against a specific regression class where the wrong span ID (or no span ID) could be passed to `dataset_run_items.create`.

- The test monkeypatches `dataset_run_items.create` to capture kwargs, runs a single-item experiment, flushes the in-memory exporter, and then asserts both `trace_id` and `observation_id` match the root `\"experiment-item-run\"` span's context — confirming the existing `observation_id=span.id` path already passes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only addition with no production code changes; the existing SDK path it exercises already behaves correctly.

The change is a single new test file with no modifications to production code. The test correctly exercises the observation-ID linking path through a real DatasetClient, a monkeypatched API layer, and the in-memory OTel exporter already used by the unit test suite.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test
    participant DatasetClient
    participant Langfuse as Langfuse Client
    participant Span as OTel Span (experiment-item-run)
    participant Mock as Mock dataset_run_items.create

    Test->>DatasetClient: "run_experiment(name=experiment, task=...)"
    DatasetClient->>Langfuse: "run_experiment(data=[item], ...)"
    Langfuse->>Span: start_as_current_observation(experiment-item-run)
    Span-->>Langfuse: "span (span.id = root observation id)"
    Langfuse->>Mock: "create(trace_id=trace_id, observation_id=span.id, ...)"
    Mock-->>Langfuse: DatasetRunItem
    Langfuse-->>Span: end span
    Test->>Langfuse: flush()
    Test->>Test: get_span(experiment-item-run)
    Test->>Test: "assert created_run_item trace_id == root_span.context.trace_id"
    Test->>Test: "assert created_run_item observation_id == root_span.context.span_id"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test
    participant DatasetClient
    participant Langfuse as Langfuse Client
    participant Span as OTel Span (experiment-item-run)
    participant Mock as Mock dataset_run_items.create

    Test->>DatasetClient: "run_experiment(name=experiment, task=...)"
    DatasetClient->>Langfuse: "run_experiment(data=[item], ...)"
    Langfuse->>Span: start_as_current_observation(experiment-item-run)
    Span-->>Langfuse: "span (span.id = root observation id)"
    Langfuse->>Mock: "create(trace_id=trace_id, observation_id=span.id, ...)"
    Mock-->>Langfuse: DatasetRunItem
    Langfuse-->>Span: end span
    Test->>Langfuse: flush()
    Test->>Test: get_span(experiment-item-run)
    Test->>Test: "assert created_run_item trace_id == root_span.context.trace_id"
    Test->>Test: "assert created_run_item observation_id == root_span.context.span_id"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/test_dataset_run_item_observation_id.py:63-64
If `run_experiment` ever fails to call `dataset_run_items.create` (e.g. the item is skipped for any reason), `created_run_item` stays as an empty `{}` and the assertion on `created_run_item["trace_id"]` raises a `KeyError` instead of a meaningful `AssertionError`. Adding an explicit guard makes the failure message immediately actionable.

```suggestion
    root_span = get_span("experiment-item-run")
    assert created_run_item, "dataset_run_items.create was never called"
    assert created_run_item["trace_id"] == format(root_span.context.trace_id, "032x")
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover dataset run item observation..."](https://github.com/langfuse/langfuse-python/commit/3d682897c116e1ed0613c044ba80cccfbd707a01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37913799)</sub>

<!-- /greptile_comment -->