### PR TITLE
fix(score): raise ValueError when create_score receives None name or value

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -39,6 +39,7 @@ from opentelemetry.util._decorator import (
     _agnosticcontextmanager,
 )
 from packaging.version import Version
+from pydantic import ValidationError
 from typing_extensions import deprecated
 
 from langfuse._client.attributes import (
@@ -1987,6 +1988,8 @@ class Langfuse:
                     force_sample=force_sample,
                 )
 
+        except ValidationError as e:
+            raise ValueError(f"Invalid score parameters: {e}") from e
         except Exception as e:
             langfuse_logger.exception(
                 f"Error creating score: Failed to process score event for trace_id={trace_id}, name={name}. Error: {e}"

--- a/tests/unit/test_create_score_validation.py
+++ b/tests/unit/test_create_score_validation.py
@@ -1,0 +1,36 @@
+"""Unit tests for create_score input validation.
+
+Ensures that programmer errors (None name or value) raise ValueError
+at the call site rather than being silently swallowed.
+"""
+
+import pytest
+
+from langfuse import Langfuse
+from langfuse._client.resource_manager import LangfuseResourceManager
+
+
+@pytest.fixture(autouse=True)
+def _clear_singleton():
+    yield
+    with LangfuseResourceManager._lock:
+        LangfuseResourceManager._instances.clear()
+
+
+@pytest.fixture()
+def lf():
+    return Langfuse(
+        public_key="pk-lf-test",
+        secret_key="sk-lf-test",
+        host="http://localhost:19999",
+    )
+
+
+def test_create_score_raises_on_none_value(lf):
+    with pytest.raises(ValueError, match="Invalid score parameters"):
+        lf.create_score(name="accuracy", value=None, trace_id="fake-trace-id")
+
+
+def test_create_score_raises_on_none_name(lf):
+    with pytest.raises(ValueError, match="Invalid score parameters"):
+        lf.create_score(name=None, value=0.9, trace_id="fake-trace-id")


### PR DESCRIPTION
## What does this PR do?

Fixes langfuse/langfuse#14615

create_score() catches a pydantic ValidationError inside the broad except Exception block when name or value is None. The error gets logged at ERROR level but the function still returns None, so the caller has no way to tell the score wasn't created.

This catches ValidationError separately and re-raises it as ValueError so the failure is visible at the call site.

## Type of change

- [x] Bug fix

## Verification

List the main commands you ran:

```bash
uv run --frozen pytest tests/unit/test_create_score_validation.py -v
uv run --frozen ruff check langfuse/_client/client.py tests/unit/test_create_score_validation.py
uv run --frozen ruff format --check langfuse/_client/client.py tests/unit/test_create_score_validation.py
uv run --frozen mypy langfuse/_client/client.py --no-error-summary
uv run --frozen pytest -n auto --dist worksteal tests/unit
```

Full unit suite passes aside from 3 pre-existing failures unrelated to this change (Windows path separator issue in test_serializer.py::test_path, flaky atexit tests under parallel execution in test_prompt_atexit.py). Confirmed these fail identically on main before this change too.

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent failure in `create_score()` where passing `None` for `name` or `value` caused a pydantic `ValidationError` to be caught by the broad `except Exception` block, logged, and then swallowed — leaving the caller with no indication the score was never created. The fix intercepts `ValidationError` before the catch-all and re-raises it as `ValueError`.

- A new `except ValidationError` clause is added ahead of `except Exception` in `create_score`, converting the pydantic error into a caller-visible `ValueError`.
- Two unit tests verify that `None` name and `None` value each raise `ValueError` with the expected message.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core fix is correct and well-tested, with one minor behavioral gap when tracing is disabled.

The fix correctly intercepts pydantic ValidationError before the broad except Exception swallows it, and the import is properly placed at module scope. The one gap is that the early-return guard on _tracing_enabled means invalid inputs are not validated at all when tracing is off, so the same None call would raise in a production environment but silently succeed in a tracing-disabled test or staging environment.

The early-return at lines 1917–1918 of langfuse/_client/client.py is worth a second look — consider whether argument validation should be hoisted above it.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[create_score called] --> B{_tracing_enabled?}
    B -- No --> C[return None\nno validation]
    B -- Yes --> D[ScoreBody pydantic constructor]
    D -- ValidationError\ne.g. name=None --> E[NEW: except ValidationError]
    E --> F[raise ValueError\nInvalid score parameters]
    D -- success --> G[build event dict]
    G --> H[add_score_task]
    H -- Exception --> I[log error, swallow]
    H -- success --> J[score enqueued]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[create_score called] --> B{_tracing_enabled?}
    B -- No --> C[return None\nno validation]
    B -- Yes --> D[ScoreBody pydantic constructor]
    D -- ValidationError\ne.g. name=None --> E[NEW: except ValidationError]
    E --> F[raise ValueError\nInvalid score parameters]
    D -- success --> G[build event dict]
    G --> H[add_score_task]
    H -- Exception --> I[log error, swallow]
    H -- success --> J[score enqueued]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/_client/client.py:1917-1918
**Validation skipped when tracing is disabled**

When `_tracing_enabled` is `False`, the function returns on line 1918 before entering the `try` block, so `create_score(name=None, value=None)` silently returns `None` instead of raising `ValueError`. This means the same call raises in production (where tracing is on) but succeeds silently in environments where tracing has been disabled — making it easy to ship a bug without test coverage catching it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(score): raise ValueError when create..."](https://github.com/langfuse/langfuse-python/commit/999a53125a80b46fc7883e2d5c4d6fc17d6b91ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40757665)</sub>

<!-- /greptile_comment -->