### PR TITLE
fix: preserve zero sample rate

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -351,7 +351,8 @@ class Langfuse:
             or get_common_release_envs()
         )
         self._project_id: Optional[str] = None
-        sample_rate = sample_rate or float(os.environ.get(LANGFUSE_SAMPLE_RATE, 1.0))
+        if sample_rate is None:
+            sample_rate = float(os.environ.get(LANGFUSE_SAMPLE_RATE, 1.0))
         if not 0.0 <= sample_rate <= 1.0:
             raise ValueError(
                 f"Sample rate must be between 0.0 and 1.0, got {sample_rate}"

--- a/tests/unit/test_initialization.py
+++ b/tests/unit/test_initialization.py
@@ -109,6 +109,22 @@ class TestClientInitialization:
 
         assert client._base_url == "https://cloud.langfuse.com"
 
+    def test_zero_sample_rate_parameter_is_preserved(
+        self, cleanup_env_vars, monkeypatch
+    ):
+        """Test that an explicit zero sample rate overrides the environment."""
+        monkeypatch.setenv("LANGFUSE_SAMPLE_RATE", "1.0")
+
+        client = Langfuse(
+            public_key="test_pk_zero_sample_rate",
+            secret_key="test_sk",
+            tracing_enabled=False,
+            sample_rate=0.0,
+        )
+
+        assert client._resources is not None
+        assert client._resources.sample_rate == 0.0
+
     def test_base_url_env_var(self, cleanup_env_vars):
         """Test that LANGFUSE_BASE_URL environment variable is used correctly."""
         os.environ["LANGFUSE_BASE_URL"] = "http://test-base-url.com"


### PR DESCRIPTION
## What changed

- preserve an explicit `sample_rate=0.0` instead of falling back to the environment or `1.0`
- add a regression test proving the explicit keyword value takes precedence over `LANGFUSE_SAMPLE_RATE`

## Why

`Langfuse(sample_rate=0.0)` currently uses a truthiness fallback, so the documented zero value becomes `1.0` and traces everything. The environment-variable path already preserves zero; this makes the keyword path follow the same documented contract.

This prevents users who intentionally disable sampling from unexpectedly exporting all traces.

## Scope

This is limited to `sample_rate` resolution. The separate timeout and stale-docstring observations mentioned in the report are intentionally out of scope.

## Validation

- `uv run --frozen pytest tests/unit/test_initialization.py -q` (19 passed)
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check langfuse/_client/client.py tests/unit/test_initialization.py`
- `uv run --frozen mypy langfuse --no-error-summary`
- direct one-process reproduction: stored sample rate changed from `1.0` before the fix to `0.0` after it

Linear: [LFE-14503](https://linear.app/clickhouse/issue/LFE-14503/sample-rate00-is-silently-replaced-by-10-so-a-documented-value-cannot)

Closes #1782

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Preserves an explicitly configured zero sample rate instead of falling back to the environment or default.
- Resolves the environment-based sample rate only when the constructor argument is `None`.
- Adds a regression test confirming that `sample_rate=0.0` overrides `LANGFUSE_SAMPLE_RATE`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the focused configuration fix covered by an appropriate regression test.

The explicit `None` check preserves `0.0` while retaining environment and default resolution for omitted values, and no blocking failure remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve zero sample rate"](https://github.com/langfuse/langfuse-python/commit/87d753f91541ea7f5c4ca30db0897fbd7070f2f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47563696)</sub>

**Context used:**

- Knowledge Base — [Client Core](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/client-core.md)

<!-- /greptile_comment -->