### PR TITLE
fix(langchain): propagate run name as trace name

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -594,7 +594,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
                     session_id=parsed_trace_attributes.get("session_id", None),
                     tags=parsed_trace_attributes.get("tags", None),
                     metadata=parsed_trace_attributes.get("metadata", None),
-                    trace_name=parsed_trace_attributes.get("trace_name", None),
+                    trace_name=parsed_trace_attributes.get("trace_name", span_name),
                 )
 
                 root_run_state = self._get_root_run_state(run_id)

--- a/tests/unit/test_langchain.py
+++ b/tests/unit/test_langchain.py
@@ -1,6 +1,6 @@
 import importlib
 from contextvars import copy_context
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -274,6 +274,27 @@ def test_root_chain_exports_when_end_runs_in_copied_context(
         )
     finally:
         otel_context.detach(context_token)
+
+
+def test_root_chain_propagates_run_name_as_default_trace_name():
+    handler = CallbackHandler()
+    run_id = uuid4()
+    propagation_context_manager = MagicMock()
+
+    with patch.object(
+        callback_handler_module,
+        "propagate_attributes",
+        return_value=propagation_context_manager,
+    ) as mock_propagate:
+        handler.on_chain_start(
+            {"id": ["langgraph", "Pregel"]},
+            {"messages": ["hello"]},
+            run_id=run_id,
+            name="my-agent",
+        )
+
+    mock_propagate.assert_called_once()
+    assert mock_propagate.call_args.kwargs["trace_name"] == "my-agent"
 
 
 def test_control_flow_errors_use_default_level_and_keep_status_message(


### PR DESCRIPTION
## Summary
- use the LangChain root run name as the default propagated trace name
- preserve explicit `langfuse_trace_name` metadata as the override when provided
- add a regression test for the default trace-name propagation path

Fixes #1602

## Tests
- PYTHONDONTWRITEBYTECODE=1 UV_CACHE_DIR=/private/tmp/uv-cache-langfuse-python uv run --frozen pytest tests/unit/test_langchain.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache-langfuse-python uv run --frozen ruff check langfuse/langchain/CallbackHandler.py tests/unit/test_langchain.py
- UV_CACHE_DIR=/private/tmp/uv-cache-langfuse-python uv run --frozen ruff format --check langfuse/langchain/CallbackHandler.py tests/unit/test_langchain.py
- PYTHONPYCACHEPREFIX=/private/tmp/langfuse-python-pycache python3 -m py_compile langfuse/langchain/CallbackHandler.py tests/unit/test_langchain.py
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes #1602 by propagating the LangChain root run name as the default trace name in Langfuse when no explicit `langfuse_trace_name` is provided in metadata.

- **One-line fix** in `on_chain_start`: `parsed_trace_attributes.get(\"trace_name\", None)` → `parsed_trace_attributes.get(\"trace_name\", span_name)`, so the LangChain run name flows through as the trace name unless a user-specified override exists.
- **New unit test** patches `propagate_attributes` and asserts that `trace_name` equals the `name` kwarg passed to `on_chain_start`, covering the primary regression path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The fix is minimal and correct — it threads the LangChain run name through to Langfuse when no explicit override is provided, and does not touch any other code paths.

The core change is a one-line default swap that works as described. The only wrinkle is that `get_langchain_run_name` can return `"<unknown>"` as a sentinel, and that sentinel will now be written into the OTel propagation context as an explicit trace name instead of being silently omitted. This is a narrow edge case (unnamed chains with no serialized id), but the behaviour change is observable in Langfuse traces.

langfuse/langchain/CallbackHandler.py — specifically the `"<unknown>"` sentinel path in `get_langchain_run_name`
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["on_chain_start called\n(parent_run_id is None)"] --> B["get_langchain_run_name()\n→ span_name"]
    B --> C["_parse_langfuse_trace_attributes(metadata, tags)\n→ parsed_trace_attributes"]
    C --> D{langfuse_trace_name\nin metadata?}
    D -- "Yes" --> E["trace_name = parsed_trace_attributes['trace_name']\n(explicit override)"]
    D -- "No (before PR)" --> F["trace_name = None\n(no name propagated)"]
    D -- "No (after PR)" --> G["trace_name = span_name\n(LangChain run name)"]
    G --> H{span_name resolved?}
    H -- "kwargs['name'] set" --> I["trace_name = kwargs['name']"]
    H -- "serialized['name'] set" --> J["trace_name = serialized['name']"]
    H -- "serialized['id'] set" --> K["trace_name = serialized['id'][-1]"]
    H -- "nothing set" --> L["trace_name = 'unknown'"]
    E --> M["propagate_attributes(trace_name=...)"]
    F --> N["propagate_attributes(trace_name=None)\n→ filtered out, no name set"]
    I --> M
    J --> M
    K --> M
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["on_chain_start called\n(parent_run_id is None)"] --> B["get_langchain_run_name()\n→ span_name"]
    B --> C["_parse_langfuse_trace_attributes(metadata, tags)\n→ parsed_trace_attributes"]
    C --> D{langfuse_trace_name\nin metadata?}
    D -- "Yes" --> E["trace_name = parsed_trace_attributes['trace_name']\n(explicit override)"]
    D -- "No (before PR)" --> F["trace_name = None\n(no name propagated)"]
    D -- "No (after PR)" --> G["trace_name = span_name\n(LangChain run name)"]
    G --> H{span_name resolved?}
    H -- "kwargs['name'] set" --> I["trace_name = kwargs['name']"]
    H -- "serialized['name'] set" --> J["trace_name = serialized['name']"]
    H -- "serialized['id'] set" --> K["trace_name = serialized['id'][-1]"]
    H -- "nothing set" --> L["trace_name = 'unknown'"]
    E --> M["propagate_attributes(trace_name=...)"]
    F --> N["propagate_attributes(trace_name=None)\n→ filtered out, no name set"]
    I --> M
    J --> M
    K --> M
    L --> M
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/langchain/CallbackHandler.py:597
When `serialized` carries no name information and the `name` kwarg is absent, `get_langchain_run_name` returns the sentinel string `"<unknown>"`. With this change, `"<unknown>"` will now be propagated as the explicit trace name (it is non-`None`, so `propagate_attributes` won't filter it out and will write it into the OTel context). Before this PR the `None` default caused the `trace_name` attribute to be omitted entirely. Consider guarding against the sentinel so the pre-existing "no-name" behaviour is preserved for that edge case.

```suggestion
                    trace_name=parsed_trace_attributes.get(
                        "trace_name",
                        span_name if span_name != "<unknown>" else None,
                    ),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix langchain trace name propagation"](https://github.com/langfuse/langfuse-python/commit/82edecced6b7a9ba37cf24ad93a76089bd63f09b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42591496)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->