### PR TITLE
fix(openai): handle None arguments in legacy function_call streaming merge

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -811,7 +811,9 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                         curr["name"] = curr["name"] or getattr(
                             tool_call_chunk, "name", None
                         )
-                        curr["arguments"] += getattr(tool_call_chunk, "arguments", "")
+                        curr["arguments"] = (curr.get("arguments") or "") + (
+                            getattr(tool_call_chunk, "arguments", None) or ""
+                        )
 
                 if (
                     delta.get("tool_calls", None) is not None

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -814,7 +814,9 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                         curr["name"] = curr["name"] or getattr(
                             tool_call_chunk, "name", None
                         )
-                        curr["arguments"] += getattr(tool_call_chunk, "arguments", "")
+                        curr["arguments"] = (curr.get("arguments") or "") + (
+                            getattr(tool_call_chunk, "arguments", None) or ""
+                        )
 
                 if (
                     delta.get("tool_calls", None) is not None

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -452,7 +452,7 @@ def test_streaming_chat_completion_handles_legacy_function_call_none_arguments()
     OpenAI-compatible-proxy behaviour, analogous to the `tool_calls` bug
     fixed in PR #1339 but never patched for this legacy branch).
     """
-    model, completion, usage, metadata = (
+    model, completion, usage, metadata, _service_tier = (
         lf_openai_module._extract_streamed_openai_response(
             SimpleNamespace(type="chat"),
             _make_chat_stream_chunks_with_legacy_function_call_none_arguments(),

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -401,6 +401,75 @@ def test_streaming_chat_completion_preserves_tool_calls_after_content():
     assert metadata == {"finish_reason": "tool_calls"}
 
 
+def _make_chat_stream_chunks_with_legacy_function_call_none_arguments():
+    """Mirrors a real OpenAI-compatible-proxy payload shape (see PR #1339,
+    which fixed the identical crash for the newer `tool_calls` array but
+    left this deprecated `function_call` merge branch unpatched): the first
+    streamed delta carries a `function_call` with `arguments=None`, and a
+    later delta appends string arguments to it.
+    """
+    return [
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role="assistant",
+                        content=None,
+                        function_call=SimpleNamespace(
+                            name="get_weather", arguments=None
+                        ),
+                        tool_calls=None,
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        ),
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role=None,
+                        content=None,
+                        function_call=SimpleNamespace(
+                            name=None, arguments='{"city": "Berlin"}'
+                        ),
+                        tool_calls=None,
+                    ),
+                    finish_reason="function_call",
+                )
+            ],
+            usage=None,
+        ),
+    ]
+
+
+def test_streaming_chat_completion_handles_legacy_function_call_none_arguments():
+    """Regression test: the deprecated `function_call` streaming-merge branch
+    must not crash when the first delta's `arguments` is None (a real
+    OpenAI-compatible-proxy behaviour, analogous to the `tool_calls` bug
+    fixed in PR #1339 but never patched for this legacy branch).
+    """
+    model, completion, usage, metadata = (
+        lf_openai_module._extract_streamed_openai_response(
+            SimpleNamespace(type="chat"),
+            _make_chat_stream_chunks_with_legacy_function_call_none_arguments(),
+        )
+    )
+
+    assert model == "gpt-4o-mini"
+    assert completion == {
+        "role": "assistant",
+        "function_call": {
+            "name": "get_weather",
+            "arguments": '{"city": "Berlin"}',
+        },
+    }
+    assert metadata == {"finish_reason": "function_call"}
+
+
 def test_response_api_output_serializes_openai_parsed_response_objects():
     class ParsedOutput(BaseModel):
         name: str


### PR DESCRIPTION
## What does this PR do?

`_extract_streamed_openai_response` (`langfuse/openai.py`) merges the deprecated `function_call`
streaming delta with a bare `+=`:

```python
curr["arguments"] += getattr(tool_call_chunk, "arguments", "")
```

`getattr(obj, "arguments", "")` only returns the `""` default when the attribute is absent. Some
OpenAI-compatible proxies send a first delta with `function_call.arguments` explicitly set to
`None` (not missing) — a real payload shape, not a hypothetical one. In that case
`curr["arguments"]` is `None`, and `None += str` raises `TypeError`, killing the merge for the
whole streamed completion. The `TypeError` is currently swallowed by a bare `except Exception:
pass` further up the call stack, so today this fails silently: the generation ends with no output
and no error a caller would notice.

This is the same crash class PR #1339 already fixed for the newer `tool_calls` array — but that
fix only touched the `tool_calls` branch a few lines below; the sibling legacy `function_call`
branch was never patched. The `tool_calls` branch already guards the accumulator side and skips
`None` increments:

```python
if tool_arguments is not None:
    function_call["arguments"] = (function_call.get("arguments") or "") + tool_arguments
```

The fix brings the same protection to the legacy branch, adopting that branch's
`(... or "") + ...` accumulator guard and coalescing the incoming delta inline so a `None` (or
missing) `arguments` on either side can't break the concatenation:

```python
curr["arguments"] = (curr.get("arguments") or "") + (
    getattr(tool_call_chunk, "arguments", None) or ""
)
```

This guards both sides: the accumulator being `None`, and the incoming delta's `arguments` being
`None` or missing. When both sides are normal strings it is equivalent to the original `+=` — no
behavior change on the happy path. Two-line functional change to a single merge branch; does not
touch the `tool_calls` branch or any other streaming path.

No existing issue or open PR describes this legacy-`function_call`-branch crash (see the search
under Verification below); happy to open a tracking issue first if that's preferred for bug-fix PRs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash
# RED: fix reverted (source only, test kept)
python -m pytest tests/unit/test_openai.py::test_streaming_chat_completion_handles_legacy_function_call_none_arguments -q
# -> 1 failed: TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str' in the legacy
#    function_call merge branch of _extract_streamed_openai_response

# GREEN: fix restored
python -m pytest tests/unit/test_openai.py::test_streaming_chat_completion_handles_legacy_function_call_none_arguments -q
# -> 1 passed

# Full mapped file, regression check
python -m pytest tests/unit/test_openai.py
# -> 35 passed (34 pre-existing + 1 new), no regressions

ruff check langfuse/openai.py tests/unit/test_openai.py
# -> All checks passed!

gh pr list --repo langfuse/langfuse-python --state open --search "function_call None arguments"
# -> empty; #1339 (merged) is the sibling tool_calls fix this mirrors; no PR touches the legacy
#    function_call branch.
```

Test added: `test_streaming_chat_completion_handles_legacy_function_call_none_arguments`, mirroring
the existing `test_streaming_chat_completion_preserves_tool_calls_after_content` pattern but for
the legacy branch, with a first delta carrying `function_call.arguments=None`.

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed. (No public API or documented
  behavior changed; two-line internal guard.)
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream
  regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent `TypeError` crash in the deprecated `function_call` streaming-merge branch of `_extract_streamed_openai_response` when an OpenAI-compatible proxy sends a delta with `arguments` explicitly set to `None`. The fix mirrors the identical guard already applied to the `tool_calls` branch in PR #1339 that was never extended to this legacy sibling branch.

- **`langfuse/openai.py`**: Replaces the bare `curr["arguments"] += getattr(...)` accumulation with a null-safe pattern `(curr.get("arguments") or "") + (getattr(...) or "")`, protecting both the accumulator and the incoming delta from being `None`.
- **`tests/unit/test_openai.py`**: Adds a regression test that replays the two-delta payload shape (first delta with `arguments=None`, second with the real JSON string) and asserts correct final output.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a two-line targeted guard that cannot regress the happy path (string + string produces the same result as before), and the new test directly validates the failing case.

The fix is a minimal null-coalescing guard that mirrors an already-proven pattern from the tool_calls branch. The initialization path at line 807 could still store None for arguments on a single-delta stream, but that pre-existing edge produces None output rather than a crash and is out of scope for this PR. No other correctness issues found.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Proxy as OpenAI-compatible Proxy
    participant Extract as _extract_streamed_openai_response
    participant Accum as function_call accumulator

    Proxy->>Extract: "chunk 1: function_call.arguments = None"
    Extract->>Accum: "if not curr → initialize {name, arguments: None}"

    Proxy->>Extract: "chunk 2: function_call.arguments = '{"city":"Berlin"}'"
    Note over Extract,Accum: BEFORE fix: None += str → TypeError (swallowed silently)
    Note over Extract,Accum: AFTER fix: (None or "") + (str or "") → '{"city":"Berlin"}'
    Extract->>Accum: "curr["arguments"] = "" + '{"city":"Berlin"}'"
    Accum-->>Extract: "{name: "get_weather", arguments: '{"city":"Berlin"}'}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Proxy as OpenAI-compatible Proxy
    participant Extract as _extract_streamed_openai_response
    participant Accum as function_call accumulator

    Proxy->>Extract: "chunk 1: function_call.arguments = None"
    Extract->>Accum: "if not curr → initialize {name, arguments: None}"

    Proxy->>Extract: "chunk 2: function_call.arguments = '{"city":"Berlin"}'"
    Note over Extract,Accum: BEFORE fix: None += str → TypeError (swallowed silently)
    Note over Extract,Accum: AFTER fix: (None or "") + (str or "") → '{"city":"Berlin"}'
    Extract->>Accum: "curr["arguments"] = "" + '{"city":"Berlin"}'"
    Accum-->>Extract: "{name: "get_weather", arguments: '{"city":"Berlin"}'}"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(openai): rebase legacy function\_cal..."](https://github.com/langfuse/langfuse-python/commit/94b33dda2753918cf03b7a1ae5a785d86221cc08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43529686)</sub>

<!-- /greptile_comment -->