### PR TITLE
fix(media): normalize urlsafe base64 for media uploads

### DIFF
--- a/langfuse/media.py
+++ b/langfuse/media.py
@@ -291,7 +291,9 @@ class LangfuseMedia:
             if not content_type:
                 raise ValueError("Content type is empty")
 
-            return base64.b64decode(actual_data), cast(MediaContentType, content_type)
+            normalized_data = actual_data.replace("-", "+").replace("_", "/")
+
+            return base64.b64decode(normalized_data), cast(MediaContentType, content_type)
 
         except Exception as e:
             logger.error("Error parsing base64 data URI", exc_info=e)


### PR DESCRIPTION
## What does this PR do?

https://github.com/langfuse/langfuse/issues/15179

Fixes compatibility issues with openinference package, which uses urlsafe base64 in certain output fields.
Normalizes the base64 string during the parse function.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash

```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a compatibility bug where media uploads would fail when the base64 payload used the URL-safe alphabet (`-` and `_` instead of `+` and `/`), as produced by the `openinference` package. The fix normalizes the incoming base64 string before decoding.

- **Normalization logic**: `actual_data.replace("-", "+").replace("_", "/")` is applied before `base64.b64decode`, converting URL-safe base64 to standard base64. This is functionally correct; an equally valid (and more idiomatic) alternative is `base64.urlsafe_b64decode`.
- **No padding handling added**: Both the old and new code assume the base64 string is properly padded with `=`; if `openinference` ever omits padding the call will still raise and be swallowed by the outer `except` block.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a one-line normalization that fixes a real compatibility gap and degrades gracefully on failure.

The normalization logic is correct and the error path is already guarded by the outer try/except. The only gaps are a missed opportunity to use the stdlib urlsafe_b64decode and the absence of unit tests for the new code path.

langfuse/media.py — worth adding a unit test in tests/unit/test_media.py that covers URL-safe encoded inputs.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant LangfuseMedia
    participant base64

    Caller->>LangfuseMedia: _parse_base64_data_uri(data_uri)
    LangfuseMedia->>LangfuseMedia: "validate 'data:' prefix & split header/body"
    LangfuseMedia->>LangfuseMedia: check 'base64' in header parts
    Note over LangfuseMedia: NEW: normalize URL-safe chars<br/>replace('-','+').replace('_','/')
    LangfuseMedia->>base64: b64decode(normalized_data)
    base64-->>LangfuseMedia: raw bytes
    LangfuseMedia-->>Caller: (bytes, content_type)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant LangfuseMedia
    participant base64

    Caller->>LangfuseMedia: _parse_base64_data_uri(data_uri)
    LangfuseMedia->>LangfuseMedia: "validate 'data:' prefix & split header/body"
    LangfuseMedia->>LangfuseMedia: check 'base64' in header parts
    Note over LangfuseMedia: NEW: normalize URL-safe chars<br/>replace('-','+').replace('_','/')
    LangfuseMedia->>base64: b64decode(normalized_data)
    base64-->>LangfuseMedia: raw bytes
    LangfuseMedia-->>Caller: (bytes, content_type)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
langfuse/media.py:294-296
Python's standard library already provides `base64.urlsafe_b64decode`, which performs exactly this alphabet substitution (`-`→`+`, `_`→`/`) internally. Using it directly is more idiomatic and makes the intent self-documenting.

```suggestion
            return base64.urlsafe_b64decode(actual_data), cast(MediaContentType, content_type)
```

### Issue 2 of 2
langfuse/media.py:294-296
**Missing test coverage for URL-safe base64 inputs.** The PR checklist acknowledges no tests were added. `tests/unit/test_media.py` has no case exercising the `-` and `_` substitution path, so a future regression (e.g. re-introduction of `b64decode` without normalisation) would go undetected. Consider adding a unit test that passes a URL-safe encoded data URI and asserts the decoded bytes match the expected output.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(media): normalize urlsafe base64 for..."](https://github.com/langfuse/langfuse-python/commit/23ba6a2f7b177a7c16a0af36d0a54450f27ae240) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45049954)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->