### PR TITLE
fix(tracing): apply environments to processor spans

### DIFF
--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -294,6 +294,7 @@ class LangfuseResourceManager:
                 span_exporter=span_exporter,
                 media_manager=self._media_manager,
                 mask_otel_spans=mask_otel_spans,
+                environment=environment,
             )
             tracer_provider.add_span_processor(langfuse_processor)
 

--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -14,7 +14,7 @@ Key features:
 import base64
 import os
 import threading
-from typing import Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, cast
 
 from opentelemetry import context as context_api
 from opentelemetry.context import Context
@@ -35,7 +35,7 @@ from langfuse._client.propagation import (
 )
 from langfuse._client.span_exporter import LangfuseTransformingSpanExporter
 from langfuse._client.span_filter import is_default_export_span, is_langfuse_span
-from langfuse._client.utils import span_formatter
+from langfuse._client.utils import get_string_span_attribute, span_formatter
 from langfuse._task_manager.media_manager import MediaManager
 from langfuse._version import __version__ as langfuse_version
 from langfuse.logger import langfuse_logger
@@ -74,8 +74,10 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         span_exporter: Optional[SpanExporter] = None,
         media_manager: Optional[MediaManager] = None,
         mask_otel_spans: Optional[MaskOtelSpansFunction] = None,
+        environment: Optional[str] = None,
     ):
         self.public_key = public_key
+        self._environment = environment
         self.blocked_instrumentation_scopes = (
             blocked_instrumentation_scopes
             if blocked_instrumentation_scopes is not None
@@ -143,6 +145,7 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
     def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         context = parent_context or context_api.get_current()
         propagated_attributes = _get_propagated_attributes_from_context(context)
+        self._apply_default_environment(span=span, attributes=propagated_attributes)
 
         if propagated_attributes:
             span.set_attributes(propagated_attributes)
@@ -161,6 +164,33 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
             )
 
         return super().on_start(span, parent_context)
+
+    def _apply_default_environment(
+        self, *, span: Span, attributes: Dict[str, Any]
+    ) -> None:
+        """Apply the processor environment to spans without an explicit environment.
+
+        Langfuse-created wrapper spans set ``langfuse.environment`` themselves, and
+        ``propagate_attributes(environment=...)`` adds it to the active context for
+        request-scoped overrides. Third-party OpenTelemetry spans only pass through
+        this processor, so they need the client-level environment applied here when
+        neither of those more specific sources is present.
+        """
+
+        if LangfuseOtelSpanAttributes.ENVIRONMENT in attributes:
+            return
+
+        environment = getattr(self, "_environment", None)
+        if environment is None:
+            return
+
+        if (
+            get_string_span_attribute(span, LangfuseOtelSpanAttributes.ENVIRONMENT)
+            is not None
+        ):
+            return
+
+        attributes[LangfuseOtelSpanAttributes.ENVIRONMENT] = environment
 
     def on_end(self, span: ReadableSpan) -> None:
         try:

--- a/tests/unit/test_span_processor.py
+++ b/tests/unit/test_span_processor.py
@@ -1,8 +1,11 @@
 from typing import Sequence
 
-from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
+from langfuse import propagate_attributes
+from langfuse._client.attributes import LangfuseOtelSpanAttributes
 from langfuse._client.environment_variables import (
     LANGFUSE_FLUSH_AT,
     LANGFUSE_FLUSH_INTERVAL,
@@ -16,6 +19,68 @@ class NoOpSpanExporter(SpanExporter):
 
     def shutdown(self) -> None:
         pass
+
+
+class InMemorySpanExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        self.spans.extend(spans)
+
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+
+def _export_third_party_span(
+    *,
+    processor_environment: str,
+    span_attributes: dict[str, str] | None = None,
+    resource_attributes: dict[str, str] | None = None,
+    propagated_environment: str | None = None,
+) -> ReadableSpan:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(
+        resource=Resource.create(
+            {"service.name": "test", **(resource_attributes or {})}
+        )
+    )
+    processor = LangfuseSpanProcessor(
+        public_key="pk-test",
+        secret_key="sk-test",
+        base_url="http://localhost:3000",
+        flush_at=10,
+        flush_interval=1,
+        span_exporter=exporter,
+        environment=processor_environment,
+        should_export_span=lambda span: True,
+    )
+    provider.add_span_processor(processor)
+
+    try:
+        tracer = provider.get_tracer("third-party.instrumentation", "1.0.0")
+
+        if propagated_environment is None:
+            with tracer.start_as_current_span(
+                "third-party-span", attributes=span_attributes
+            ):
+                pass
+        else:
+            with propagate_attributes(environment=propagated_environment):
+                with tracer.start_as_current_span(
+                    "third-party-span", attributes=span_attributes
+                ):
+                    pass
+
+        provider.force_flush()
+
+        assert len(exporter.spans) == 1
+
+        return exporter.spans[0]
+    finally:
+        provider.shutdown()
 
 
 def test_span_processor_uses_constructor_flush_settings_without_env(monkeypatch):
@@ -35,6 +100,33 @@ def test_span_processor_uses_constructor_flush_settings_without_env(monkeypatch)
         assert processor._batch_processor._schedule_delay_millis == 2500
     finally:
         processor.shutdown()
+
+
+def test_span_processor_applies_environment_to_third_party_spans():
+    span = _export_third_party_span(processor_environment="proxy-prod")
+
+    assert span.attributes is not None
+    assert span.attributes[LangfuseOtelSpanAttributes.ENVIRONMENT] == "proxy-prod"
+
+
+def test_span_processor_prefers_propagated_environment_for_third_party_spans():
+    span = _export_third_party_span(
+        processor_environment="proxy-prod",
+        propagated_environment="staging",
+    )
+
+    assert span.attributes is not None
+    assert span.attributes[LangfuseOtelSpanAttributes.ENVIRONMENT] == "staging"
+
+
+def test_span_processor_preserves_explicit_third_party_span_environment():
+    span = _export_third_party_span(
+        processor_environment="proxy-prod",
+        span_attributes={LangfuseOtelSpanAttributes.ENVIRONMENT: "span-env"},
+    )
+
+    assert span.attributes is not None
+    assert span.attributes[LangfuseOtelSpanAttributes.ENVIRONMENT] == "span-env"
 
 
 def test_span_processor_uses_env_flush_settings_when_constructor_omits_them(


### PR DESCRIPTION
## Summary
- pass the client environment into the Langfuse span processor
- apply that environment to third-party OpenTelemetry spans that do not already have a propagated or explicit `langfuse.environment`
- add processor tests for default, propagated, and explicit third-party span environments

## Verification
- `uv run --frozen pytest tests/unit/test_span_processor.py tests/unit/test_propagate_attributes.py::TestPropagateAttributesEnvironment`
- `uv run --frozen ruff format --check langfuse/_client/span_processor.py langfuse/_client/resource_manager.py tests/unit/test_span_processor.py`
- `uv run --frozen ruff check .`
- `uv run --frozen mypy langfuse --no-error-summary`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR passes the client-level `environment` string into `LangfuseSpanProcessor` and applies it as a default to third-party OpenTelemetry spans that do not already carry an explicit or propagated `langfuse.environment` attribute.

- **`span_processor.py`** — adds `environment: Optional[str]` to the constructor and a new `_apply_default_environment` helper that mutates the freshly-created `propagated_attributes` dict before it is applied to the span, respecting the priority order: explicit span attribute > baggage-propagated > processor default.
- **`resource_manager.py`** — threads the existing `environment` value through to the processor constructor with a single-line addition.
- **`test_span_processor.py`** — three new focused tests cover the default, propagated-override, and explicit-attribute cases using a minimal in-memory exporter harness.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is narrowly scoped to defaulting the environment on third-party spans, with no mutations to shared state or existing attribute-setting paths.

The implementation correctly handles all three environment-priority cases and the tests exercise each one. The only finding is a cosmetic getattr that could silently swallow a future typo in the attribute name instead of raising an error.

No files require special attention.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/_client/span_processor.py:183-185
`getattr(self, "_environment", None)` is unnecessary here — `_environment` is unconditionally assigned in `__init__`, so a missing attribute can only happen if something has gone very wrong. Using `self._environment` directly is clearer and would surface a real `AttributeError` rather than silently returning `None` if the attribute name were ever misspelled.

```suggestion
        environment = self._environment
        if environment is None:
            return
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tracing): apply environments to proc..."](https://github.com/langfuse/langfuse-python/commit/89f96b34ef69da566e6cd03b575f7b45f0f1c142) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39814329)</sub>

<!-- /greptile_comment -->