### PR TITLE
fix(observe): close abandoned generators when their span already ended

### DIFF
--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -735,12 +735,17 @@ class _ContextPreservedAsyncGeneratorWrapper:
 
     async def _close_generator(self) -> None:
         try:
-            await asyncio.create_task(
+            close_task = asyncio.create_task(
                 self.generator.aclose(),
                 context=self.context,
             )  # type: ignore
         except TypeError:
-            await self.context.run(asyncio.create_task, self.generator.aclose())
+            # Python 3.10: create_task has no context parameter. Only the
+            # create_task call is guarded so a TypeError raised from the
+            # generator's own cleanup is not mistaken for it.
+            close_task = self.context.run(asyncio.create_task, self.generator.aclose())
+
+        await close_task
 
     async def close(self) -> None:
         await self.aclose()

--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -616,6 +616,12 @@ class _ContextPreservedSyncGeneratorWrapper:
 
     def close(self) -> None:
         if self._span_ended:
+            # The span can end while the generator is still suspended (e.g.
+            # an error surfaced from __next__ without resuming the generator).
+            # Still close the generator so its cleanup runs deterministically
+            # in the preserved context instead of at GC time under an
+            # arbitrary ambient context.
+            self.context.run(self.generator.close)
             return
 
         try:
@@ -711,21 +717,30 @@ class _ContextPreservedAsyncGeneratorWrapper:
 
     async def aclose(self) -> None:
         if self._span_ended:
+            # The span can end while the generator is still suspended (e.g. a
+            # cancellation delivered before the inner __anext__ task resumed
+            # the generator). Still close the generator so its cleanup runs
+            # deterministically in the preserved context instead of at GC time
+            # under an arbitrary ambient context.
+            await self._close_generator()
             return
 
         try:
-            try:
-                await asyncio.create_task(
-                    self.generator.aclose(),
-                    context=self.context,
-                )  # type: ignore
-            except TypeError:
-                await self.context.run(asyncio.create_task, self.generator.aclose())
+            await self._close_generator()
         except (Exception, asyncio.CancelledError) as error:
             self._finalize_with_error(error)
             raise
         else:
             self._finalize()
+
+    async def _close_generator(self) -> None:
+        try:
+            await asyncio.create_task(
+                self.generator.aclose(),
+                context=self.context,
+            )  # type: ignore
+        except TypeError:
+            await self.context.run(asyncio.create_task, self.generator.aclose())
 
     async def close(self) -> None:
         await self.aclose()

--- a/langfuse/_client/observe.py
+++ b/langfuse/_client/observe.py
@@ -616,11 +616,7 @@ class _ContextPreservedSyncGeneratorWrapper:
 
     def close(self) -> None:
         if self._span_ended:
-            # The span can end while the generator is still suspended (e.g.
-            # an error surfaced from __next__ without resuming the generator).
-            # Still close the generator so its cleanup runs deterministically
-            # in the preserved context instead of at GC time under an
-            # arbitrary ambient context.
+            # Still close the generator so cleanup runs in the preserved context, not at GC time.
             self.context.run(self.generator.close)
             return
 
@@ -717,11 +713,7 @@ class _ContextPreservedAsyncGeneratorWrapper:
 
     async def aclose(self) -> None:
         if self._span_ended:
-            # The span can end while the generator is still suspended (e.g. a
-            # cancellation delivered before the inner __anext__ task resumed
-            # the generator). Still close the generator so its cleanup runs
-            # deterministically in the preserved context instead of at GC time
-            # under an arbitrary ambient context.
+            # Still close the generator so cleanup runs in the preserved context, not at GC time.
             await self._close_generator()
             return
 
@@ -740,9 +732,7 @@ class _ContextPreservedAsyncGeneratorWrapper:
                 context=self.context,
             )  # type: ignore
         except TypeError:
-            # Python 3.10: create_task has no context parameter. Only the
-            # create_task call is guarded so a TypeError raised from the
-            # generator's own cleanup is not mistaken for it.
+            # Python 3.10 create_task has no context param; guard only the call itself.
             close_task = self.context.run(asyncio.create_task, self.generator.aclose())
 
         await close_task

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -400,6 +400,32 @@ async def test_async_generator_wrapper_closes_generator_cancel_never_resumed() -
 
 
 @pytest.mark.asyncio
+async def test_async_generator_wrapper_aclose_propagates_cleanup_type_error() -> None:
+    async def generator() -> AsyncGenerator[str, None]:
+        try:
+            yield "item_0"
+        finally:
+            raise TypeError("cleanup failed")
+
+    span = SpanRecorder()
+    wrapper = _ContextPreservedAsyncGeneratorWrapper(
+        generator(),
+        contextvars.copy_context(),
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert await wrapper.__anext__() == "item_0"
+
+    with pytest.raises(TypeError, match="cleanup failed"):
+        await wrapper.aclose()
+
+    assert span.ended == 1
+    assert span.updates[-1] == {"level": "ERROR", "status_message": "cleanup failed"}
+
+
+@pytest.mark.asyncio
 async def test_async_generator_wrapper_fallback_preserves_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextvars
 import gc
-import inspect
 import json
 import sys
 from typing import Any, AsyncGenerator, Generator, cast
@@ -295,8 +294,7 @@ def test_sync_generator_wrapper_close_closes_generator_after_span_ended() -> Non
 
     assert next(wrapper) == "item_0"
 
-    # __next__ raising without resuming the generator (here: re-entering the
-    # preserved context) ends the span while the generator is still suspended.
+    # An error from __next__ that never resumed the generator ends the span.
     with pytest.raises(RuntimeError):
         context.run(lambda: next(wrapper))
 
@@ -337,8 +335,7 @@ async def test_async_generator_wrapper_aclose_closes_generator_after_span_ended(
 
     assert await wrapper.__anext__() == "item_0"
 
-    # Span ends while the generator is still suspended (as happens when a
-    # cancellation never resumes the generator, see the test below).
+    # Span ends while the generator is still suspended (e.g. the cancel race below).
     wrapper._finalize_with_error(asyncio.CancelledError())
     assert span.ended == 1
     assert seen == []
@@ -381,20 +378,19 @@ async def test_async_generator_wrapper_closes_generator_cancel_never_resumed() -
     consumer = asyncio.create_task(consume())
     for _ in range(4):
         await asyncio.sleep(0)
-    # The cancel lands between chunks, before the inner __anext__ task's
-    # first step: the generator is never resumed, but the span is ended.
+    # Cancel lands before the inner __anext__ task's first step.
     asyncio.get_running_loop().call_soon(consumer.cancel)
     with pytest.raises(asyncio.CancelledError):
         await consumer
 
-    assert inspect.getasyncgenstate(raw) == "AGEN_SUSPENDED"
+    assert raw.ag_frame is not None  # still suspended, never resumed
     assert span.ended == 1
     assert seen == []
 
     marker.set("ambient-now")
     await wrapper.aclose()
 
-    assert inspect.getasyncgenstate(raw) == "AGEN_CLOSED"
+    assert raw.ag_frame is None  # closed
     assert seen == ["preserved"]
     assert span.ended == 1
 

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 import gc
+import inspect
 import json
 import sys
 from typing import Any, AsyncGenerator, Generator, cast
@@ -266,6 +267,134 @@ async def test_async_generator_wrapper_aclose_preserves_context() -> None:
 
     await wrapper.aclose()
 
+    assert seen == ["preserved"]
+    assert span.ended == 1
+
+
+def test_sync_generator_wrapper_close_closes_generator_after_span_ended() -> None:
+    marker = contextvars.ContextVar("marker", default="ambient")
+    seen: list[str] = []
+
+    def generator() -> Generator[str, None, None]:
+        try:
+            yield "item_0"
+            yield "item_1"
+        finally:
+            seen.append(marker.get())
+
+    span = SpanRecorder()
+    context = contextvars.copy_context()
+    context.run(marker.set, "preserved")
+    wrapper = _ContextPreservedSyncGeneratorWrapper(
+        generator(),
+        context,
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert next(wrapper) == "item_0"
+
+    # __next__ raising without resuming the generator (here: re-entering the
+    # preserved context) ends the span while the generator is still suspended.
+    with pytest.raises(RuntimeError):
+        context.run(lambda: next(wrapper))
+
+    assert span.ended == 1
+    assert seen == []
+
+    marker.set("ambient-now")
+    wrapper.close()
+
+    assert seen == ["preserved"]
+    assert span.ended == 1
+
+
+@pytest.mark.asyncio
+async def test_async_generator_wrapper_aclose_closes_generator_after_span_ended() -> (
+    None
+):
+    marker = contextvars.ContextVar("marker", default="ambient")
+    seen: list[str] = []
+
+    async def generator() -> AsyncGenerator[str, None]:
+        try:
+            yield "item_0"
+            yield "item_1"
+        finally:
+            seen.append(marker.get())
+
+    span = SpanRecorder()
+    context = contextvars.copy_context()
+    context.run(marker.set, "preserved")
+    wrapper = _ContextPreservedAsyncGeneratorWrapper(
+        generator(),
+        context,
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    assert await wrapper.__anext__() == "item_0"
+
+    # Span ends while the generator is still suspended (as happens when a
+    # cancellation never resumes the generator, see the test below).
+    wrapper._finalize_with_error(asyncio.CancelledError())
+    assert span.ended == 1
+    assert seen == []
+
+    marker.set("ambient-now")
+    await wrapper.aclose()
+
+    assert seen == ["preserved"]
+    assert span.ended == 1
+
+
+@pytest.mark.asyncio
+async def test_async_generator_wrapper_closes_generator_cancel_never_resumed() -> None:
+    marker = contextvars.ContextVar("marker", default="ambient")
+    seen: list[str] = []
+
+    async def generator() -> AsyncGenerator[str, None]:
+        try:
+            yield "item_0"
+            yield "item_1"
+        finally:
+            seen.append(marker.get())
+
+    span = SpanRecorder()
+    context = contextvars.copy_context()
+    context.run(marker.set, "preserved")
+    raw = generator()
+    wrapper = _ContextPreservedAsyncGeneratorWrapper(
+        raw,
+        context,
+        cast(Any, span),
+        False,
+        None,
+    )
+
+    async def consume() -> None:
+        async for _ in wrapper:
+            await asyncio.sleep(0)
+
+    consumer = asyncio.create_task(consume())
+    for _ in range(4):
+        await asyncio.sleep(0)
+    # The cancel lands between chunks, before the inner __anext__ task's
+    # first step: the generator is never resumed, but the span is ended.
+    asyncio.get_running_loop().call_soon(consumer.cancel)
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+
+    assert inspect.getasyncgenstate(raw) == "AGEN_SUSPENDED"
+    assert span.ended == 1
+    assert seen == []
+
+    marker.set("ambient-now")
+    await wrapper.aclose()
+
+    assert inspect.getasyncgenstate(raw) == "AGEN_CLOSED"
     assert seen == ["preserved"]
     assert span.ended == 1
 


### PR DESCRIPTION
## What does this PR do?

Once a wrapped generator's span has ended, `aclose()`/`close()` return without closing the generator. But a span can end while the generator is still suspended mid-stream — for example, a client disconnect that cancels iteration before the generator resumes. The generator is then never closed: the GC finalizes it later, running its `finally` block under whatever request context happens to be active at that moment.

In our production streaming service this fired many times a day: "Setting attribute on ended span" warnings from `finally`-block span updates, running under *other requests'* contexts.

Fix: always close the generator, even if the span already ended. Span behavior is unchanged. Also narrows a pre-existing `except TypeError` that could mistake an error raised by generator cleanup for the Python 3.10 `create_task` signature fallback and silently swallow it.

Alternative: #1792 builds on this and also preserves the generator's final span updates in the cancellation case. Pick whichever you prefer; happy to close the other.

<details><summary>Minimal repro (fails before, passes after)</summary>

```python
import asyncio, contextvars, gc
from langfuse import observe

request_ctx = contextvars.ContextVar("request", default="none")

@observe(name="stream")
async def stream():
    try:
        yield "a"
        yield "b"
    finally:
        print(f"finally ran under {request_ctx.get()!r}")

async def main():
    request_ctx.set("request-A")
    gen = stream()

    async def consume():
        async for _ in gen:
            await asyncio.sleep(0)

    task = asyncio.create_task(consume())
    for _ in range(4):
        await asyncio.sleep(0)
    asyncio.get_running_loop().call_soon(task.cancel)  # lands before the inner task's first step
    try:
        await task
    except asyncio.CancelledError:
        pass

    await gen.aclose()            # was a no-op: span already ended
    request_ctx.set("request-B")
    del gen; gc.collect(); await asyncio.sleep(0.05)
    # before this fix: prints "finally ran under 'request-B'"

asyncio.run(main())
```

</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

```bash
uv run --frozen pytest -n auto --dist worksteal tests/unit   # also run on 3.10 and 3.11
uv run --frozen ruff check .
uv run --frozen ruff format --check .
uv run --frozen mypy langfuse --no-error-summary
```

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

