### PR TITLE
perf(span-processor): defer span_formatter serialization behind DEBUG guard

### DIFF
--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -12,6 +12,7 @@ Key features:
 """
 
 import base64
+import logging
 import os
 import threading
 from typing import Callable, Dict, List, Optional, cast
@@ -218,9 +219,10 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
                 )
                 return
 
-            langfuse_logger.debug(
-                f"Trace: Processing span name='{span._name}' | Full details:\n{span_formatter(span)}"
-            )
+            if langfuse_logger.isEnabledFor(logging.DEBUG):
+                langfuse_logger.debug(
+                    f"Trace: Processing span name='{span._name}' | Full details:\n{span_formatter(span)}"
+                )
 
             super().on_end(span)
         finally:

--- a/tests/unit/test_span_processor.py
+++ b/tests/unit/test_span_processor.py
@@ -1,13 +1,17 @@
+import logging
 from typing import Sequence
+from unittest.mock import Mock, patch
 
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
+import langfuse._client.span_processor as span_processor_module
 from langfuse._client.environment_variables import (
     LANGFUSE_FLUSH_AT,
     LANGFUSE_FLUSH_INTERVAL,
 )
 from langfuse._client.span_processor import LangfuseSpanProcessor
+from langfuse.logger import langfuse_logger
 
 
 class NoOpSpanExporter(SpanExporter):
@@ -53,4 +57,63 @@ def test_span_processor_uses_env_flush_settings_when_constructor_omits_them(
         assert processor._batch_processor._max_export_batch_size == 19
         assert processor._batch_processor._schedule_delay_millis == 3250
     finally:
+        processor.shutdown()
+
+
+def _make_processor() -> LangfuseSpanProcessor:
+    return LangfuseSpanProcessor(
+        public_key="pk-test",
+        secret_key="sk-test",
+        base_url="http://localhost:3000",
+        span_exporter=NoOpSpanExporter(),
+    )
+
+
+def _reach_debug_log_line(processor, monkeypatch):
+    """Force on_end past its early-return guards to the debug-log statement."""
+    monkeypatch.setattr(processor, "_is_langfuse_project_span", lambda span: True)
+    monkeypatch.setattr(
+        processor, "_is_blocked_instrumentation_scope", lambda span: False
+    )
+    monkeypatch.setattr(processor, "_should_export_span", lambda span: True)
+    monkeypatch.setattr(processor, "_cleanup_app_root_state", lambda span: None)
+    # Isolate from the batch exporter's on_end
+    monkeypatch.setattr(
+        span_processor_module.BatchSpanProcessor,
+        "on_end",
+        lambda self, span: None,
+    )
+
+
+def test_on_end_does_not_call_span_formatter_when_debug_disabled(monkeypatch):
+    processor = _make_processor()
+    _reach_debug_log_line(processor, monkeypatch)
+    span = Mock()
+    span._name = "test-span"
+
+    original_level = langfuse_logger.level
+    try:
+        langfuse_logger.setLevel(logging.WARNING)
+        with patch.object(span_processor_module, "span_formatter") as mock_formatter:
+            processor.on_end(span)
+        mock_formatter.assert_not_called()
+    finally:
+        langfuse_logger.setLevel(original_level)
+        processor.shutdown()
+
+
+def test_on_end_calls_span_formatter_when_debug_enabled(monkeypatch):
+    processor = _make_processor()
+    _reach_debug_log_line(processor, monkeypatch)
+    span = Mock()
+    span._name = "test-span"
+
+    original_level = langfuse_logger.level
+    try:
+        langfuse_logger.setLevel(logging.DEBUG)
+        with patch.object(span_processor_module, "span_formatter") as mock_formatter:
+            processor.on_end(span)
+        mock_formatter.assert_called_once()
+    finally:
+        langfuse_logger.setLevel(original_level)
         processor.shutdown()


### PR DESCRIPTION
## What does this PR do?

`LangfuseSpanProcessor.on_end` logs the full span at DEBUG level with an f-string:

```python
langfuse_logger.debug(f"... {span_formatter(span)}")
```

Because f-strings are built before the call, `span_formatter(span)` (a full span serialization) runs on every span even when DEBUG logging is off — and `logger.debug` then discards the string. Since `on_end` runs once per span, that's wasted work on the hot path when debug isn't enabled. See #15339 for the profiling details.

This guards the log behind `isEnabledFor(logging.DEBUG)` so the serialization only happens when the output would actually be emitted. I kept the change to this one hot call — the other debug logs in `on_end` are in rarely-hit early-return/error branches, so I left them alone to keep the diff small.

Fixes langfuse/langfuse#15339

## Type of change

- [x] Bug fix

## Verification

```bash
uv run --frozen pytest tests/unit/test_span_processor.py
uv run --frozen ruff check .
uv run --frozen mypy langfuse --no-error-summary
```

Added two tests: one checks `span_formatter` isn't called when the logger is above DEBUG (fails without this change), the other checks it still runs when DEBUG is on.

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs, examples, or `.env.template` if needed. — n/a, internal-only change
- [x] I did not hand-edit generated files.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR avoids unnecessary span serialization when DEBUG logging is disabled.
- Guards the hot-path debug log with `isEnabledFor(logging.DEBUG)`.
- Adds tests confirming formatting is skipped above DEBUG and retained at DEBUG.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new guard uses the standard logger’s effective-level check and preserves formatting whenever DEBUG is enabled while removing unnecessary serialization otherwise.

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(span-processor): defer span\_formatt..."](https://github.com/langfuse/langfuse-python/commit/4cd5424576d7f7867edf207835349780e0ff3ccb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46776889)</sub>

<!-- /greptile_comment -->