### PR TITLE
fix(langchain): handle Anthropic cache_creation nested dict in usage

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -1685,6 +1685,28 @@ def _parse_usage_model(usage: Union[pydantic.BaseModel, dict]) -> Any:
                             0, usage_model[f"input_modality_{item['modality']}"] - value
                         )
 
+        # Anthropic extended prompt caching — cache_creation is a nested dict
+        # keyed by cache tier, e.g. {"ephemeral_5m_input_tokens": 2048, "ephemeral_1h_input_tokens": 0}
+        if "cache_creation" in usage_model and isinstance(
+            usage_model["cache_creation"], dict
+        ):
+            cache_creation = usage_model.pop("cache_creation")
+            total_cache_creation_tokens = 0
+
+            for key, value in cache_creation.items():
+                if not isinstance(value, int):
+                    continue
+
+                usage_model[f"cache_creation_{key}"] = value
+                total_cache_creation_tokens += value
+
+            # Aggregate mirrors Anthropic's legacy cache_creation_input_tokens field;
+            # keep the API-provided value if it is already present
+            if total_cache_creation_tokens > 0:
+                usage_model.setdefault(
+                    "cache_creation_input_tokens", total_cache_creation_tokens
+                )
+
     usage_model = {k: v for k, v in usage_model.items() if isinstance(v, int)}
 
     return usage_model if usage_model else None

--- a/tests/unit/test_parse_usage_model.py
+++ b/tests/unit/test_parse_usage_model.py
@@ -78,6 +78,60 @@ def test_prompt_tokens_details_dict_empty():
     assert result["output"] == 100
 
 
+def test_anthropic_cache_creation_nested_dict():
+    """Anthropic extended prompt caching: cache_creation nested dict is flattened."""
+    usage = {
+        "input_tokens": 9454,
+        "output_tokens": 380,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 2048,
+        },
+    }
+    result = _parse_usage_model(usage)
+    assert result["input"] == 9454
+    assert result["output"] == 380
+    assert result["cache_creation_ephemeral_1h_input_tokens"] == 0
+    assert result["cache_creation_ephemeral_5m_input_tokens"] == 2048
+    assert result["cache_creation_input_tokens"] == 2048
+    # No nested dict may survive into the final usage model
+    assert all(isinstance(v, int) for v in result.values())
+
+
+def test_anthropic_cache_creation_keeps_existing_aggregate():
+    """API-provided cache_creation_input_tokens is not overwritten by the computed sum."""
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "cache_creation_input_tokens": 3000,
+        "cache_creation": {
+            "ephemeral_1h_input_tokens": 1000,
+            "ephemeral_5m_input_tokens": 2000,
+        },
+    }
+    result = _parse_usage_model(usage)
+    assert result["cache_creation_input_tokens"] == 3000
+    assert result["cache_creation_ephemeral_1h_input_tokens"] == 1000
+    assert result["cache_creation_ephemeral_5m_input_tokens"] == 2000
+
+
+def test_anthropic_cache_creation_all_zero():
+    """All-zero cache_creation tiers: flattened keys kept, no aggregate invented."""
+    usage = {
+        "input_tokens": 50,
+        "output_tokens": 5,
+        "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0,
+        },
+    }
+    result = _parse_usage_model(usage)
+    assert result["cache_creation_ephemeral_1h_input_tokens"] == 0
+    assert result["cache_creation_ephemeral_5m_input_tokens"] == 0
+    assert "cache_creation_input_tokens" not in result
+
+
 def test_priority_tier_not_subtracted():
     """Priority tier: 'priority' and 'priority_*' keys must NOT be subtracted."""
     usage = {


### PR DESCRIPTION
## Summary

Anthropic's extended prompt caching returns a nested `cache_creation` dict in the usage payload:

```python
{
    "input_tokens": 9454,
    "output_tokens": 380,
    "cache_read_input_tokens": 0,
    "cache_creation": {
        "ephemeral_1h_input_tokens": 0,
        "ephemeral_5m_input_tokens": 2048,
    },
}
```

`_parse_usage_model` in the LangChain callback handler ended with a `isinstance(v, int)` filter that silently discarded the nested dict, so cache-creation token counts were lost entirely (on v2.x this same payload caused a Pydantic `ValidationError` that dropped the whole generation `end()` event — see #1697).

## Fix

Before the final int filter, flatten the nested dict into per-tier keys (`cache_creation_ephemeral_5m_input_tokens`, `cache_creation_ephemeral_1h_input_tokens`) and set an aggregated `cache_creation_input_tokens` total via `setdefault`, so an API-provided aggregate is never overwritten.

Parsed result for the payload above:

```python
{
    "cache_read_input_tokens": 0,
    "input": 9454,
    "output": 380,
    "cache_creation_ephemeral_1h_input_tokens": 0,
    "cache_creation_ephemeral_5m_input_tokens": 2048,
    "cache_creation_input_tokens": 2048,
}
```

## Tests

- `test_anthropic_cache_creation_nested_dict` — reproduces the reported payload, asserts flattened tiers + aggregate and that no non-int value survives
- `test_anthropic_cache_creation_keeps_existing_aggregate` — API-provided `cache_creation_input_tokens` wins over the computed sum
- `test_anthropic_cache_creation_all_zero` — zero tiers are kept, no aggregate is invented
- `uv run pytest tests/unit/test_parse_usage_model.py` → 9 passed; ruff + mypy clean

Fixes #1697
Fixes LFE-10230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes silent loss of Anthropic extended prompt-caching token counts in the LangChain callback handler. When `cache_creation` is a nested dict (new API format), the existing `isinstance(v, int)` final filter was silently discarding it; on pydantic v2 it went further and raised a `ValidationError` that dropped the entire `end()` event.

- Adds a flattening step in `_parse_usage_model` that pops the `cache_creation` dict, creates per-tier flattened keys (e.g. `cache_creation_ephemeral_5m_input_tokens`), and computes an aggregate `cache_creation_input_tokens` via `setdefault` so an API-provided value is never overwritten.
- Adds three unit tests covering the standard case, the pre-existing aggregate case, and the all-zero tiers case.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrowly scoped to flattening a previously-discarded nested dict; all existing code paths are unaffected and the only observable change is that Anthropic extended-caching token counts now appear in the usage model instead of being silently dropped.

The flattening logic is correct and the three new unit tests cover the main behavioural contracts. The one gap is that the per-tier key assignment unconditionally overwrites any pre-existing flat key of the same name, but this requires a payload structure that does not appear in any known Anthropic API response today.

No files require special attention; the two changed files are self-contained and the test coverage matches the documented fix.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
langfuse/langchain/CallbackHandler.py:1700-1701
**Flattened tier keys silently overwrite pre-existing flat keys**

If `usage_model` already contains a top-level `cache_creation_ephemeral_5m_input_tokens` key (e.g. from a future API response that sends both formats), `usage_model[f"cache_creation_{key}"] = value` will overwrite it without warning. The existing pattern for `prompt_tokens_details` and `input_token_details` has the same behaviour, so this is consistent, but it is worth noting if Anthropic ever starts sending mixed payloads. A `setdefault` here (mirroring the aggregate line below) would avoid the silent overwrite.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): handle Anthropic cache\_c..."](https://github.com/langfuse/langfuse-python/commit/782c0398e104e8f618bd1677c6d5099526a67bd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42971110)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->