### PR TITLE
fix(langchain): extract model name for ChatHuggingFace

### DIFF
--- a/langfuse/langchain/utils.py
+++ b/langfuse/langchain/utils.py
@@ -97,6 +97,7 @@ def _extract_model_name(
         ("ChatCohere", "model", None),
         ("Cohere", "model", None),
         ("HuggingFaceHub", "model", None),
+        ("ChatHuggingFace", "model_id", None),
         ("ChatAnyscale", "model_name", None),
         ("TextGen", "model", "text-gen"),
         ("Ollama", "model", None),

--- a/tests/unit/test_langchain_utils.py
+++ b/tests/unit/test_langchain_utils.py
@@ -1,9 +1,13 @@
 """Unit tests for langfuse.langchain.utils model-name extraction."""
 
+import pytest
+
 from langfuse.langchain.utils import _extract_model_name
 
+_MODEL_ID = "Qwen/Qwen2.5-Coder-32B-Instruct"
 
-def _chat_huggingface_serialized(model_id: str) -> dict:
+
+def _chat_huggingface_serialized(inner_repr: str) -> dict:
     """Mirror ``langchain_core.load.dumpd(ChatHuggingFace(...))``.
 
     ChatHuggingFace is not LangChain-serializable, so it serializes to a
@@ -19,15 +23,22 @@ def _chat_huggingface_serialized(model_id: str) -> dict:
             "huggingface",
             "ChatHuggingFace",
         ],
-        "repr": (
-            f"ChatHuggingFace(llm=HuggingFaceEndpoint(repo_id='{model_id}', "
-            f"model='{model_id}', task='text-generation'), model_id='{model_id}')"
-        ),
+        "repr": f"ChatHuggingFace(llm={inner_repr}, model_id='{_MODEL_ID}')",
         "name": "ChatHuggingFace",
     }
 
 
-def test_extract_model_name_chat_huggingface():
-    serialized = _chat_huggingface_serialized("Qwen/Qwen2.5-Coder-32B-Instruct")
+@pytest.mark.parametrize(
+    "inner_repr",
+    [
+        f"HuggingFaceEndpoint(repo_id='{_MODEL_ID}', model='{_MODEL_ID}', task='text-generation')",
+        f"HuggingFaceHub(repo_id='{_MODEL_ID}')",
+        # HuggingFacePipeline exposes its own model_id, so the repr carries two
+        # model_id='...' occurrences; re.search picks the first (inner) one.
+        f"HuggingFacePipeline(model_id='{_MODEL_ID}')",
+    ],
+)
+def test_extract_model_name_chat_huggingface(inner_repr: str):
+    serialized = _chat_huggingface_serialized(inner_repr)
 
-    assert _extract_model_name(serialized) == "Qwen/Qwen2.5-Coder-32B-Instruct"
+    assert _extract_model_name(serialized) == _MODEL_ID

--- a/tests/unit/test_langchain_utils.py
+++ b/tests/unit/test_langchain_utils.py
@@ -1,0 +1,33 @@
+"""Unit tests for langfuse.langchain.utils model-name extraction."""
+
+from langfuse.langchain.utils import _extract_model_name
+
+
+def _chat_huggingface_serialized(model_id: str) -> dict:
+    """Mirror ``langchain_core.load.dumpd(ChatHuggingFace(...))``.
+
+    ChatHuggingFace is not LangChain-serializable, so it serializes to a
+    ``not_implemented`` stub with no ``kwargs``; the model id is only available
+    inside the ``repr`` string as ``model_id='...'``.
+    """
+    return {
+        "lc": 1,
+        "type": "not_implemented",
+        "id": [
+            "langchain_huggingface",
+            "chat_models",
+            "huggingface",
+            "ChatHuggingFace",
+        ],
+        "repr": (
+            f"ChatHuggingFace(llm=HuggingFaceEndpoint(repo_id='{model_id}', "
+            f"model='{model_id}', task='text-generation'), model_id='{model_id}')"
+        ),
+        "name": "ChatHuggingFace",
+    }
+
+
+def test_extract_model_name_chat_huggingface():
+    serialized = _chat_huggingface_serialized("Qwen/Qwen2.5-Coder-32B-Instruct")
+
+    assert _extract_model_name(serialized) == "Qwen/Qwen2.5-Coder-32B-Instruct"


### PR DESCRIPTION
## What does this PR do?

Fixes langfuse/langfuse#14103

When a generation runs through `ChatHuggingFace`, Langfuse recorded it without a model name and logged "Langfuse was not able to parse the LLM model". `ChatHuggingFace` is not LangChain-serializable, so it reaches the callback as a `not_implemented` stub with no `kwargs`; the model id is only present in the `repr` string as `model_id='...'`. `_extract_model_name` had no entry for it, so extraction fell through and returned `None`.

This adds a repr-pattern entry that reads `model_id`, matching how the other repr-only models (`HuggingFaceHub`, `Ollama`, etc.) are already handled. `ChatHuggingFace` exposes `model_id` regardless of the underlying backend (`HuggingFaceEndpoint`, `HuggingFaceHub`, or `HuggingFacePipeline`), so this covers those cases.

## Type of change

- [x] Bug fix

## Verification

I confirmed the model id is only available in the `repr` by dumping a real `ChatHuggingFace` via `langchain_core.load.dumpd`, then wrote a deterministic unit test using that serialized shape so it needs no live HuggingFace call. The test returns `None` before the change and the correct model id after.

```bash
uv run --frozen pytest tests/unit/test_langchain_utils.py
uv run --frozen ruff check langfuse/langchain/utils.py tests/unit/test_langchain_utils.py
uv run --frozen ruff format --check langfuse/langchain/utils.py tests/unit/test_langchain_utils.py
uv run --frozen mypy langfuse/langchain/utils.py --no-error-summary
```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `ChatHuggingFace` to the repr-based model-name extraction table so that Langfuse records a model name when LangChain callbacks arrive from `ChatHuggingFace`, which serialises as a `not_implemented` stub with the model id only available in the `repr` string.

- **`langfuse/langchain/utils.py`**: Inserts `(\"ChatHuggingFace\", \"model_id\", None)` into `models_by_pattern`, following the identical approach already used for `HuggingFaceHub`, `Ollama`, `DeepInfra`, and others that expose their model identifier only via `repr`.
- **`tests/unit/test_langchain_utils.py`**: Adds a new unit test file with a deterministic serialized stub matching the real `dumpd` shape of `ChatHuggingFace`, verifying the regex extracts the correct `model_id`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line addition to a lookup table with a corresponding unit test.

The change is minimal and self-contained: one new tuple in models_by_pattern using the same repr-regex mechanism already proven by multiple other entries. The unit test confirms the extraction works correctly for the primary backend shape. The only gap is that the HuggingFacePipeline-backend repr variant is not explicitly tested, but since both occurrences carry the same value in practice this is a test-coverage gap rather than a functional defect.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_extract_model_name called] --> B{Match by ID path\nmodels_by_id list}
    B -- match --> Z[Return model name]
    B -- no match --> C{AzureOpenAI\nspecial case?}
    C -- yes --> D[Extract from\ninvocation_params / kwargs]
    D --> Z
    C -- no --> E{Match by repr\nmodels_by_pattern list}
    E -- includes new ChatHuggingFace entry\nre.search model_id='.+' in repr --> F{repr contains\nmodel_id='...'?}
    F -- yes --> Z
    F -- no --> G[Return None default]
    E -- no match --> H{Catch-all path\nkwargs / serialized}
    H -- found --> Z
    H -- not found --> I[Return None]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[_extract_model_name called] --> B{Match by ID path\nmodels_by_id list}
    B -- match --> Z[Return model name]
    B -- no match --> C{AzureOpenAI\nspecial case?}
    C -- yes --> D[Extract from\ninvocation_params / kwargs]
    D --> Z
    C -- no --> E{Match by repr\nmodels_by_pattern list}
    E -- includes new ChatHuggingFace entry\nre.search model_id='.+' in repr --> F{repr contains\nmodel_id='...'?}
    F -- yes --> Z
    F -- no --> G[Return None default]
    E -- no match --> H{Catch-all path\nkwargs / serialized}
    H -- found --> Z
    H -- not found --> I[Return None]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/test_langchain_utils.py:29-32
**Test only covers HuggingFaceEndpoint backend shape**

The PR description correctly notes that `ChatHuggingFace` works with three backends — `HuggingFaceEndpoint`, `HuggingFaceHub`, and `HuggingFacePipeline`. `HuggingFacePipeline` itself has a `model_id` attribute in its own repr, so a wrapped repr could look like `ChatHuggingFace(llm=HuggingFacePipeline(model_id='...', ...), model_id='...')`. The regex uses `re.search` (first match), meaning it would pick up the inner `HuggingFacePipeline`'s `model_id` rather than `ChatHuggingFace`'s. In practice both should be the same value, but adding a parameterised test for each backend shape would guard against any future repr change where the two values might differ.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): extract model name for C..."](https://github.com/langfuse/langfuse-python/commit/de988287c9151d272a061aa7c7eeddd30e6c70ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40383804)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->