### PR TITLE
fix(resource-manager): prevent shutdown queue deadlock

### DIFF
--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -134,10 +134,14 @@ class LangfuseResourceManager:
         id_generator: Optional[IdGenerator] = None,
         span_exporter: Optional[SpanExporter] = None,
     ) -> "LangfuseResourceManager":
-        if public_key in cls._instances:
-            return cls._instances[public_key]
-
         with cls._lock:
+            cached_instance = cls._instances.get(public_key)
+            if cached_instance is not None and not cached_instance._shutdown:
+                return cached_instance
+
+            if cached_instance is not None:
+                cls._instances.pop(public_key, None)
+
             if public_key not in cls._instances:
                 instance = super(LangfuseResourceManager, cls).__new__(cls)
 
@@ -226,6 +230,7 @@ class LangfuseResourceManager:
 
         self._custom_httpx_client = httpx_client
         self._init_api_clients()
+        self._span_processor: Optional[LangfuseSpanProcessor] = None
 
         # Media
         self._media_upload_enabled = os.environ.get(
@@ -263,6 +268,7 @@ class LangfuseResourceManager:
                 mask_otel_spans=mask_otel_spans,
             )
             tracer_provider.add_span_processor(langfuse_processor)
+            self._span_processor = langfuse_processor
 
             self._otel_tracer = tracer_provider.get_tracer(
                 LANGFUSE_TRACER_NAME,
@@ -476,10 +482,11 @@ class LangfuseResourceManager:
     @classmethod
     def reset(cls) -> None:
         with cls._lock:
-            for key in cls._instances:
-                cls._instances[key].shutdown()
-
+            instances = list(cls._instances.values())
             cls._instances.clear()
+
+        for instance in instances:
+            instance.shutdown()
 
     def add_score_task(self, event: dict, *, force_sample: bool = False) -> None:
         try:
@@ -508,10 +515,17 @@ class LangfuseResourceManager:
             )
 
             if should_sample:
-                langfuse_logger.debug(
-                    f"Score: Enqueuing event type={event['type']} for trace_id={event['body'].trace_id} name={event['body'].name} value={event['body'].value}"
-                )
-                self._score_ingestion_queue.put(event, block=False)
+                with self._lock:
+                    if self._shutdown:
+                        langfuse_logger.warning(
+                            "Score: Dropping event because the Langfuse client has already been shut down."
+                        )
+                        return
+
+                    langfuse_logger.debug(
+                        f"Score: Enqueuing event type={event['type']} for trace_id={event['body'].trace_id} name={event['body'].name} value={event['body'].value}"
+                    )
+                    self._score_ingestion_queue.put(event, block=False)
 
         except Full:
             langfuse_logger.warning(
@@ -531,10 +545,17 @@ class LangfuseResourceManager:
         event: dict,
     ) -> None:
         try:
-            langfuse_logger.debug(
-                f"Trace: Enqueuing event type={event['type']} for trace_id={event['body'].id}"
-            )
-            self._score_ingestion_queue.put(event, block=False)
+            with self._lock:
+                if self._shutdown:
+                    langfuse_logger.warning(
+                        "Trace: Dropping event because the Langfuse client has already been shut down."
+                    )
+                    return
+
+                langfuse_logger.debug(
+                    f"Trace: Enqueuing event type={event['type']} for trace_id={event['body'].id}"
+                )
+                self._score_ingestion_queue.put(event, block=False)
 
         except Full:
             langfuse_logger.warning(
@@ -612,13 +633,24 @@ class LangfuseResourceManager:
         langfuse_logger.debug("Successfully flushed media upload queue")
 
     def shutdown(self) -> None:
-        self._shutdown = True
+        with self._lock:
+            if self._shutdown:
+                return
+
+            self._shutdown = True
+            if self._instances.get(self.public_key) is self:
+                self._instances.pop(self.public_key)
+            self._media_manager.begin_shutdown()
 
         # Unregister the atexit handler first
         atexit.unregister(self.shutdown)
 
-        self.flush()
-        self._stop_and_join_consumer_threads()
+        try:
+            self.flush()
+        finally:
+            self._stop_and_join_consumer_threads()
+            if self._span_processor is not None:
+                self._span_processor.shutdown()
 
 
 def _init_tracer_provider(

--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -1,4 +1,5 @@
 import os
+import threading
 import time
 from queue import Empty, Full, Queue
 from typing import Any, Callable, Optional, TypeVar, cast
@@ -42,6 +43,8 @@ class MediaManager:
         self._httpx_client = httpx_client
         self._queue = media_upload_queue
         self._max_retries = max_retries
+        self._state_lock = threading.Lock()
+        self._shutdown = False
         self._enabled = os.environ.get(
             LANGFUSE_MEDIA_UPLOAD_ENABLED, "True"
         ).lower() not in ("false", "0")
@@ -53,9 +56,15 @@ class MediaManager:
         httpx_client: httpx.Client,
         media_upload_queue: Queue,
     ) -> None:
-        self._api_client = api_client
-        self._httpx_client = httpx_client
-        self._queue = media_upload_queue
+        with self._state_lock:
+            self._api_client = api_client
+            self._httpx_client = httpx_client
+            self._queue = media_upload_queue
+            self._shutdown = False
+
+    def begin_shutdown(self) -> None:
+        with self._state_lock:
+            self._shutdown = True
 
     def process_next_media_upload(self) -> None:
         try:
@@ -98,6 +107,13 @@ class MediaManager:
     ) -> Any:
         if not self._enabled:
             return data
+
+        with self._state_lock:
+            if self._shutdown:
+                logger.warning(
+                    "Media: Skipping upload because the Langfuse client has already been shut down."
+                )
+                return data
 
         seen = set()
         max_levels = 10
@@ -279,10 +295,17 @@ class MediaManager:
                 field=field,
             )
 
-            self._queue.put(
-                item=upload_media_job,
-                block=False,
-            )
+            with self._state_lock:
+                if self._shutdown:
+                    logger.warning(
+                        f"Media: Skipping upload for media_id={media._media_id} because the Langfuse client has already been shut down."
+                    )
+                    return
+
+                self._queue.put(
+                    item=upload_media_job,
+                    block=False,
+                )
             logger.debug(
                 f"Queue: Enqueued media ID {media._media_id} for upload processing | trace_id={trace_id} | field={field}"
             )

--- a/tests/unit/test_resource_manager.py
+++ b/tests/unit/test_resource_manager.py
@@ -20,11 +20,14 @@ from langfuse.types import MaskOtelSpansResult
 class NoOpSpanExporter(SpanExporter):
     """Minimal exporter used to verify configuration propagation."""
 
+    def __init__(self) -> None:
+        self.shutdown_count = 0
+
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         return SpanExportResult.SUCCESS
 
     def shutdown(self) -> None:
-        pass
+        self.shutdown_count += 1
 
 
 def test_get_client_preserves_all_settings(monkeypatch):
@@ -170,6 +173,109 @@ def test_media_upload_consumer_signal_shutdown_wakes_blocked_thread():
     consumer.join(timeout=0.5)
 
     assert not consumer.is_alive()
+
+
+def test_shutdown_evicts_manager_and_rejects_stale_client_tasks(monkeypatch):
+    monkeypatch.setenv("LANGFUSE_MEDIA_UPLOAD_ENABLED", "false")
+
+    with LangfuseResourceManager._lock:
+        LangfuseResourceManager._instances.clear()
+
+    old_exporter = NoOpSpanExporter()
+    settings = {
+        "public_key": "pk-shutdown-reinit",
+        "secret_key": "sk-shutdown-reinit",
+        "span_exporter": old_exporter,
+    }
+    first_client = Langfuse(**settings)
+    stale_client = Langfuse(**settings)
+    old_manager = first_client._resources
+
+    assert old_manager is not None
+    assert stale_client._resources is old_manager
+
+    first_client.shutdown()
+
+    assert old_manager._shutdown
+    assert settings["public_key"] not in LangfuseResourceManager._instances
+    assert not old_manager._ingestion_consumers[0].is_alive()
+    assert old_exporter.shutdown_count == 1
+
+    stale_client.create_score(name="quality", value=1.0)
+    stale_client._create_trace_tags_via_ingestion(
+        trace_id="0" * 32,
+        tags=["after-shutdown"],
+    )
+
+    assert old_manager._score_ingestion_queue.unfinished_tasks == 0
+    stale_client.shutdown()
+
+    fresh_client = Langfuse(
+        public_key=settings["public_key"],
+        secret_key=settings["secret_key"],
+        span_exporter=NoOpSpanExporter(),
+    )
+    fresh_manager = fresh_client._resources
+
+    assert fresh_manager is not None
+    assert fresh_manager is not old_manager
+    assert fresh_manager._ingestion_consumers[0].is_alive()
+
+    fresh_client.shutdown()
+
+
+def test_shutdown_rejects_stale_media_tasks(monkeypatch):
+    monkeypatch.setenv("LANGFUSE_MEDIA_UPLOAD_ENABLED", "true")
+
+    with LangfuseResourceManager._lock:
+        LangfuseResourceManager._instances.clear()
+
+    client = Langfuse(
+        public_key="pk-media-shutdown",
+        secret_key="sk-media-shutdown",
+        span_exporter=NoOpSpanExporter(),
+    )
+    manager = client._resources
+    assert manager is not None
+
+    client.shutdown()
+
+    data_uri = "data:text/plain;base64,SGVsbG8="
+    processed = manager._media_manager._find_and_process_media(
+        data=data_uri,
+        trace_id="0" * 32,
+        observation_id="0" * 16,
+        field="input",
+    )
+
+    assert processed == data_uri
+    assert manager._media_upload_queue.unfinished_tasks == 0
+
+
+def test_reset_handles_shutdown_eviction(monkeypatch):
+    monkeypatch.setenv("LANGFUSE_MEDIA_UPLOAD_ENABLED", "false")
+
+    with LangfuseResourceManager._lock:
+        LangfuseResourceManager._instances.clear()
+
+    first_client = Langfuse(
+        public_key="pk-reset-first",
+        secret_key="sk-reset-first",
+        span_exporter=NoOpSpanExporter(),
+    )
+    second_client = Langfuse(
+        public_key="pk-reset-second",
+        secret_key="sk-reset-second",
+        span_exporter=NoOpSpanExporter(),
+    )
+
+    LangfuseResourceManager.reset()
+
+    assert LangfuseResourceManager._instances == {}
+    assert first_client._resources is not None
+    assert first_client._resources._shutdown
+    assert second_client._resources is not None
+    assert second_client._resources._shutdown
 
 
 def test_at_fork_reinit_creates_new_queues_and_consumers(monkeypatch):


### PR DESCRIPTION
## Summary

- evict shut-down resource managers so a same-key client can initialize fresh workers
- reject stale score, trace, and media queue admission after shutdown begins
- make shutdown idempotent, retire the old span processor, and keep reset safe during eviction
- add regression coverage for stale wrappers, media admission, fresh reconstruction, and reset

## Root cause

`LangfuseResourceManager` was cached by public key after shutdown. Existing wrappers could enqueue work after its consumers had stopped, leaving `Queue.unfinished_tasks` non-zero and causing a later `flush()` or `shutdown()` to block forever in `Queue.join()`.

## User impact

Independent application or pytest instances using the same public key can now shut down without deadlocking. A client constructed after shutdown receives a fresh resource manager with live workers; stale wrappers drop asynchronous work with a warning instead of queueing work that cannot be consumed.

## Validation

- `LANGFUSE_PUBLIC_KEY=test-public-key LANGFUSE_SECRET_KEY=test-secret-key LANGFUSE_BASE_URL=http://localhost:9 UV_CACHE_DIR=/tmp/langfuse-python-uv-cache bash scripts/codex/quick-check.sh` (677 passed, 2 skipped)
- `UV_CACHE_DIR=/tmp/langfuse-python-uv-cache uv run --frozen pytest tests/unit/test_media.py -q` (19 passed)
- bounded reproduction now reports `unfinished 0`, creates a fresh manager with a live consumer, and returns from shutdown

Linear: [LFE-14771](https://linear.app/clickhouse/issue/LFE-14771/langfuseshutdown-hangs-forever-on-score-ingestion-queuejoin-cached)

Closes #1799

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents stale shared resource managers from accepting asynchronous work after shutdown and allows same-key clients to reconstruct fresh workers.
- Evicts shut-down managers from the singleton cache and makes shutdown idempotent.
- Synchronizes score, trace, and media queue admission with shutdown state.
- Retires the manager-owned span processor and keeps reset and fork reinitialization lifecycle-safe.
- Adds regression coverage for stale clients, media admission, reconstruction, reset, and exporter shutdown.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with shutdown admission and resource reconstruction consistently synchronized across the changed paths.

Shutdown now marks and evicts the old manager before draining work, stale score, trace, and media producers reject new queue entries, and subsequent same-key clients receive newly initialized workers.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Shared active resource manager] --> B[Client calls shutdown]
  B --> C[Mark manager and media pipeline shut down]
  C --> D[Evict manager from singleton cache]
  D --> E[Flush existing queues]
  E --> F[Stop consumer threads and span processor]
  C --> G[Stale wrapper submits asynchronous work]
  G --> H[Drop work with warning]
  D --> I[New same-key client is constructed]
  I --> J[Create fresh manager with live workers]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(resource-manager): prevent shutdown ..."](https://github.com/langfuse/langfuse-python/commit/685d7f79b10da72a47c50d28d4be2e3b17cce38f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50836109)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Client Core](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/client-core.md)
- Knowledge Base — [Task Manager: Media Upload and Score Ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/task-manager.md)
- Knowledge Base — [OTel Span Processing and Export Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/otel-pipeline.md)
</details>

<!-- /greptile_comment -->