### PR TITLE
fix(otel): preserve external observation type on update

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1548,6 +1548,7 @@ class Langfuse:
                 langfuse_client=self,
                 environment=self._environment,
                 release=self._release,
+                set_observation_type=False,
             )
 
             if name:
@@ -1604,6 +1605,7 @@ class Langfuse:
                 langfuse_client=self,
                 environment=self._environment,
                 release=self._release,
+                set_observation_type=False,
             )
 
             span.set_trace_io(
@@ -1638,6 +1640,7 @@ class Langfuse:
                 otel_span=current_otel_span,
                 langfuse_client=self,
                 environment=self._environment,
+                set_observation_type=False,
             )
 
             span.set_trace_as_public()

--- a/langfuse/_client/span.py
+++ b/langfuse/_client/span.py
@@ -96,6 +96,7 @@ class LangfuseObservationWrapper:
         usage_details: Optional[Dict[str, int]] = None,
         cost_details: Optional[Dict[str, float]] = None,
         prompt: Optional[PromptClient] = None,
+        set_observation_type: bool = True,
     ):
         """Initialize a new Langfuse span wrapper.
 
@@ -120,11 +121,15 @@ class LangfuseObservationWrapper:
             usage_details: Token usage information (e.g., prompt_tokens, completion_tokens)
             cost_details: Cost information for the model call
             prompt: Associated prompt template from Langfuse prompt management
+            set_observation_type: Whether to write the Langfuse observation type to
+                the wrapped OpenTelemetry span
         """
         self._otel_span = otel_span
-        self._otel_span.set_attribute(
-            LangfuseOtelSpanAttributes.OBSERVATION_TYPE, as_type
-        )
+        self._set_observation_type = set_observation_type
+        if self._set_observation_type:
+            self._otel_span.set_attribute(
+                LangfuseOtelSpanAttributes.OBSERVATION_TYPE, as_type
+            )
         self._langfuse_client = langfuse_client
         self._observation_type = as_type
 
@@ -727,6 +732,9 @@ class LangfuseObservationWrapper:
                 ),
             )
 
+        if not self._set_observation_type:
+            attributes.pop(LangfuseOtelSpanAttributes.OBSERVATION_TYPE, None)
+
         self._otel_span.set_attributes(attributes=attributes)
         # Set OTEL span status if level is ERROR
         self._set_otel_span_status_if_error(level=level, status_message=status_message)
@@ -1286,6 +1294,7 @@ class LangfuseSpan(LangfuseObservationWrapper):
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        set_observation_type: bool = True,
     ):
         """Initialize a new LangfuseSpan.
 
@@ -1300,6 +1309,8 @@ class LangfuseSpan(LangfuseObservationWrapper):
             version: Version identifier for the code or component
             level: Importance level of the span (info, warning, error)
             status_message: Optional status message for the span
+            set_observation_type: Whether to write the Langfuse observation type to
+                the wrapped OpenTelemetry span
         """
         super().__init__(
             otel_span=otel_span,
@@ -1313,6 +1324,7 @@ class LangfuseSpan(LangfuseObservationWrapper):
             version=version,
             level=level,
             status_message=status_message,
+            set_observation_type=set_observation_type,
         )
 
 
@@ -1343,6 +1355,7 @@ class LangfuseGeneration(LangfuseObservationWrapper):
         usage_details: Optional[Dict[str, int]] = None,
         cost_details: Optional[Dict[str, float]] = None,
         prompt: Optional[PromptClient] = None,
+        set_observation_type: bool = True,
     ):
         """Initialize a new LangfuseGeneration span.
 
@@ -1363,6 +1376,8 @@ class LangfuseGeneration(LangfuseObservationWrapper):
             usage_details: Token usage information (e.g., prompt_tokens, completion_tokens)
             cost_details: Cost information for the model call
             prompt: Associated prompt template from Langfuse prompt management
+            set_observation_type: Whether to write the Langfuse observation type to
+                the wrapped OpenTelemetry span
         """
         super().__init__(
             as_type="generation",
@@ -1382,6 +1397,7 @@ class LangfuseGeneration(LangfuseObservationWrapper):
             usage_details=usage_details,
             cost_details=cost_details,
             prompt=prompt,
+            set_observation_type=set_observation_type,
         )
 
 
@@ -1401,6 +1417,7 @@ class LangfuseEvent(LangfuseObservationWrapper):
         version: Optional[str] = None,
         level: Optional[SpanLevel] = None,
         status_message: Optional[str] = None,
+        set_observation_type: bool = True,
     ):
         """Initialize a new LangfuseEvent span.
 
@@ -1415,6 +1432,8 @@ class LangfuseEvent(LangfuseObservationWrapper):
             version: Version identifier for the model or component
             level: Importance level of the generation (info, warning, error)
             status_message: Optional status message for the generation
+            set_observation_type: Whether to write the Langfuse observation type to
+                the wrapped OpenTelemetry span
         """
         super().__init__(
             otel_span=otel_span,
@@ -1428,6 +1447,7 @@ class LangfuseEvent(LangfuseObservationWrapper):
             version=version,
             level=level,
             status_message=status_message,
+            set_observation_type=set_observation_type,
         )
 
     def update(

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -374,6 +374,19 @@ class TestBasicSpans(TestOTelBase):
         )
         assert len(original_spans) == 0, "Expected no spans with original name"
 
+    def test_update_current_span_preserves_third_party_observation_type(
+        self, langfuse_client, tracer_provider
+    ):
+        tracer = tracer_provider.get_tracer("openinference.instrumentation.agno")
+
+        with tracer.start_as_current_span("third-party-agent") as span:
+            span.set_attribute("openinference.span.kind", "AGENT")
+
+            langfuse_client.update_current_span(metadata={"user_id": "u1"})
+
+            assert LangfuseOtelSpanAttributes.OBSERVATION_TYPE not in span.attributes
+            assert span.attributes["langfuse.observation.metadata.user_id"] == "u1"
+
     def test_span_attributes(self, langfuse_client, memory_exporter):
         """Test that span attributes are correctly set and updated."""
         # Create a span with attributes


### PR DESCRIPTION
## What

Prevent `update_current_span()` and trace-level helper wrappers from writing a fallback `langfuse.observation.type` onto an existing OpenTelemetry span. Third-party instrumentation can therefore retain its own observation classification while still receiving Langfuse metadata and other updates.

Adds a regression test using an OpenInference instrumentation scope and `openinference.span.kind=AGENT`.

Linear: [LFE-14798](https://linear.app/clickhouse/issue/LFE-14798/bugsdk-python-update-current-span-overwrites-third-party-observation)
Source report: [langfuse/langfuse#15814](https://github.com/langfuse/langfuse/issues/15814)

## Verification

- `UV_CACHE_DIR=/tmp/langfuse-python-uv-cache uv run --frozen ruff check .`
- `UV_CACHE_DIR=/tmp/langfuse-python-uv-cache uv run --frozen mypy langfuse --no-error-summary`
- `UV_CACHE_DIR=/tmp/langfuse-python-uv-cache uv run --frozen pytest tests/unit/test_otel.py` (66 passed, 2 skipped)