### PR TITLE
fix(openai): handle null choices in default response extraction

### DIFF
--- a/langfuse/logger.py
+++ b/langfuse/logger.py
@@ -22,7 +22,10 @@ httpx_logger = logging.getLogger("httpx")
 httpx_logger.setLevel(logging.WARNING)
 
 # Add console handler if no handlers exist
-console_handler = logging.StreamHandler()
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-console_handler.setFormatter(formatter)
-httpx_logger.addHandler(console_handler)
+if not httpx_logger.handlers:
+    console_handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    console_handler.setFormatter(formatter)
+    httpx_logger.addHandler(console_handler)

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -898,7 +898,7 @@ def _get_langfuse_data_from_default_response(
     completion = None
 
     if resource.type == "completion":
-        choices = response.get("choices", [])
+        choices = response.get("choices") or []
         if len(choices) > 0:
             choice = choices[-1]
 
@@ -908,7 +908,7 @@ def _get_langfuse_data_from_default_response(
         completion = _extract_response_api_completion(response.get("output", {}))
 
     elif resource.type == "chat":
-        choices = response.get("choices", [])
+        choices = response.get("choices") or []
         if len(choices) > 0:
             # If multiple choices were generated, we'll show all of them in the UI as a list.
             if len(choices) > 1:

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,3 +1,5 @@
+import importlib
+import logging
 import os
 
 from langfuse import Langfuse
@@ -34,3 +36,18 @@ def test_debug_langfuse():
 
     # Reset
     langfuse_logger.setLevel("WARNING")
+
+
+def test_httpx_handler_not_duplicated_when_handler_exists():
+    import langfuse.logger as lf_logger
+
+    httpx_logger = logging.getLogger("httpx")
+    saved = httpx_logger.handlers[:]
+    httpx_logger.handlers = []
+    pre_existing = logging.NullHandler()
+    httpx_logger.addHandler(pre_existing)
+    try:
+        importlib.reload(lf_logger)
+        assert httpx_logger.handlers == [pre_existing]
+    finally:
+        httpx_logger.handlers = saved

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -1051,3 +1051,15 @@ def test_with_raw_response_streaming_passes_through_untraced(
         span.name != "OpenAI-generation"
         for span in memory_exporter.get_finished_spans()
     )
+
+
+def test_default_response_handles_null_choices():
+    for resource_type in ("chat", "completion"):
+        model, completion, usage = (
+            lf_openai_module._get_langfuse_data_from_default_response(
+                SimpleNamespace(type=resource_type, object="ChatCompletion"),
+                {"model": "gpt-4", "choices": None, "usage": None},
+            )
+        )
+        assert completion is None
+        assert model == "gpt-4"


### PR DESCRIPTION
An OpenAI-compatible provider can return a chat completion with `choices: null`. `response.get("choices", [])` returns `None` in that case — the default only applies to a missing key, not an explicit null — so the next `len(choices)` raises `TypeError: object of type 'NoneType' has no len()` and hides the provider's real response (issue #1741).

This falls back to `[]` when `choices` is null, in both the chat and completion paths. Also guards the httpx logger handler so it's only added when none exists, matching the comment's intent and avoiding duplicate log lines.

Added a unit test covering `choices: null` for both resource types (fails with the reported TypeError before the fix). Full `tests/unit/test_openai.py` + `test_logger.py` pass.

Fixes #1741

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `TypeError` that occurred when an OpenAI-compatible provider returned `choices: null` in the response body — `dict.get("choices", [])` does not substitute the default for an explicit `null`, so `len(None)` raised. It also guards the `httpx` logger handler setup to avoid duplicates on module reload.

- `langfuse/openai.py`: Changes `response.get("choices", [])` to `response.get("choices") or []` in both the `completion` and `chat` branches of `_get_langfuse_data_from_default_response`, correctly handling an explicit `null` value.
- `langfuse/logger.py`: Wraps the `httpx` console handler creation in `if not httpx_logger.handlers:`, matching the comment's intent and preventing duplicate log lines.
- `tests/unit/test_openai.py` / `test_logger.py`: Adds targeted unit tests for both fixes, including a regression test that would reproduce the reported `TypeError` before the change.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core fix is correct and well-targeted; a single style nit in the test file is the only thing holding this back from a clean merge.

Both changes are narrow and correct. The `or []` idiom properly covers the null-choices case, the logger guard prevents handler duplication, and the new tests would reproduce the original crash before the fix. The only observation is an in-function import in `test_logger.py` that violates the project's import ordering rule; it does not affect test correctness but should be moved to the module level.

tests/unit/test_logger.py — the `import langfuse.logger as lf_logger` statement should move to the top of the module.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OpenAI-compatible provider response] --> B{response is None?}
    B -- yes --> C[Return NoneType message]
    B -- no --> D[Extract model]
    D --> E{resource.type?}
    E -- completion --> F["choices = response.get('choices') or []"]
    E -- chat --> G["choices = response.get('choices') or []"]
    E -- Responses/AsyncResponses --> H[Extract output]
    E -- embedding --> I[Extract data]
    F --> J{len choices > 0?}
    G --> K{len choices > 0?}
    J -- yes, was crashing on null --> L[Extract text]
    J -- no or null → [] --> M[completion = None]
    K -- yes, was crashing on null --> N[Extract messages]
    K -- no or null → [] --> O[completion = None]
    L --> P["Return (model, completion, usage)"]
    M --> P
    N --> P
    O --> P
    H --> P
    I --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OpenAI-compatible provider response] --> B{response is None?}
    B -- yes --> C[Return NoneType message]
    B -- no --> D[Extract model]
    D --> E{resource.type?}
    E -- completion --> F["choices = response.get('choices') or []"]
    E -- chat --> G["choices = response.get('choices') or []"]
    E -- Responses/AsyncResponses --> H[Extract output]
    E -- embedding --> I[Extract data]
    F --> J{len choices > 0?}
    G --> K{len choices > 0?}
    J -- yes, was crashing on null --> L[Extract text]
    J -- no or null → [] --> M[completion = None]
    K -- yes, was crashing on null --> N[Extract messages]
    K -- no or null → [] --> O[completion = None]
    L --> P["Return (model, completion, usage)"]
    M --> P
    N --> P
    O --> P
    H --> P
    I --> P
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/test_logger.py:41-44
The `import langfuse.logger as lf_logger` statement is placed inside the function body, which violates the project's rule requiring imports to live at the top of the module. Because the test's purpose is to call `importlib.reload`, this alias can be imported at module level and the reload can still be called on it — moving the import up doesn't change the test's correctness.

```suggestion
def test_httpx_handler_not_duplicated_when_handler_exists():
    httpx_logger = logging.getLogger("httpx")
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(openai): handle null choices in defa..."](https://github.com/langfuse/langfuse-python/commit/19cc85489e0846b0b25b34671059041fc8f52efb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42535737)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->