### PR TITLE
fix(langchain): escape empty json braces in prompts

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -171,7 +171,7 @@ class BasePromptClient(ABC):
 
         A curly brace is considered “JSON-related” when, after skipping any
         immediate whitespace, the next non-whitespace character is a single
-        or double quote.
+        quote, double quote, or the matching closing brace of an empty object.
 
         Braces that are already doubled (e.g. {{variable}} placeholders) are
         left untouched.
@@ -206,7 +206,7 @@ class BasePromptClient(ABC):
                 while j < n and text[j].isspace():
                     j += 1
 
-                is_json = j < n and text[j] in {"'", '"'}
+                is_json = j < n and text[j] in {"'", '"', "}"}
                 out.append("{{" if is_json else "{")
                 stack.append(is_json)  # remember how this “{” was treated
                 i += 1

--- a/tests/unit/test_prompt_compilation.py
+++ b/tests/unit/test_prompt_compilation.py
@@ -449,6 +449,43 @@ Final note: Hello and Test input"""
 
         assert formatted_prompt == expected
 
+    def test_langchain_prompt_escapes_bare_empty_json_objects(self):
+        """Test that bare empty JSON objects remain literals in LangChain prompts."""
+        prompt_string = """Variable: {{test_var}}
+Empty object: {}
+Spaced empty object: { }
+Multiline empty object: {
+}
+LangChain variable: {langchain_var}"""
+
+        prompt = TextPromptClient(
+            Prompt_Text(
+                type="text",
+                name="bare_empty_json_test",
+                version=1,
+                config={},
+                tags=[],
+                labels=[],
+                prompt=prompt_string,
+            )
+        )
+
+        langchain_prompt_string = prompt.get_langchain_prompt()
+        langchain_prompt = PromptTemplate.from_template(langchain_prompt_string)
+        formatted_prompt = langchain_prompt.format(
+            test_var="value",
+            langchain_var="chain",
+        )
+
+        expected = """Variable: value
+Empty object: {}
+Spaced empty object: { }
+Multiline empty object: {
+}
+LangChain variable: chain"""
+
+        assert formatted_prompt == expected
+
     def test_edge_case_nested_quotes_in_json(self):
         """Test edge case with nested quotes and escaped characters in JSON."""
         prompt_string = """Message: {{message}}


### PR DESCRIPTION
## Summary
- Treat bare empty JSON object braces as literal braces when converting Langfuse prompts for LangChain.
- Add a regression test covering {}, { }, and multiline empty-object literals alongside normal LangChain variables.

Fixes langfuse/langfuse#14721

## Verification
- RED: UV_CACHE_DIR=.uv-cache uv run --frozen pytest tests/unit/test_prompt_compilation.py::TestLangchainPromptCompilation::test_langchain_prompt_escapes_bare_empty_json_objects -q (failed with LangChain formatting IndexError before the fix)
- UV_CACHE_DIR=.uv-cache uv run --frozen pytest tests/unit/test_prompt_compilation.py::TestLangchainPromptCompilation::test_langchain_prompt_escapes_bare_empty_json_objects -q
- UV_CACHE_DIR=.uv-cache uv run --frozen pytest tests/unit/test_prompt_compilation.py -q
- UV_CACHE_DIR=.uv-cache uv run --frozen ruff check .
- UV_CACHE_DIR=.uv-cache uv run --frozen ruff format --check langfuse/model.py tests/unit/test_prompt_compilation.py
- UV_CACHE_DIR=.uv-cache uv run --frozen mypy langfuse --no-error-summary
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash when Langfuse prompts containing bare empty JSON objects (`{}`, `{ }`, or `{\n}`) are converted for use with LangChain. Previously, an empty `{}` would reach LangChain as an unescaped single-brace pair, causing an `IndexError` during `.format()`.

- **Fix (`langfuse/model.py`)**: A one-character addition — `"}"` is added to the lookahead set that classifies an opening `{` as JSON-related, so empty objects are now doubled to `{{}}` before reaching LangChain's template formatter.
- **Regression test**: Covers the three empty-object forms (`{}`, `{ }`, `{\n}`) mixed with both Langfuse-style (`{{test_var}}`) and LangChain-style (`{langchain_var}`) variables in a single prompt.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal and targeted, and the added test directly reproduces the previously crashing scenario.

The logic change is a single-character addition to a lookahead character set inside a well-isolated static method. Adding `}` to the set that marks an opening brace as JSON-related correctly handles all three empty-object forms. Existing behaviour for non-empty JSON objects and LangChain variable placeholders is unaffected.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): escape empty json braces..."](https://github.com/langfuse/langfuse-python/commit/54cdaa61fd2e1d03be37ee3464a910d846c55a55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41435633)</sub>

<!-- /greptile_comment -->