### PR TITLE
feat(tracing): allow explicit observation start times

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -521,6 +521,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
         completion_start_time: Optional[datetime] = None,
         model: Optional[str] = None,
         model_parameters: Optional[Dict[str, MapValue]] = None,
@@ -542,6 +543,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> LangfuseSpan: ...
 
     @overload
@@ -557,6 +559,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> LangfuseAgent: ...
 
     @overload
@@ -572,6 +575,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> LangfuseTool: ...
 
     @overload
@@ -587,6 +591,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> LangfuseChain: ...
 
     @overload
@@ -602,6 +607,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> LangfuseRetriever: ...
 
     @overload
@@ -617,6 +623,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> LangfuseEvaluator: ...
 
     @overload
@@ -632,6 +639,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
         completion_start_time: Optional[datetime] = None,
         model: Optional[str] = None,
         model_parameters: Optional[Dict[str, MapValue]] = None,
@@ -653,6 +661,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> LangfuseGuardrail: ...
 
     def start_observation(
@@ -667,6 +676,7 @@ class Langfuse:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
         completion_start_time: Optional[datetime] = None,
         model: Optional[str] = None,
         model_parameters: Optional[Dict[str, MapValue]] = None,
@@ -699,6 +709,7 @@ class Langfuse:
             version: Version identifier for the code or component
             level: Importance level of the observation
             status_message: Optional status message for the observation
+            start_time: Optional explicit start time in nanoseconds since epoch
             completion_start_time: When the model started generating (for generation types)
             model: Name/identifier of the AI model used (for generation types)
             model_parameters: Parameters used for the model (for generation types)
@@ -721,7 +732,9 @@ class Langfuse:
                 with otel_trace_api.use_span(
                     cast(otel_trace_api.Span, remote_parent_span)
                 ):
-                    otel_span = self._otel_tracer.start_span(name=name)
+                    otel_span = self._otel_tracer.start_span(
+                        name=name, start_time=start_time
+                    )
                     otel_span.set_attribute(LangfuseOtelSpanAttributes.AS_ROOT, True)
 
                     return self._create_observation_from_otel_span(
@@ -741,7 +754,7 @@ class Langfuse:
                         prompt=prompt,
                     )
 
-        otel_span = self._otel_tracer.start_span(name=name)
+        otel_span = self._otel_tracer.start_span(name=name, start_time=start_time)
 
         return self._create_observation_from_otel_span(
             otel_span=otel_span,

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -745,6 +745,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> "LangfuseSpan": ...
 
     @overload
@@ -759,6 +760,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
         completion_start_time: Optional[datetime] = None,
         model: Optional[str] = None,
         model_parameters: Optional[Dict[str, MapValue]] = None,
@@ -779,6 +781,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> "LangfuseAgent": ...
 
     @overload
@@ -793,6 +796,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> "LangfuseTool": ...
 
     @overload
@@ -807,6 +811,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> "LangfuseChain": ...
 
     @overload
@@ -821,6 +826,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> "LangfuseRetriever": ...
 
     @overload
@@ -835,6 +841,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> "LangfuseEvaluator": ...
 
     @overload
@@ -849,6 +856,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
         completion_start_time: Optional[datetime] = None,
         model: Optional[str] = None,
         model_parameters: Optional[Dict[str, MapValue]] = None,
@@ -869,6 +877,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> "LangfuseGuardrail": ...
 
     @overload
@@ -883,6 +892,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
     ) -> "LangfuseEvent": ...
 
     def start_observation(
@@ -896,6 +906,7 @@ class LangfuseObservationWrapper:
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        start_time: Optional[int] = None,
         completion_start_time: Optional[datetime] = None,
         model: Optional[str] = None,
         model_parameters: Optional[Dict[str, MapValue]] = None,
@@ -929,6 +940,7 @@ class LangfuseObservationWrapper:
             version: Version identifier for the code or component
             level: Importance level of the observation (info, warning, error)
             status_message: Optional status message for the observation
+            start_time: Optional explicit start time in nanoseconds since epoch
             completion_start_time: When the model started generating (for generation types)
             model: Name/identifier of the AI model used (for generation types)
             model_parameters: Parameters used for the model (for generation types)
@@ -940,7 +952,7 @@ class LangfuseObservationWrapper:
             A new observation of the specified type that must be ended with .end()
         """
         if as_type == "event":
-            timestamp = time_ns()
+            timestamp = start_time if start_time is not None else time_ns()
             event_span = self._langfuse_client._otel_tracer.start_span(
                 name=name, start_time=timestamp
             )
@@ -968,7 +980,9 @@ class LangfuseObservationWrapper:
             observation_class = LangfuseSpan
 
         with otel_trace_api.use_span(self._otel_span):
-            new_otel_span = self._langfuse_client._otel_tracer.start_span(name=name)
+            new_otel_span = self._langfuse_client._otel_tracer.start_span(
+                name=name, start_time=start_time
+            )
 
         common_args = {
             "otel_span": new_otel_span,

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -3142,6 +3142,37 @@ class TestConcurrencyAndAsync(TestOTelBase):
             f"Span duration ({span_duration_seconds}s) should be at least 0.05s"
         )
 
+    def test_manual_observations_accept_historical_start_times(
+        self, langfuse_client, memory_exporter
+    ):
+        root_start_time = 1_750_000_000_000_000_000
+        generation_start_time = root_start_time + 100_000_000
+        end_time = root_start_time + 1_000_000_000
+
+        root = langfuse_client.start_observation(
+            name="historical-root",
+            trace_context={"trace_id": "a" * 32},
+            start_time=root_start_time,
+        )
+        generation = root.start_observation(
+            name="historical-generation",
+            as_type="generation",
+            start_time=generation_start_time,
+        )
+        generation.end(end_time=end_time)
+        root.end(end_time=end_time)
+
+        spans_by_name = {
+            span.name: span for span in memory_exporter.get_finished_spans()
+        }
+        root_span = spans_by_name["historical-root"]
+        generation_span = spans_by_name["historical-generation"]
+
+        assert root_span.start_time == root_start_time
+        assert generation_span.start_time == generation_start_time
+        assert root_span.end_time == end_time
+        assert generation_span.end_time == end_time
+
 
 # Add tests for media functionality in its own class
 class TestMediaHandling(TestOTelBase):


### PR DESCRIPTION
## What does this PR do?

Adds an optional nanosecond `start_time` to manual root and child observations. This makes manual observation creation symmetric with `end(end_time=...)` and preserves historical durations when an integration emits spans after the underlying work has completed

Fixes #1377

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

```bash
uv run --frozen pytest -q tests/unit/test_otel.py
uv run --frozen mypy langfuse --no-error-summary
uv run --frozen ruff check .
uv run --frozen ruff format --check .
```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds explicit start times for manually created observations. The main changes are:

- Adds an optional nanosecond `start_time` to root and child observation APIs.
- Passes explicit start times to OpenTelemetry span creation.
- Uses explicit timestamps for manually created child events.
- Tests historical start and end times for root and generation spans.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- Existing behavior remains unchanged when `start_time` is omitted.
- Explicit timestamps are forwarded on both root creation paths and the child observation path.

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tracing): allow explicit observatio..."](https://github.com/langfuse/langfuse-python/commit/6478803c418bb6c1c569bf177e515a8e2e59f84a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46254166)</sub>

<!-- /greptile_comment -->