### PR TITLE
fix(openai): handle null choices in chat completion responses

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -755,7 +755,7 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
         if chunk_usage is not None:
             usage = chunk_usage
 
-        choices = chunk.get("choices", [])
+        choices = chunk.get("choices") or []
 
         for choice in choices:
             if _is_openai_v1():
@@ -898,7 +898,7 @@ def _get_langfuse_data_from_default_response(
     completion = None
 
     if resource.type == "completion":
-        choices = response.get("choices", [])
+        choices = response.get("choices") or []
         if len(choices) > 0:
             choice = choices[-1]
 
@@ -908,7 +908,7 @@ def _get_langfuse_data_from_default_response(
         completion = _extract_response_api_completion(response.get("output", {}))
 
     elif resource.type == "chat":
-        choices = response.get("choices", [])
+        choices = response.get("choices") or []
         if len(choices) > 0:
             # If multiple choices were generated, we'll show all of them in the UI as a list.
             if len(choices) > 1:
@@ -927,7 +927,7 @@ def _get_langfuse_data_from_default_response(
                 )
 
     elif resource.type == "embedding":
-        data = response.get("data", [])
+        data = response.get("data") or []
         if len(data) > 0:
             first_embedding = data[0]
             embedding_vector = (

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -311,6 +311,69 @@ def test_chat_completion_exports_generation_span(
     }
 
 
+def test_chat_completion_with_none_choices_does_not_crash(
+    langfuse_memory_client, get_span, json_attr
+):
+    openai_client = lf_openai.OpenAI(api_key="test")
+    response = SimpleNamespace(
+        model="gpt-4o-mini",
+        choices=None,
+        usage=SimpleNamespace(prompt_tokens=3, completion_tokens=1, total_tokens=4),
+    )
+
+    with patch.object(openai_client.chat.completions, "_post", return_value=response):
+        result = openai_client.chat.completions.create(
+            name="unit-openai-chat-none-choices",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "1 + 1 = ?"}],
+        )
+
+    assert result is response
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-chat-none-choices")
+
+    assert LangfuseOtelSpanAttributes.OBSERVATION_LEVEL not in span.attributes
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL] == "gpt-4o-mini"
+    )
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS) == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
+    }
+
+
+def test_openai_stream_with_none_choices_chunk_does_not_crash(
+    langfuse_memory_client, get_span
+):
+    openai_client = lf_openai.OpenAI(api_key="test")
+    chunks_with_none_choices = [
+        SimpleNamespace(model="gpt-4o-mini", choices=None, usage=None),
+        *_make_chat_stream_chunks(),
+    ]
+    raw_stream = DummyOpenAIStream(chunks_with_none_choices, DummySyncResponse())
+
+    with patch.object(openai_client.chat.completions, "_post", return_value=raw_stream):
+        stream = openai_client.chat.completions.create(
+            name="unit-openai-stream-none-choices",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "1 + 1 = ?"}],
+            stream=True,
+        )
+
+    chunks = list(stream)
+    stream.close()
+
+    assert len(chunks) == 3
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-stream-none-choices")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] == "2"
+    assert span.attributes["langfuse.observation.metadata.finish_reason"] == "stop"
+
+
 def test_streaming_chat_completion_preserves_tool_calls_after_content():
     model, completion, usage, metadata = (
         lf_openai_module._extract_streamed_openai_response(


### PR DESCRIPTION
## Problem

[LFE-10734](https://linear.app/langfuse/issue/LFE-10734/openai-wrapper-crashes-when-chat-completion-response-has-choicesnull): the OpenAI wrapper crashes when a chat completion response contains `"choices": null`, which some OpenAI-compatible providers/gateways return. The OpenAI v1 SDK constructs response models leniently, so the `None` reaches `_get_langfuse_data_from_default_response`, where `len(choices)` raises:

```
TypeError: object of type 'NoneType' has no len()
```

The exception is re-raised by the wrapper's error handler, so the user's `create()` call fails even though the underlying API request succeeded.

## Root cause

`response.get("choices", [])` only falls back to the default when the key is *missing* — an explicit `null` value returns `None` as-is.

## Fix

Use `response.get("choices") or []` in:
- the non-streaming chat path (`len(choices)` crash from the issue)
- the non-streaming legacy completion path (same pattern)
- the streaming chunk path (`for choice in choices` would crash the same way)
- the embedding `data` extraction (identical latent bug)

## Tests

- Added a regression test for a non-streaming chat completion with `choices=None`: the call succeeds, the response is returned unchanged, and the generation span is exported with model and usage (no ERROR level).
- Added a regression test for a stream containing a `choices=None` chunk: iteration completes and the span still captures the output and finish reason from subsequent chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `TypeError` crash in the OpenAI wrapper when an API response contains an explicit `"choices": null` (or `"data": null`), as returned by some OpenAI-compatible gateways. The root cause was `dict.get("key", [])` returning `None` when the key is present but explicitly `null`, while `dict.get("key") or []` correctly falls back to an empty list in that case.

- Four call sites in `langfuse/openai.py` are updated: the streaming chunk path, the legacy completion path, the chat completion path, and the embedding data extraction path.
- Two regression tests are added — one for a non-streaming chat response with `choices=None`, and one for a stream containing a `choices=None` chunk — verifying that neither the call nor span export fails.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, targeted change that fixes a real crash without altering any happy-path behavior.

The four changed lines are strictly additive guard rails; `[] or []` and `some_list or []` both produce the same result as before, so existing callers are unaffected. The regression tests exercise both the streaming and non-streaming code paths that previously crashed. No other code paths appear to share this null-dereference pattern.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant LangfuseWrapper as Langfuse OpenAI Wrapper
    participant OpenAI as OpenAI-Compatible API

    Client->>LangfuseWrapper: chat.completions.create(...)
    LangfuseWrapper->>OpenAI: HTTP POST /v1/chat/completions
    OpenAI-->>LangfuseWrapper: "{"choices": null, "usage": {...}}"

    alt Before fix
        LangfuseWrapper->>LangfuseWrapper: "choices = response.get("choices", []) → None"
        LangfuseWrapper->>LangfuseWrapper: len(None) → TypeError raised
        LangfuseWrapper-->>Client: Exception (call fails)
    else After fix
        LangfuseWrapper->>LangfuseWrapper: "choices = response.get("choices") or [] → []"
        LangfuseWrapper->>LangfuseWrapper: "len([]) == 0, skip extraction"
        LangfuseWrapper->>LangfuseWrapper: Export span with model + usage only
        LangfuseWrapper-->>Client: response (unchanged)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant LangfuseWrapper as Langfuse OpenAI Wrapper
    participant OpenAI as OpenAI-Compatible API

    Client->>LangfuseWrapper: chat.completions.create(...)
    LangfuseWrapper->>OpenAI: HTTP POST /v1/chat/completions
    OpenAI-->>LangfuseWrapper: "{"choices": null, "usage": {...}}"

    alt Before fix
        LangfuseWrapper->>LangfuseWrapper: "choices = response.get("choices", []) → None"
        LangfuseWrapper->>LangfuseWrapper: len(None) → TypeError raised
        LangfuseWrapper-->>Client: Exception (call fails)
    else After fix
        LangfuseWrapper->>LangfuseWrapper: "choices = response.get("choices") or [] → []"
        LangfuseWrapper->>LangfuseWrapper: "len([]) == 0, skip extraction"
        LangfuseWrapper->>LangfuseWrapper: Export span with model + usage only
        LangfuseWrapper-->>Client: response (unchanged)
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(openai): handle null choices in chat..."](https://github.com/langfuse/langfuse-python/commit/f601727b0e0a39ee452c04c8e345ba6e3ba4c2ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42735515)</sub>

<!-- /greptile_comment -->