### PR TITLE
fix(openai): preserve Responses tools and streamed tool calls

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -185,6 +185,93 @@ OPENAI_METHODS_V1 = [
 ]
 
 
+_RESPONSES_PROMPT_FIELDS = ("tools", "tool_choice", "parallel_tool_calls")
+_STRUCTURED_OUTPUT_METADATA_FIELDS = ("response_format", "text_format")
+
+
+def _is_not_given(value: Any) -> bool:
+    return isinstance(value, NotGiven)
+
+
+def _get_attr_or_item(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(key, default)
+
+    return getattr(value, key, default)
+
+
+def _serialize_openai_value(value: Any) -> Any:
+    """Convert OpenAI SDK request/response wrapper values into plain data."""
+
+    if _is_not_given(value):
+        return None
+
+    if isclass(value) and issubclass(value, BaseModel):
+        return value.model_json_schema()
+
+    if isinstance(value, BaseModel):
+        value.model_rebuild()
+
+        try:
+            return _serialize_openai_value(
+                value.model_dump(mode="json", warnings=False)
+            )
+        except Exception:
+            return _serialize_openai_value(value.model_dump(warnings=False))
+
+    if isinstance(value, dict):
+        return {
+            key: _serialize_openai_value(val)
+            for key, val in value.items()
+            if not _is_not_given(val)
+        }
+
+    if isinstance(value, (list, tuple)):
+        return [_serialize_openai_value(item) for item in value]
+
+    return value
+
+
+def _get_structured_output_metadata(metadata: Optional[Any], kwargs: Any) -> Any:
+    structured_output_metadata = {}
+
+    for key in _STRUCTURED_OUTPUT_METADATA_FIELDS:
+        value = kwargs.get(key, None)
+
+        if value is not None and not _is_not_given(value):
+            structured_output_metadata[key] = _serialize_openai_value(value)
+
+    if not structured_output_metadata:
+        return metadata
+
+    metadata_dict = (
+        metadata.model_dump() if isinstance(metadata, BaseModel) else metadata
+    )
+
+    if metadata_dict is None:
+        metadata_dict = {}
+
+    if not isinstance(metadata_dict, dict):
+        metadata_dict = {}
+
+    return {**metadata_dict, **structured_output_metadata}
+
+
+def _extract_response_api_completion(output: Any) -> Any:
+    output = _serialize_openai_value(output)
+
+    if not isinstance(output, list):
+        return output
+
+    if len(output) > 1:
+        return output
+
+    if len(output) == 1:
+        return output[0]
+
+    return None
+
+
 class OpenAiArgsExtractor:
     def __init__(
         self,
@@ -199,17 +286,7 @@ class OpenAiArgsExtractor:
         **kwargs: Any,
     ) -> None:
         self.args = {}
-        self.args["metadata"] = (
-            metadata
-            if "response_format" not in kwargs
-            else {
-                **(metadata or {}),
-                "response_format": kwargs["response_format"].model_json_schema()
-                if isclass(kwargs["response_format"])
-                and issubclass(kwargs["response_format"], BaseModel)
-                else kwargs["response_format"],
-            }
-        )
+        self.args["metadata"] = _get_structured_output_metadata(metadata, kwargs)
         self.args["name"] = name
         self.args["langfuse_public_key"] = langfuse_public_key
         self.args["langfuse_prompt"] = langfuse_prompt
@@ -231,7 +308,8 @@ class OpenAiArgsExtractor:
 
             # OpenAI does not support non-string type values in metadata when using
             # model distillation feature
-            self.kwargs["metadata"].pop("response_format", None)
+            for key in _STRUCTURED_OUTPUT_METADATA_FIELDS:
+                self.kwargs["metadata"].pop(key, None)
 
         return self.kwargs
 
@@ -249,6 +327,13 @@ def _langfuse_wrapper(func: Any) -> Any:
 def _extract_responses_prompt(kwargs: Any) -> Any:
     input_value = kwargs.get("input", None)
     instructions = kwargs.get("instructions", None)
+    prompt_fields = {}
+
+    for key in _RESPONSES_PROMPT_FIELDS:
+        value = kwargs.get(key, None)
+
+        if value is not None and not isinstance(value, NotGiven):
+            prompt_fields[key] = _serialize_openai_value(value)
 
     if isinstance(input_value, NotGiven):
         input_value = None
@@ -257,21 +342,29 @@ def _extract_responses_prompt(kwargs: Any) -> Any:
         instructions = None
 
     if instructions is None:
-        return input_value
-
-    if input_value is None:
-        return {"instructions": instructions}
-
-    if isinstance(input_value, str):
-        return [
+        prompt = input_value
+    elif input_value is None:
+        prompt = {"instructions": instructions}
+    elif isinstance(input_value, str):
+        prompt = [
             {"role": "system", "content": instructions},
             {"role": "user", "content": input_value},
         ]
+    elif isinstance(input_value, list):
+        prompt = [{"role": "system", "content": instructions}, *input_value]
+    else:
+        prompt = {"instructions": instructions, "input": input_value}
 
-    if isinstance(input_value, list):
-        return [{"role": "system", "content": instructions}, *input_value]
+    if not prompt_fields:
+        return prompt
 
-    return {"instructions": instructions, "input": input_value}
+    if isinstance(prompt, dict) and set(prompt.keys()) <= {"instructions", "input"}:
+        return {**prompt, **prompt_fields}
+
+    if prompt is not None:
+        return {"input": prompt, **prompt_fields}
+
+    return prompt_fields
 
 
 def _extract_chat_prompt(kwargs: Any) -> Any:
@@ -620,13 +713,7 @@ def _extract_streamed_response_api_response(chunks: Any) -> Any:
                     metadata[key] = val
 
                 if key == "output":
-                    output = val
-                    if not isinstance(output, list):
-                        completion = output
-                    elif len(output) > 1:
-                        completion = output
-                    elif len(output) == 1:
-                        completion = output[0]
+                    completion = _extract_response_api_completion(val)
 
     return (model, completion, usage, metadata)
 
@@ -670,7 +757,8 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                         if completion["content"] is None
                         else completion["content"] + delta.get("content", None)
                     )
-                elif delta.get("function_call", None) is not None:
+
+                if delta.get("function_call", None) is not None:
                     curr = completion["function_call"]
                     tool_call_chunk = delta.get("function_call", None)
 
@@ -686,70 +774,86 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                         )
                         curr["arguments"] += getattr(tool_call_chunk, "arguments", "")
 
-                elif (
+                if (
                     delta.get("tool_calls", None) is not None
                     and len(delta.get("tool_calls")) > 0
                 ):
                     curr = completion["tool_calls"]
-                    tool_call_chunk = getattr(
-                        delta.get("tool_calls", None)[0], "function", None
-                    )
 
                     if not curr:
-                        completion["tool_calls"] = [
-                            {
-                                "name": getattr(tool_call_chunk, "name", ""),
-                                "arguments": getattr(tool_call_chunk, "arguments", ""),
-                            }
-                        ]
+                        completion["tool_calls"] = []
+                        curr = completion["tool_calls"]
 
-                    elif getattr(tool_call_chunk, "name", None) is not None:
-                        curr.append(
-                            {
-                                "name": getattr(tool_call_chunk, "name", None),
-                                "arguments": getattr(
-                                    tool_call_chunk, "arguments", None
-                                ),
-                            }
+                    for raw_tool_call in delta.get("tool_calls", []):
+                        index = _get_attr_or_item(raw_tool_call, "index", None)
+
+                        if not isinstance(index, int):
+                            index = len(curr) - 1 if curr else 0
+
+                        while len(curr) <= index:
+                            curr.append({"function": {"name": "", "arguments": ""}})
+
+                        current_tool_call = curr[index]
+                        tool_call_id = _get_attr_or_item(raw_tool_call, "id", None)
+                        tool_call_type = _get_attr_or_item(raw_tool_call, "type", None)
+                        tool_call_chunk = _get_attr_or_item(
+                            raw_tool_call, "function", None
                         )
 
-                    else:
-                        curr[-1]["name"] = curr[-1]["name"] or getattr(
-                            tool_call_chunk, "name", None
+                        if tool_call_id is not None:
+                            current_tool_call["id"] = tool_call_id
+
+                        if tool_call_type is not None:
+                            current_tool_call["type"] = tool_call_type
+
+                        if tool_call_chunk is None:
+                            continue
+
+                        function_call = current_tool_call.setdefault("function", {})
+                        tool_name = _get_attr_or_item(tool_call_chunk, "name", None)
+                        tool_arguments = _get_attr_or_item(
+                            tool_call_chunk, "arguments", None
                         )
 
-                        if curr[-1]["arguments"] is None:
-                            curr[-1]["arguments"] = ""
+                        if tool_name is not None:
+                            function_call["name"] = (
+                                function_call.get("name") or tool_name
+                            )
 
-                        curr[-1]["arguments"] += getattr(
-                            tool_call_chunk, "arguments", ""
-                        )
+                        if tool_arguments is not None:
+                            function_call["arguments"] = (
+                                function_call.get("arguments") or ""
+                            ) + tool_arguments
 
             if resource.type == "completion":
                 completion += choice.get("text", "")
 
     def get_response_for_chat() -> Any:
-        return (
-            completion["content"]
-            or (
-                completion["function_call"]
-                and {
-                    "role": "assistant",
-                    "function_call": completion["function_call"],
-                }
-            )
-            or (
-                completion["tool_calls"]
-                and {
-                    "role": "assistant",
-                    # "tool_calls": [{"function": completion["tool_calls"]}],
-                    "tool_calls": [
-                        {"function": data} for data in completion["tool_calls"]
-                    ],
-                }
-            )
-            or None
-        )
+        content = completion["content"]
+
+        if completion["tool_calls"]:
+            response = {
+                "role": "assistant",
+                "tool_calls": completion["tool_calls"],
+            }
+
+            if content is not None:
+                response["content"] = content
+
+            return response
+
+        if completion["function_call"]:
+            response = {
+                "role": "assistant",
+                "function_call": completion["function_call"],
+            }
+
+            if content is not None:
+                response["content"] = content
+
+            return response
+
+        return content or None
 
     return (
         model,
@@ -777,14 +881,7 @@ def _get_langfuse_data_from_default_response(
             completion = choice.text if _is_openai_v1() else choice.get("text", None)
 
     elif resource.object == "Responses" or resource.object == "AsyncResponses":
-        output = response.get("output", {})
-
-        if not isinstance(output, list):
-            completion = output
-        elif len(output) > 1:
-            completion = output
-        elif len(output) == 1:
-            completion = output[0]
+        completion = _extract_response_api_completion(response.get("output", {}))
 
     elif resource.type == "chat":
         choices = response.get("choices", [])

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -17,6 +17,7 @@ The integration is fully interoperable with the `observe()` decorator and the lo
 See docs for more details: https://langfuse.com/docs/integrations/openai
 """
 
+import json
 import types
 from collections import defaultdict
 from dataclasses import dataclass
@@ -27,6 +28,7 @@ from typing import Any, Optional, cast
 from openai._types import NotGiven
 from packaging.version import Version
 from pydantic import BaseModel
+from pydantic_core import to_jsonable_python
 from wrapt import wrap_function_wrapper
 
 from langfuse._client.get_client import get_client
@@ -217,7 +219,12 @@ def _serialize_openai_value(value: Any) -> Any:
                 value.model_dump(mode="json", warnings=False)
             )
         except Exception:
-            return _serialize_openai_value(value.model_dump(warnings=False))
+            try:
+                return _serialize_openai_value(
+                    json.loads(value.model_dump_json(warnings=False))
+                )
+            except Exception:
+                return _serialize_openai_value(value.model_dump(warnings=False))
 
     if isinstance(value, dict):
         return {
@@ -229,7 +236,10 @@ def _serialize_openai_value(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_serialize_openai_value(item) for item in value]
 
-    return value
+    try:
+        return to_jsonable_python(value)
+    except Exception:
+        return str(value)
 
 
 def _get_structured_output_metadata(metadata: Optional[Any], kwargs: Any) -> Any:
@@ -242,10 +252,12 @@ def _get_structured_output_metadata(metadata: Optional[Any], kwargs: Any) -> Any
             structured_output_metadata[key] = _serialize_openai_value(value)
 
     if not structured_output_metadata:
-        return metadata
+        return _serialize_openai_value(metadata)
 
     metadata_dict = (
-        metadata.model_dump() if isinstance(metadata, BaseModel) else metadata
+        _serialize_openai_value(metadata)
+        if isinstance(metadata, BaseModel)
+        else metadata
     )
 
     if metadata_dict is None:
@@ -286,6 +298,7 @@ class OpenAiArgsExtractor:
         **kwargs: Any,
     ) -> None:
         self.args = {}
+        self.metadata = metadata
         self.args["metadata"] = _get_structured_output_metadata(metadata, kwargs)
         self.args["name"] = name
         self.args["langfuse_public_key"] = langfuse_public_key
@@ -299,19 +312,15 @@ class OpenAiArgsExtractor:
         return {**self.args, **self.kwargs}
 
     def get_openai_args(self) -> Any:
+        openai_args = self.kwargs.copy()
+
         # If OpenAI model distillation is enabled, we need to add the metadata to the kwargs
         # https://platform.openai.com/docs/guides/distillation
-        if self.kwargs.get("store", False):
-            self.kwargs["metadata"] = (
-                {} if self.args.get("metadata", None) is None else self.args["metadata"]
-            )
+        if openai_args.get("store", False):
+            metadata = _serialize_openai_value(self.metadata)
+            openai_args["metadata"] = metadata if isinstance(metadata, dict) else {}
 
-            # OpenAI does not support non-string type values in metadata when using
-            # model distillation feature
-            for key in _STRUCTURED_OUTPUT_METADATA_FIELDS:
-                self.kwargs["metadata"].pop(key, None)
-
-        return self.kwargs
+        return openai_args
 
 
 def _langfuse_wrapper(func: Any) -> Any:
@@ -513,7 +522,7 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
         and not isinstance(metadata, dict)
     ):
         if isinstance(metadata, BaseModel):
-            metadata = metadata.model_dump()
+            metadata = _serialize_openai_value(metadata)
         else:
             metadata = {}
 

--- a/tests/live_provider/test_openai.py
+++ b/tests/live_provider/test_openai.py
@@ -1385,7 +1385,10 @@ def test_response_api_web_search(openai):
     assert len(generation.data) != 0
     generationData = generation.data[0]
     assert generationData.name == generation_name
-    assert generationData.input == "What was a positive news story from today?"
+    assert generationData.input == {
+        "input": "What was a positive news story from today?",
+        "tools": [{"type": "web_search_preview"}],
+    }
     assert generationData.type == "GENERATION"
     assert "gpt-4o" in generationData.model
     assert generationData.start_time is not None
@@ -1479,7 +1482,11 @@ def test_response_api_functions(openai):
     assert len(generation.data) != 0
     generationData = generation.data[0]
     assert generationData.name == generation_name
-    assert generation.data[0].input == "What is the weather like in Boston today?"
+    assert generation.data[0].input == {
+        "input": "What is the weather like in Boston today?",
+        "tools": tools,
+        "tool_choice": "auto",
+    }
     assert generationData.type == "GENERATION"
     assert "gpt-4o" in generationData.model
     assert generationData.start_time is not None

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -3,6 +3,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from openai.types.responses import ParsedResponseOutputMessage, ParsedResponseOutputText
+from pydantic import BaseModel
 
 import langfuse.openai as lf_openai_module
 from langfuse._client.attributes import LangfuseOtelSpanAttributes
@@ -159,6 +161,78 @@ def _make_chat_stream_chunks_with_trailing_content_filter_chunk():
     ]
 
 
+def _make_chat_stream_chunks_with_content_before_tool_call():
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+    return [
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role="assistant",
+                        content="\n\n",
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        ),
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role=None,
+                        content=None,
+                        function_call=None,
+                        tool_calls=[
+                            SimpleNamespace(
+                                index=0,
+                                id="call_weather",
+                                type="function",
+                                function=SimpleNamespace(
+                                    name="get_weather",
+                                    arguments='{"city"',
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        ),
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role=None,
+                        content=None,
+                        function_call=None,
+                        tool_calls=[
+                            SimpleNamespace(
+                                index=0,
+                                id=None,
+                                type=None,
+                                function=SimpleNamespace(
+                                    name=None,
+                                    arguments=': "Berlin"}',
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=usage,
+        ),
+    ]
+
+
 def _make_single_chunk_stream():
     return SimpleNamespace(
         model="gpt-4o-mini",
@@ -234,6 +308,79 @@ def test_chat_completion_exports_generation_span(
         "prompt_tokens": 3,
         "completion_tokens": 1,
         "total_tokens": 4,
+    }
+
+
+def test_streaming_chat_completion_preserves_tool_calls_after_content():
+    model, completion, usage, metadata = (
+        lf_openai_module._extract_streamed_openai_response(
+            SimpleNamespace(type="chat"),
+            _make_chat_stream_chunks_with_content_before_tool_call(),
+        )
+    )
+
+    assert model == "gpt-4o-mini"
+    assert completion == {
+        "role": "assistant",
+        "content": "\n\n",
+        "tool_calls": [
+            {
+                "id": "call_weather",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "Berlin"}',
+                },
+            }
+        ],
+    }
+    assert usage.prompt_tokens == 10
+    assert metadata == {"finish_reason": "tool_calls"}
+
+
+def test_response_api_output_serializes_openai_parsed_response_objects():
+    class ParsedOutput(BaseModel):
+        name: str
+
+    _, completion, _ = lf_openai_module._get_langfuse_data_from_default_response(
+        SimpleNamespace(type="chat", object="Responses"),
+        {
+            "model": "gpt-4.1-mini",
+            "output": [
+                ParsedResponseOutputMessage(
+                    id="msg_1",
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[
+                        ParsedResponseOutputText(
+                            annotations=[],
+                            text='{"name":"dave"}',
+                            type="output_text",
+                            parsed=ParsedOutput(name="dave"),
+                        )
+                    ],
+                )
+            ],
+            "usage": None,
+        },
+    )
+
+    assert completion == {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [
+            {
+                "annotations": [],
+                "text": '{"name":"dave"}',
+                "type": "output_text",
+                "logprobs": None,
+                "parsed": {"name": "dave"},
+            }
+        ],
+        "phase": None,
     }
 
 

--- a/tests/unit/test_openai_prompt_extraction.py
+++ b/tests/unit/test_openai_prompt_extraction.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import BaseModel
 
 try:
     # Compatibility across OpenAI SDK versions where NOT_GIVEN export moved.
@@ -6,7 +7,12 @@ try:
 except ImportError:
     from openai._types import NOT_GIVEN
 
-from langfuse.openai import _extract_responses_prompt
+from langfuse.openai import (
+    OpenAiArgsExtractor,
+    OpenAiDefinition,
+    _extract_responses_prompt,
+    _get_langfuse_data_from_kwargs,
+)
 
 
 @pytest.mark.parametrize(
@@ -40,7 +46,72 @@ from langfuse.openai import _extract_responses_prompt
         ),
         ({"instructions": NOT_GIVEN, "input": "Hello!"}, "Hello!"),
         ({"instructions": NOT_GIVEN, "input": NOT_GIVEN}, None),
+        (
+            {
+                "input": "Search for the weather in Berlin.",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    }
+                ],
+                "tool_choice": "auto",
+                "parallel_tool_calls": False,
+            },
+            {
+                "input": "Search for the weather in Berlin.",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    }
+                ],
+                "tool_choice": "auto",
+                "parallel_tool_calls": False,
+            },
+        ),
+        (
+            {
+                "instructions": "You are helpful.",
+                "input": "Hello!",
+                "tools": [{"type": "web_search_preview"}],
+            },
+            {
+                "input": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hello!"},
+                ],
+                "tools": [{"type": "web_search_preview"}],
+            },
+        ),
     ],
 )
 def test_extract_responses_prompt(kwargs, expected):
     assert _extract_responses_prompt(kwargs) == expected
+
+
+def test_responses_parse_text_format_is_captured_as_metadata():
+    class ResponseFormat(BaseModel):
+        name: str
+
+    resource = OpenAiDefinition(
+        module="",
+        object="Responses",
+        method="parse",
+        type="chat",
+        sync=True,
+    )
+    args = OpenAiArgsExtractor(
+        model="gpt-4.1",
+        input="What is your name?",
+        text_format=ResponseFormat,
+    ).get_langfuse_args()
+
+    langfuse_data = _get_langfuse_data_from_kwargs(resource, args)
+
+    assert (
+        langfuse_data["metadata"]["text_format"]["properties"]["name"]["type"]
+        == "string"
+    )

--- a/tests/unit/test_openai_prompt_extraction.py
+++ b/tests/unit/test_openai_prompt_extraction.py
@@ -1,3 +1,7 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum
+
 import pytest
 from pydantic import BaseModel
 
@@ -12,6 +16,7 @@ from langfuse.openai import (
     OpenAiDefinition,
     _extract_responses_prompt,
     _get_langfuse_data_from_kwargs,
+    _serialize_openai_value,
 )
 
 
@@ -115,3 +120,95 @@ def test_responses_parse_text_format_is_captured_as_metadata():
         langfuse_data["metadata"]["text_format"]["properties"]["name"]["type"]
         == "string"
     )
+
+
+def test_openai_value_serialization_fallback_stays_json_safe():
+    class UnknownLeaf:
+        def __str__(self):
+            return "<unknown>"
+
+    class MetadataKind(Enum):
+        EXAMPLE = "example"
+
+    class FallbackModel(BaseModel):
+        created_at: datetime
+        amount: Decimal
+        kind: MetadataKind
+
+        def model_dump(self, *args, **kwargs):
+            if kwargs.get("mode") == "json":
+                raise RuntimeError("json mode unavailable")
+
+            return super().model_dump(*args, **kwargs)
+
+    value = FallbackModel(
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        amount=Decimal("1.23"),
+        kind=MetadataKind.EXAMPLE,
+    )
+
+    assert _serialize_openai_value(value) == {
+        "created_at": "2024-01-01T00:00:00Z",
+        "amount": "1.23",
+        "kind": "example",
+    }
+    assert _serialize_openai_value({"leaf": UnknownLeaf()}) == {"leaf": "<unknown>"}
+
+
+def test_base_model_metadata_uses_json_safe_values():
+    class Metadata(BaseModel):
+        created_at: datetime
+
+    resource = OpenAiDefinition(
+        module="",
+        object="Responses",
+        method="create",
+        type="chat",
+        sync=True,
+    )
+    args = OpenAiArgsExtractor(
+        metadata=Metadata(created_at=datetime(2024, 1, 1, tzinfo=timezone.utc)),
+        model="gpt-4.1",
+        input="Hello!",
+    ).get_langfuse_args()
+
+    langfuse_data = _get_langfuse_data_from_kwargs(resource, args)
+
+    assert langfuse_data["metadata"] == {"created_at": "2024-01-01T00:00:00Z"}
+
+
+def test_store_preserves_user_structured_output_metadata_keys_for_openai():
+    metadata = {
+        "purpose": "distillation",
+        "response_format": "user-response-format",
+        "text_format": "plain",
+    }
+
+    openai_args = OpenAiArgsExtractor(
+        metadata=metadata,
+        model="gpt-4.1",
+        input="Hello!",
+        store=True,
+    ).get_openai_args()
+
+    assert openai_args["metadata"] == metadata
+    assert openai_args["metadata"] is not metadata
+
+
+def test_store_does_not_forward_instrumentation_structured_output_metadata():
+    class ResponseFormat(BaseModel):
+        name: str
+
+    extractor = OpenAiArgsExtractor(
+        metadata={"purpose": "distillation"},
+        model="gpt-4.1",
+        input="Hello!",
+        store=True,
+        text_format=ResponseFormat,
+    )
+
+    langfuse_args = extractor.get_langfuse_args()
+    openai_args = extractor.get_openai_args()
+
+    assert "text_format" in langfuse_args["metadata"]
+    assert openai_args["metadata"] == {"purpose": "distillation"}


### PR DESCRIPTION
## What

Fixes the Python OpenAI integration for the clustered Responses API and streamed tool-call issues:

- include Responses API tool fields (`tools`, `tool_choice`, `parallel_tool_calls`) in the traced generation input
- include `text_format` / `response_format` schema metadata for structured OpenAI calls
- serialize OpenAI SDK Responses output wrapper objects into plain data before writing generation output
- reconstruct streamed Chat Completions tool calls with `id`, `type`, function name/arguments, and retain tool calls even when content chunks arrive first

## Why

The Responses API path only traced `input` and `instructions`, so available tools and structured output format were invisible in Langfuse. Separately, streamed Chat Completions could drop tool calls when content arrived first, and streamed tool-call output missed `id` / `type`, which prevented UI matching against available tools.

Relevant Linear/GitHub cluster: LFE-9895, LFE-7512, LFE-7245, LFE-10331, LFE-8780, LFE-8781.

## Verification

- `uv run --frozen pytest tests/unit/test_openai_prompt_extraction.py tests/unit/test_openai.py`
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check langfuse/openai.py tests/unit/test_openai.py tests/unit/test_openai_prompt_extraction.py`
- `uv run --frozen mypy langfuse --no-error-summary`

Note: full `uv run --frozen ruff format --check .` currently reports unrelated pre-existing formatting in `tests/unit/test_experiment.py`, so I kept formatting verification scoped to the touched files.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two classes of bugs in the Python OpenAI integration: (1) the Responses API path was omitting `tools`, `tool_choice`, `parallel_tool_calls`, and structured-output format fields from the traced generation, and (2) streamed Chat Completions were silently dropping tool calls when a content chunk arrived first, and the accumulated tool-call objects were missing the `id` and `type` fields required by the Langfuse UI.

- A new `_serialize_openai_value` helper recursively unwraps OpenAI SDK Pydantic wrapper objects into plain JSON-safe dicts, replacing ad-hoc `model_json_schema()` calls scattered across the codebase.
- `_extract_streamed_openai_response` replaces the `elif` chain with independent `if` blocks so that a delta containing both `content` and `tool_calls` is fully processed, and uses index-based slot allocation to reconstruct multi-tool streams with complete `id`/`type`/`function` structure.
- `_extract_responses_prompt` is extended to embed `tools`/`tool_choice`/`parallel_tool_calls` in the Langfuse input, and `_get_structured_output_metadata` generalises the existing `response_format` metadata capture to also include `text_format`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core streaming and serialisation logic is correct and well-covered by the new unit tests.

The index-based tool-call accumulation and the elif→if conversion are logically sound and directly verified by the new test fixture. The two minor concerns are in non-critical fallback/helper paths: _serialize_openai_value's bare except Exception can silently return non-JSON-serialisable Python objects on the second model_dump attempt, and _get_structured_output_metadata uses model_dump() without mode='json' for caller-supplied metadata BaseModels, leaving the same exposure for datetime/UUID fields. Both are low-probability edge cases but worth hardening before they surface in production traces.

langfuse/openai.py around _serialize_openai_value (lines 215–220) and _get_structured_output_metadata (lines 247–248).
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant OpenAI as OpenAI SDK
    participant Wrapper as langfuse wrapper
    participant Extract as _extract_streamed_openai_response
    participant Helper as _serialize_openai_value

    OpenAI->>Wrapper: stream chunks (content + tool_calls possible in same delta)
    Wrapper->>Extract: chunks

    loop per chunk
        Extract->>Extract: process content (if present)
        Extract->>Extract: process function_call (if present)
        Extract->>Extract: process tool_calls by index (if present)
        Note over Extract: All three now run as independent if-blocks, not elif-chain
    end

    Extract->>Extract: "get_response_for_chat() priority: tool_calls > function_call > content"
    Extract-->>Wrapper: (model, completion, usage, metadata)

    Wrapper->>Helper: _extract_response_api_completion(output)
    Helper->>Helper: _serialize_openai_value(output) unwraps Pydantic BaseModel objects
    Helper-->>Wrapper: plain dict/list

    Wrapper->>Wrapper: _get_structured_output_metadata() captures response_format / text_format in metadata
    Wrapper->>Wrapper: _extract_responses_prompt() adds tools/tool_choice/parallel_tool_calls to input
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant OpenAI as OpenAI SDK
    participant Wrapper as langfuse wrapper
    participant Extract as _extract_streamed_openai_response
    participant Helper as _serialize_openai_value

    OpenAI->>Wrapper: stream chunks (content + tool_calls possible in same delta)
    Wrapper->>Extract: chunks

    loop per chunk
        Extract->>Extract: process content (if present)
        Extract->>Extract: process function_call (if present)
        Extract->>Extract: process tool_calls by index (if present)
        Note over Extract: All three now run as independent if-blocks, not elif-chain
    end

    Extract->>Extract: "get_response_for_chat() priority: tool_calls > function_call > content"
    Extract-->>Wrapper: (model, completion, usage, metadata)

    Wrapper->>Helper: _extract_response_api_completion(output)
    Helper->>Helper: _serialize_openai_value(output) unwraps Pydantic BaseModel objects
    Helper-->>Wrapper: plain dict/list

    Wrapper->>Wrapper: _get_structured_output_metadata() captures response_format / text_format in metadata
    Wrapper->>Wrapper: _extract_responses_prompt() adds tools/tool_choice/parallel_tool_calls to input
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
langfuse/openai.py:219-220
**Fallback `model_dump` may return non-serialisable values**

When `model_dump(mode="json", warnings=False)` raises, the bare `except Exception` silently retries with `model_dump(warnings=False)` (no `mode="json"`). That second call can return raw Python objects — `datetime`, `UUID`, `Decimal`, etc. — which then pass through `_serialize_openai_value` unchanged (they are not `NotGiven`, `BaseModel`, `dict`, or `list`) and land in the trace payload. Any downstream JSON serialiser will fail on those values, and the silent catch makes the failure hard to diagnose.

### Issue 2 of 2
langfuse/openai.py:247-248
**`model_dump()` without `mode="json"` may embed non-serialisable objects in metadata**

When the caller passes a Pydantic `BaseModel` as `metadata`, the conversion `metadata.model_dump()` is done without `mode="json"`. This differs from `_serialize_openai_value`'s own Pydantic handling (which uses `mode="json"` as the primary path), so `datetime`, `Enum`, and similar field types could appear as raw Python objects in the merged metadata dict that Langfuse eventually serialises.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(openai): preserve Responses tools an..."](https://github.com/langfuse/langfuse-python/commit/8681e83b11e22fcd4f1e603c6cc4110bd16a1a06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37920937)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->