### PR TITLE
fix(langchain): mark handled tool errors as errors

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -1091,7 +1091,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
 
     def on_tool_end(
         self,
-        output: str,
+        output: Any,
         *,
         run_id: UUID,
         parent_run_id: Optional[UUID] = None,
@@ -1105,10 +1105,24 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
             if observation is not None:
                 if parent_run_id is None:
                     self._clear_root_run_resume_key(run_id)
-                observation.update(
-                    output=output,
-                    input=kwargs.get("inputs"),
-                ).end()
+
+                update_kwargs: Dict[str, Any] = {
+                    "output": output,
+                    "input": kwargs.get("inputs"),
+                }
+
+                if (
+                    isinstance(output, ToolMessage)
+                    and getattr(output, "status", None) == "error"
+                ):
+                    update_kwargs["level"] = "ERROR"
+                    update_kwargs["status_message"] = (
+                        output.content
+                        if isinstance(output.content, str)
+                        else str(output.content)
+                    )
+
+                observation.update(**update_kwargs).end()
 
         except Exception as e:
             langfuse_logger.exception(e)

--- a/tests/unit/test_langchain.py
+++ b/tests/unit/test_langchain.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import pytest
 from langchain.messages import HumanMessage
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, ToolMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.outputs import ChatGeneration, ChatResult, Generation, LLMResult
 from langchain_core.prompts import ChatPromptTemplate
@@ -789,6 +789,39 @@ def test_root_tool_and_retriever_runs_seed_resume_keys_and_cleanup(
     assert _has_pending_resume_context(handler, "retriever-thread")
     assert _get_root_resume_key(handler, retriever_run_id) is None
     assert not _has_run_state(handler, retriever_run_id)
+
+
+def test_handled_tool_error_marks_observation_error(
+    langfuse_memory_client, get_span, json_attr
+):
+    handler = CallbackHandler()
+    run_id = uuid4()
+
+    handler.on_tool_start(
+        {"name": "failing_tool"},
+        '{"query": "x"}',
+        run_id=run_id,
+    )
+    handler.on_tool_end(
+        ToolMessage(
+            content="handled failure",
+            tool_call_id="call_1",
+            status="error",
+        ),
+        run_id=run_id,
+    )
+
+    langfuse_memory_client.flush()
+    span = get_span("failing_tool")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_LEVEL] == "ERROR"
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]
+        == "handled failure"
+    )
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT)["status"] == (
+        "error"
+    )
 
 
 def test_pending_resume_contexts_are_capped(langfuse_memory_client, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes handled LangChain tool errors being recorded as successful tool observations.

When a LangChain tool is configured with `handle_tool_error=True`, LangChain can call `on_tool_end` instead of `on_tool_error`, while still passing a `ToolMessage` with `status="error"`. The callback handler previously ended the observation without checking that status, so Langfuse did not mark the observation as an error.

This updates `on_tool_end` to inspect `ToolMessage.status` and set the observation level to `ERROR` when the message status is `"error"`. It also stores the handled error content as the observation status message.

Fixes langfuse/langfuse#12867

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash
uv run --frozen pytest tests/unit/test_langchain.py::test_handled_tool_error_marks_observation_error
uv run --frozen pytest tests/unit/test_langchain.py
uv run --frozen ruff check .
uv run --frozen mypy langfuse --no-error-summary
uv run --frozen pytest -n auto --dist worksteal tests/unit
```

I also reproduced the issue locally before the fix. Before this change, a handled tool error with `ToolMessage(status="error")` had no observation level or status message. After the change, the same path records `level=ERROR` and `status_message` from the handled tool error content.

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs, examples, or `.env.template` if needed — N/A, this is covered by the LangChain callback unit test and does not change documented setup or examples.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where LangChain tool errors handled via `handle_tool_error=True` were silently recorded as successful observations. LangChain routes these through `on_tool_end` with a `ToolMessage(status="error")` rather than calling `on_tool_error`, so the previous code never set an error level.

- `on_tool_end` now widens its `output` parameter from `str` to `Any` and inspects the value: if it is a `ToolMessage` with `status="error"`, the observation is updated with `level="ERROR"` and `status_message` set from the message content.
- A focused unit test is added that drives `on_tool_start` → `on_tool_end(ToolMessage(status="error"))` and asserts the resulting span has the correct level, status message, and preserved output fields.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a small, well-targeted fix with a direct unit test. It does not alter any existing code paths — only the new ToolMessage branch is affected.

The fix is correct and the test covers the new path end-to-end. The only open question is whether cost_details should be zeroed in the new error branch to match on_tool_error behavior; if it should, users could see non-zero costs attributed to errored tool spans until that is addressed.

langfuse/langchain/CallbackHandler.py — specifically whether the new error branch in on_tool_end should zero out cost_details to match on_tool_error
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant LC as LangChain
    participant CB as CallbackHandler
    participant OB as LangfuseObservation

    Note over LC,OB: Normal tool success path
    LC->>CB: on_tool_start(tool_name, input)
    CB->>OB: create tool observation
    LC->>CB: on_tool_end(output: str)
    CB->>OB: "update(output=output).end()"

    Note over LC,OB: Handled tool error path (handle_tool_error=True) NEW
    LC->>CB: on_tool_start(tool_name, input)
    CB->>OB: create tool observation
    LC->>CB: "on_tool_end(ToolMessage(status=error, content=...))"
    CB->>CB: "check isinstance(output, ToolMessage) AND status==error"
    CB->>OB: "update(output=msg, level=ERROR, status_message=msg.content).end()"

    Note over LC,OB: Unhandled tool error path (pre-existing)
    LC->>CB: on_tool_start(tool_name, input)
    CB->>OB: create tool observation
    LC->>CB: on_tool_error(exception)
    CB->>OB: "update(level=..., status_message=...).end()"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant LC as LangChain
    participant CB as CallbackHandler
    participant OB as LangfuseObservation

    Note over LC,OB: Normal tool success path
    LC->>CB: on_tool_start(tool_name, input)
    CB->>OB: create tool observation
    LC->>CB: on_tool_end(output: str)
    CB->>OB: "update(output=output).end()"

    Note over LC,OB: Handled tool error path (handle_tool_error=True) NEW
    LC->>CB: on_tool_start(tool_name, input)
    CB->>OB: create tool observation
    LC->>CB: "on_tool_end(ToolMessage(status=error, content=...))"
    CB->>CB: "check isinstance(output, ToolMessage) AND status==error"
    CB->>OB: "update(output=msg, level=ERROR, status_message=msg.content).end()"

    Note over LC,OB: Unhandled tool error path (pre-existing)
    LC->>CB: on_tool_start(tool_name, input)
    CB->>OB: create tool observation
    LC->>CB: on_tool_error(exception)
    CB->>OB: "update(level=..., status_message=...).end()"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/langchain/CallbackHandler.py:1114-1123
The new error branch in `on_tool_end` doesn't set `cost_details={"total": 0}`, while the parallel `on_tool_error` handler does. Without this, any accumulated cost tracking may still be attributed even when the tool ended with a handled error. If the intent is that handled errors should behave consistently with unhandled ones in terms of cost reporting, `cost_details` should be zeroed here too.

```suggestion
                if (
                    isinstance(output, ToolMessage)
                    and getattr(output, "status", None) == "error"
                ):
                    update_kwargs["level"] = "ERROR"
                    update_kwargs["status_message"] = (
                        output.content
                        if isinstance(output.content, str)
                        else str(output.content)
                    )
                    update_kwargs["cost_details"] = {"total": 0}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): mark handled tool errors..."](https://github.com/langfuse/langfuse-python/commit/3d5b967acab1fe90f8dc049d874e6d7ee2f9e1ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38905303)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->