### PR TITLE
feat(tracing): make span queue size configurable via max_queue_size

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -189,6 +189,7 @@ class Langfuse:
         tracing_enabled (Optional[bool]): Enable or disable tracing. Defaults to True. Can also be set via LANGFUSE_TRACING_ENABLED environment variable.
         flush_at (Optional[int]): Number of spans to batch before sending to the API. Defaults to 512. Can also be set via LANGFUSE_FLUSH_AT environment variable.
         flush_interval (Optional[float]): Time in seconds between batch flushes. Defaults to 5 seconds. Can also be set via LANGFUSE_FLUSH_INTERVAL environment variable.
+        max_queue_size (Optional[int]): Maximum number of spans buffered in memory before export. When the buffer fills (for example under high concurrency), additional spans are dropped, which can result in incomplete traces; increase this to reduce drops. Must be greater than or equal to flush_at. Defaults to 2048. Can also be set via LANGFUSE_MAX_QUEUE_SIZE environment variable.
         environment (Optional[str]): Environment name for tracing. Default is 'default'. Can also be set via LANGFUSE_TRACING_ENVIRONMENT environment variable. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
         release (Optional[str]): Release version/hash of your application. Used for grouping analytics by release.
         media_upload_thread_count (Optional[int]): Number of background threads for handling media uploads. Defaults to 1. Can also be set via LANGFUSE_MEDIA_UPLOAD_THREAD_COUNT environment variable.
@@ -299,6 +300,7 @@ class Langfuse:
         tracing_enabled: Optional[bool] = True,
         flush_at: Optional[int] = None,
         flush_interval: Optional[float] = None,
+        max_queue_size: Optional[int] = None,
         environment: Optional[str] = None,
         release: Optional[str] = None,
         media_upload_thread_count: Optional[int] = None,
@@ -398,6 +400,7 @@ class Langfuse:
             release=release,
             flush_at=flush_at,
             flush_interval=flush_interval,
+            max_queue_size=max_queue_size,
             httpx_client=httpx_client,
             media_upload_thread_count=media_upload_thread_count,
             sample_rate=sample_rate,

--- a/langfuse/_client/environment_variables.py
+++ b/langfuse/_client/environment_variables.py
@@ -105,6 +105,17 @@ Max delay in seconds until a new ingestion batch is sent to the API.
 **Default value:** same as OTEL ``OTEL_BSP_SCHEDULE_DELAY``
 """
 
+LANGFUSE_MAX_QUEUE_SIZE = "LANGFUSE_MAX_QUEUE_SIZE"
+"""
+.. envvar:: LANGFUSE_MAX_QUEUE_SIZE
+
+Max number of spans buffered in memory before the exporter flushes them. When the
+buffer is full (for example under high concurrency), additional spans are dropped,
+which can result in incomplete traces. Increase this to reduce drops. Must be
+greater than or equal to ``LANGFUSE_FLUSH_AT``.
+**Default value:** same as OTEL ``OTEL_BSP_MAX_QUEUE_SIZE`` (``2048``)
+"""
+
 LANGFUSE_SAMPLE_RATE = "LANGFUSE_SAMPLE_RATE"
 """
 .. envvar: LANGFUSE_SAMPLE_RATE

--- a/langfuse/_client/get_client.py
+++ b/langfuse/_client/get_client.py
@@ -46,6 +46,7 @@ def _create_client_from_instance(
         timeout=instance.timeout,
         flush_at=instance.flush_at,
         flush_interval=instance.flush_interval,
+        max_queue_size=instance.max_queue_size,
         release=instance.release,
         media_upload_thread_count=instance.media_upload_thread_count,
         sample_rate=instance.sample_rate,

--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -121,6 +121,7 @@ class LangfuseResourceManager:
         timeout: Optional[int] = None,
         flush_at: Optional[int] = None,
         flush_interval: Optional[float] = None,
+        max_queue_size: Optional[int] = None,
         httpx_client: Optional[httpx.Client] = None,
         media_upload_thread_count: Optional[int] = None,
         sample_rate: Optional[float] = None,
@@ -157,6 +158,7 @@ class LangfuseResourceManager:
                     release=release,
                     flush_at=flush_at,
                     flush_interval=flush_interval,
+                    max_queue_size=max_queue_size,
                     httpx_client=httpx_client,
                     media_upload_thread_count=media_upload_thread_count,
                     sample_rate=sample_rate,
@@ -188,6 +190,7 @@ class LangfuseResourceManager:
         timeout: Optional[int] = None,
         flush_at: Optional[int] = None,
         flush_interval: Optional[float] = None,
+        max_queue_size: Optional[int] = None,
         media_upload_thread_count: Optional[int] = None,
         httpx_client: Optional[httpx.Client] = None,
         sample_rate: Optional[float] = None,
@@ -214,6 +217,7 @@ class LangfuseResourceManager:
         self.timeout = timeout
         self.flush_at = flush_at
         self.flush_interval = flush_interval
+        self.max_queue_size = max_queue_size
         self.release = release
         self.media_upload_thread_count = media_upload_thread_count
         self.sample_rate = sample_rate
@@ -255,6 +259,7 @@ class LangfuseResourceManager:
                 timeout=timeout,
                 flush_at=flush_at,
                 flush_interval=flush_interval,
+                max_queue_size=max_queue_size,
                 blocked_instrumentation_scopes=blocked_instrumentation_scopes,
                 should_export_span=should_export_span,
                 additional_headers=additional_headers,

--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -27,6 +27,7 @@ from langfuse._client.attributes import LangfuseOtelSpanAttributes
 from langfuse._client.environment_variables import (
     LANGFUSE_FLUSH_AT,
     LANGFUSE_FLUSH_INTERVAL,
+    LANGFUSE_MAX_QUEUE_SIZE,
     LANGFUSE_OTEL_TRACES_EXPORT_PATH,
 )
 from langfuse._client.propagation import (
@@ -68,6 +69,7 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         timeout: Optional[int] = None,
         flush_at: Optional[int] = None,
         flush_interval: Optional[float] = None,
+        max_queue_size: Optional[int] = None,
         blocked_instrumentation_scopes: Optional[List[str]] = None,
         should_export_span: Optional[Callable[[ReadableSpan], bool]] = None,
         additional_headers: Optional[Dict[str, str]] = None,
@@ -93,6 +95,10 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         env_flush_interval = os.environ.get(LANGFUSE_FLUSH_INTERVAL, None)
         if flush_interval is None and env_flush_interval is not None:
             flush_interval = float(env_flush_interval)
+
+        env_max_queue_size = os.environ.get(LANGFUSE_MAX_QUEUE_SIZE, None)
+        if max_queue_size is None and env_max_queue_size is not None:
+            max_queue_size = int(env_max_queue_size)
 
         if span_exporter is None:
             basic_auth_header = "Basic " + base64.b64encode(
@@ -134,6 +140,7 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
         super().__init__(
             span_exporter=span_exporter,
             export_timeout_millis=timeout * 1_000 if timeout else None,
+            max_queue_size=max_queue_size,
             max_export_batch_size=flush_at,
             schedule_delay_millis=flush_interval * 1_000
             if flush_interval is not None

--- a/tests/unit/test_span_processor.py
+++ b/tests/unit/test_span_processor.py
@@ -6,6 +6,7 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from langfuse._client.environment_variables import (
     LANGFUSE_FLUSH_AT,
     LANGFUSE_FLUSH_INTERVAL,
+    LANGFUSE_MAX_QUEUE_SIZE,
 )
 from langfuse._client.span_processor import LangfuseSpanProcessor
 
@@ -52,5 +53,55 @@ def test_span_processor_uses_env_flush_settings_when_constructor_omits_them(
     try:
         assert processor._batch_processor._max_export_batch_size == 19
         assert processor._batch_processor._schedule_delay_millis == 3250
+    finally:
+        processor.shutdown()
+
+
+def test_span_processor_uses_constructor_max_queue_size_without_env(monkeypatch):
+    monkeypatch.delenv(LANGFUSE_MAX_QUEUE_SIZE, raising=False)
+    processor = LangfuseSpanProcessor(
+        public_key="pk-test",
+        secret_key="sk-test",
+        base_url="http://localhost:3000",
+        max_queue_size=5000,
+        span_exporter=NoOpSpanExporter(),
+    )
+
+    try:
+        assert processor._batch_processor._max_queue_size == 5000
+    finally:
+        processor.shutdown()
+
+
+def test_span_processor_uses_env_max_queue_size_when_constructor_omits_it(monkeypatch):
+    monkeypatch.setenv(LANGFUSE_MAX_QUEUE_SIZE, "4096")
+    processor = LangfuseSpanProcessor(
+        public_key="pk-test",
+        secret_key="sk-test",
+        base_url="http://localhost:3000",
+        span_exporter=NoOpSpanExporter(),
+    )
+
+    try:
+        assert processor._batch_processor._max_queue_size == 4096
+    finally:
+        processor.shutdown()
+
+
+def test_span_processor_defaults_to_otel_max_queue_size(monkeypatch):
+    # When neither the constructor arg nor the Langfuse env var is set, the queue
+    # size falls back to OpenTelemetry's default (OTEL_BSP_MAX_QUEUE_SIZE, 2048),
+    # keeping behavior unchanged for existing users.
+    monkeypatch.delenv(LANGFUSE_MAX_QUEUE_SIZE, raising=False)
+    monkeypatch.delenv("OTEL_BSP_MAX_QUEUE_SIZE", raising=False)
+    processor = LangfuseSpanProcessor(
+        public_key="pk-test",
+        secret_key="sk-test",
+        base_url="http://localhost:3000",
+        span_exporter=NoOpSpanExporter(),
+    )
+
+    try:
+        assert processor._batch_processor._max_queue_size == 2048
     finally:
         processor.shutdown()


### PR DESCRIPTION
## What does this PR do?

Refs langfuse/langfuse#12974

Under high concurrency the OpenTelemetry `BatchSpanProcessor` drops spans once its in-memory queue fills up. When the dropped span happens to be a parent, the trace ends up broken/incomplete — which is what #12974 describes ("the SDK's flush queue gets overwhelmed … some spans don't get flushed before the trace completes").

`flush_at` and `flush_interval` are already exposed as first-class Langfuse settings, but `max_queue_size` — the knob that actually governs how many spans can be buffered before drops start — wasn't. That left the queue pinned to OTEL's default of 2048 with no Langfuse-native way to raise it (you'd have to know about the underlying `OTEL_BSP_MAX_QUEUE_SIZE` env var).

This adds a `max_queue_size` client argument and a matching `LANGFUSE_MAX_QUEUE_SIZE` env var, threaded through the resource manager and span processor exactly like the existing flush settings. It defaults to `None`, so behavior is unchanged for existing users (OTEL still falls back to `OTEL_BSP_MAX_QUEUE_SIZE` / 2048). Users hitting drops under load can now raise the buffer without reaching into OTEL internals.

Note: this doesn't eliminate the bounded-queue drop behavior itself — it gives users a documented, first-class way to size the buffer for their concurrency, consistent with how `flush_at`/`flush_interval` already work.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash
uv run --frozen pytest tests/unit/test_span_processor.py   # 5 passed (3 new: constructor arg, env var, unchanged 2048 default)
uv run --frozen pytest -n auto --dist worksteal tests/unit  # 636 passed (the test_prompt.py errors are pre-existing and credential-related; they reproduce on a clean tree)
uv run --frozen ruff check .                                # passed
uv run --frozen mypy langfuse --no-error-summary            # passed
```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs, examples, or `.env.template` if needed. (Added the client docstring + `LANGFUSE_MAX_QUEUE_SIZE` env-var reference; no `.env.template` change needed.)
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes `max_queue_size` as a first-class Langfuse setting (constructor argument + env var `LANGFUSE_MAX_QUEUE_SIZE`), giving users a documented way to raise the OTEL `BatchSpanProcessor` in-memory buffer beyond its 2 048-span default without reaching into OTEL internals. The change defaults to `None` so existing behavior is fully preserved.

- Threads `max_queue_size` consistently through `client.py` → `resource_manager.py` → `span_processor.py` → `BatchSpanProcessor.__init__`, mirroring the existing `flush_at`/`flush_interval` pattern.
- Adds three unit tests covering the constructor argument, env-var override, and OTEL fallback default; all pass cleanly.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all existing behavior is unchanged when max_queue_size is not set, and the new parameter is correctly propagated through every layer.

The change is mechanical and well-tested, following the existing flush_at/flush_interval pattern precisely. Two small gaps in span_processor.py mean a misconfigured value surfaces as a raw OTEL exception rather than a clear Langfuse message, but neither gap causes silent data loss.

langfuse/_client/span_processor.py — env-var parsing and the constraint check before the BatchSpanProcessor call.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Langfuse as Langfuse(client.py)
    participant RM as LangfuseResourceManager
    participant SP as LangfuseSpanProcessor
    participant BSP as BatchSpanProcessor(OTEL)
    participant Env as Environment Variables

    User->>Langfuse: "Langfuse(max_queue_size=N)"
    Langfuse->>RM: "LangfuseResourceManager(max_queue_size=N)"
    RM->>SP: "LangfuseSpanProcessor(max_queue_size=N)"
    SP->>Env: os.environ.get(LANGFUSE_MAX_QUEUE_SIZE)
    Env-->>SP: env value (if set, overrides None only)
    SP->>BSP: "super().__init__(max_queue_size=N or None)"
    BSP->>Env: os.environ.get(OTEL_BSP_MAX_QUEUE_SIZE)
    Env-->>BSP: fallback to 2048 if all None
    BSP-->>SP: initialized with effective queue size
    SP-->>RM: span processor ready
    RM-->>Langfuse: resource manager ready
    Langfuse-->>User: client initialized
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Langfuse as Langfuse(client.py)
    participant RM as LangfuseResourceManager
    participant SP as LangfuseSpanProcessor
    participant BSP as BatchSpanProcessor(OTEL)
    participant Env as Environment Variables

    User->>Langfuse: "Langfuse(max_queue_size=N)"
    Langfuse->>RM: "LangfuseResourceManager(max_queue_size=N)"
    RM->>SP: "LangfuseSpanProcessor(max_queue_size=N)"
    SP->>Env: os.environ.get(LANGFUSE_MAX_QUEUE_SIZE)
    Env-->>SP: env value (if set, overrides None only)
    SP->>BSP: "super().__init__(max_queue_size=N or None)"
    BSP->>Env: os.environ.get(OTEL_BSP_MAX_QUEUE_SIZE)
    Env-->>BSP: fallback to 2048 if all None
    BSP-->>SP: initialized with effective queue size
    SP-->>RM: span processor ready
    RM-->>Langfuse: resource manager ready
    Langfuse-->>User: client initialized
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
langfuse/_client/span_processor.py:99-101
**No validation guard for invalid env-var value**

`int(env_max_queue_size)` raises an unhandled `ValueError` if `LANGFUSE_MAX_QUEUE_SIZE` is set to a non-integer (e.g. `"auto"` or `"4096.5"`). The same pattern exists for `flush_at` on line 93, so this is a pre-existing gap — but this PR is a good opportunity to add a friendlier parse-or-warn pattern. A failed `int()` here will surface as a raw Python exception deep in the constructor, with no hint that `LANGFUSE_MAX_QUEUE_SIZE` is the culprit.

### Issue 2 of 2
langfuse/_client/span_processor.py:140-148
**Undocumented constraint not validated before OTEL call**

The docstring states `max_queue_size` must be `>= flush_at`, but no check is performed before passing both values to `BatchSpanProcessor.__init__`. When the constraint is violated (e.g., `max_queue_size=100` with the default `flush_at=512`), OTEL raises a `ValueError` citing `max_export_batch_size` and `max_queue_size` — names internal to OTEL and not exposed in the Langfuse API, making the error hard to diagnose. An explicit guard here would produce a clear, Langfuse-native message before reaching the OTEL constructor.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tracing): make span queue size conf..."](https://github.com/langfuse/langfuse-python/commit/f55b6e9983a5e47cb21588f0e00ac45c0cf3b1ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43509643)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->