### PR TITLE
fix(otel): keep last duplicate span in masking batches

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -222,7 +222,7 @@ class Langfuse:
 
             The hook receives one OpenTelemetry export batch. A batch is not guaranteed to contain a complete trace, request, or Langfuse observation tree. The hook usually runs on the OpenTelemetry batch span processor worker thread; during `flush()` and shutdown it may run on the caller thread. Keep it synchronous, deterministic, and fast.
 
-            Return `None` to leave the batch unchanged. Return `MaskOtelSpansResult` with `OtelSpanPatch` values to delete or replace attributes on selected spans. If the hook raises or returns an invalid batch result, Langfuse drops the whole export batch. If one returned span patch is invalid, Langfuse drops only that span from the Langfuse export.
+            Return `None` to leave the batch unchanged. Return `MaskOtelSpansResult` with `OtelSpanPatch` values to delete or replace attributes on selected spans. If a batch contains duplicate trace and span identifiers, Langfuse keeps only the last matching span. If the hook raises or returns an invalid batch result, Langfuse drops the whole export batch. If one returned span patch is invalid, Langfuse drops only that span from the Langfuse export.
 
             Example:
                 ```python

--- a/langfuse/_client/span_exporter.py
+++ b/langfuse/_client/span_exporter.py
@@ -267,7 +267,6 @@ class LangfuseTransformingSpanExporter(SpanExporter):
         span_attributes_by_identifier: Dict[
             OtelSpanIdentifier, tuple[ReadableSpan, Dict[str, AttributeValue]]
         ] = {}
-        duplicate_span_count = 0
 
         for span, attributes in span_attributes:
             if not _has_valid_span_context(span):
@@ -280,7 +279,6 @@ class LangfuseTransformingSpanExporter(SpanExporter):
             identifier = _create_otel_span_identifier(span)
 
             if identifier in span_attributes_by_identifier:
-                duplicate_span_count += 1
                 span_attributes_by_identifier.pop(identifier)
 
             span_attributes_by_identifier[identifier] = (span, attributes)

--- a/langfuse/_client/span_exporter.py
+++ b/langfuse/_client/span_exporter.py
@@ -264,10 +264,10 @@ class LangfuseTransformingSpanExporter(SpanExporter):
         span_attributes: Sequence[tuple[ReadableSpan, Dict[str, AttributeValue]]],
     ) -> Optional[list[tuple[ReadableSpan, Dict[str, AttributeValue]]]]:
         mask_otel_spans = cast(MaskOtelSpansFunction, self._mask_otel_spans)
-        maskable_span_attributes: list[
-            tuple[ReadableSpan, Dict[str, AttributeValue]]
-        ] = []
-        span_data_by_identifier: Dict[OtelSpanIdentifier, OtelSpanData] = {}
+        span_attributes_by_identifier: Dict[
+            OtelSpanIdentifier, tuple[ReadableSpan, Dict[str, AttributeValue]]
+        ] = {}
+        duplicate_span_count = 0
 
         for span, attributes in span_attributes:
             if not _has_valid_span_context(span):
@@ -279,21 +279,31 @@ class LangfuseTransformingSpanExporter(SpanExporter):
 
             identifier = _create_otel_span_identifier(span)
 
-            if identifier in span_data_by_identifier:
-                langfuse_logger.error(
-                    "Masking error: mask_otel_spans received duplicate span identifiers. "
-                    "Dropping export batch. "
-                    f"trace_id='{identifier.trace_id}' span_id='{identifier.span_id}'"
-                )
-                return None
+            if identifier in span_attributes_by_identifier:
+                duplicate_span_count += 1
+                span_attributes_by_identifier.pop(identifier)
 
-            span_data_by_identifier[identifier] = _create_otel_span_data(
-                span=span, attributes=attributes, identifier=identifier
+            span_attributes_by_identifier[identifier] = (span, attributes)
+
+        if duplicate_span_count:
+            langfuse_logger.warning(
+                "Masking warning: mask_otel_spans received duplicate span identifiers. "
+                "Keeping the last span for each identifier. "
+                f"duplicate_span_count={duplicate_span_count} "
+                f"remaining_span_count={len(span_attributes_by_identifier)}"
             )
-            maskable_span_attributes.append((span, attributes))
+
+        maskable_span_attributes = list(span_attributes_by_identifier.values())
 
         if not maskable_span_attributes:
             return []
+
+        span_data_by_identifier = {
+            identifier: _create_otel_span_data(
+                span=span, attributes=attributes, identifier=identifier
+            )
+            for identifier, (span, attributes) in span_attributes_by_identifier.items()
+        }
 
         try:
             result: Any = mask_otel_spans(

--- a/langfuse/_client/span_exporter.py
+++ b/langfuse/_client/span_exporter.py
@@ -285,14 +285,6 @@ class LangfuseTransformingSpanExporter(SpanExporter):
 
             span_attributes_by_identifier[identifier] = (span, attributes)
 
-        if duplicate_span_count:
-            langfuse_logger.warning(
-                "Masking warning: mask_otel_spans received duplicate span identifiers. "
-                "Keeping the last span for each identifier. "
-                f"duplicate_span_count={duplicate_span_count} "
-                f"remaining_span_count={len(span_attributes_by_identifier)}"
-            )
-
         maskable_span_attributes = list(span_attributes_by_identifier.values())
 
         if not maskable_span_attributes:

--- a/langfuse/types.py
+++ b/langfuse/types.py
@@ -126,7 +126,9 @@ class MaskOtelSpansParams:
     A single call receives one OpenTelemetry export batch, not necessarily a
     complete trace, request, or Langfuse observation tree. Batch contents depend
     on OpenTelemetry span processor settings such as `flush_at`,
-    `flush_interval`, explicit `flush()`, and shutdown.
+    `flush_interval`, explicit `flush()`, and shutdown. If a batch contains
+    duplicate trace and span identifiers, Langfuse keeps only the last matching
+    span before calling the masking function.
 
     Example:
         ```python

--- a/tests/unit/test_mask_otel_spans.py
+++ b/tests/unit/test_mask_otel_spans.py
@@ -631,6 +631,8 @@ def test_mask_otel_spans_keeps_last_duplicate_without_dropping_batch():
         ),
     ]
 
+    result = transforming_exporter.export(spans)
+
     assert result == SpanExportResult.SUCCESS
     assert len(seen_params) == 1
     assert [span.name for span in seen_params[0].spans.values()] == [
@@ -647,7 +649,6 @@ def test_mask_otel_spans_keeps_last_duplicate_without_dropping_batch():
         "attempt": 2,
         "masking.applied": True,
     }
-    assert "duplicate_span_count=1 remaining_span_count=2" in caplog.text
 
 
 def test_exporter_exception_does_not_stop_background_export_thread():

--- a/tests/unit/test_mask_otel_spans.py
+++ b/tests/unit/test_mask_otel_spans.py
@@ -574,7 +574,7 @@ def test_mask_otel_spans_drops_contextless_spans_without_dropping_batch(caplog):
     )
 
 
-def test_mask_otel_spans_keeps_last_duplicate_without_dropping_batch(caplog):
+def test_mask_otel_spans_keeps_last_duplicate_without_dropping_batch():
     exporter = InMemorySpanExporter()
     seen_params: list[MaskOtelSpansParams] = []
 
@@ -630,9 +630,6 @@ def test_mask_otel_spans_keeps_last_duplicate_without_dropping_batch(caplog):
             attributes={"attempt": 2},
         ),
     ]
-
-    with caplog.at_level(logging.WARNING, logger="langfuse"):
-        result = transforming_exporter.export(spans)
 
     assert result == SpanExportResult.SUCCESS
     assert len(seen_params) == 1

--- a/tests/unit/test_mask_otel_spans.py
+++ b/tests/unit/test_mask_otel_spans.py
@@ -574,6 +574,85 @@ def test_mask_otel_spans_drops_contextless_spans_without_dropping_batch(caplog):
     )
 
 
+def test_mask_otel_spans_keeps_last_duplicate_without_dropping_batch(caplog):
+    exporter = InMemorySpanExporter()
+    seen_params: list[MaskOtelSpansParams] = []
+
+    def mask_otel_spans(*, params: MaskOtelSpansParams):
+        seen_params.append(params)
+        duplicate_identifier = next(
+            identifier
+            for identifier, span in params.spans.items()
+            if span.name == "duplicate-last"
+        )
+
+        return MaskOtelSpansResult(
+            span_patches={
+                duplicate_identifier: OtelSpanPatch(
+                    set_attributes={"masking.applied": True}
+                )
+            }
+        )
+
+    transforming_exporter = span_exporter_module.LangfuseTransformingSpanExporter(
+        exporter=exporter,
+        media_manager=None,
+        mask_otel_spans=mask_otel_spans,
+    )
+    duplicate_context = SpanContext(
+        trace_id=1,
+        span_id=2,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        trace_state=TraceState(),
+    )
+    unrelated_context = SpanContext(
+        trace_id=3,
+        span_id=4,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        trace_state=TraceState(),
+    )
+    spans = [
+        ReadableSpan(
+            name="duplicate-first",
+            context=duplicate_context,
+            attributes={"attempt": 1},
+        ),
+        ReadableSpan(
+            name="unrelated",
+            context=unrelated_context,
+            attributes={"unrelated": True},
+        ),
+        ReadableSpan(
+            name="duplicate-last",
+            context=duplicate_context,
+            attributes={"attempt": 2},
+        ),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="langfuse"):
+        result = transforming_exporter.export(spans)
+
+    assert result == SpanExportResult.SUCCESS
+    assert len(seen_params) == 1
+    assert [span.name for span in seen_params[0].spans.values()] == [
+        "unrelated",
+        "duplicate-last",
+    ]
+
+    exported_spans = exporter.get_finished_spans()
+    assert [span.name for span in exported_spans] == [
+        "unrelated",
+        "duplicate-last",
+    ]
+    assert exported_spans[1].attributes == {
+        "attempt": 2,
+        "masking.applied": True,
+    }
+    assert "duplicate_span_count=1 remaining_span_count=2" in caplog.text
+
+
 def test_exporter_exception_does_not_stop_background_export_thread():
     exporter = FailsOnceSpanExporter()
     media_manager, _ = _media_manager()


### PR DESCRIPTION
## What changed

- keep the last span when a `mask_otel_spans` export batch contains duplicate `(trace_id, span_id)` identifiers
- preserve unrelated spans and apply masking patches to the retained duplicate
- emit one warning with duplicate and remaining-span counts
- document the keep-last masking contract
- add exporter-local regression coverage

## Why

The masking hook exposes each batch as a mapping keyed by trace and span ID. Previously, one duplicate identifier caused the SDK to report export success without calling the underlying exporter, silently dropping the entire batch. Replay-safe deterministic instrumentation such as Temporal workflows can legitimately produce this condition.

Linear: [LFE-14818](https://linear.app/clickhouse/issue/LFE-14818/fixsdk-python-keep-last-duplicate-otel-span-in-masking-batches)

## Validation

- `uv run --frozen pytest -q tests/unit/test_mask_otel_spans.py` — 51 passed
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen mypy langfuse --no-error-summary`
- commit pre-commit hooks: ruff check, ruff format, mypy

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes OpenTelemetry masking batches to retain the last span for each duplicate trace/span identifier instead of dropping the entire batch.

- Deduplicates valid spans before invoking the masking callback.
- Preserves unrelated spans and applies masking patches to retained duplicates.
- Emits one aggregate warning with duplicate and remaining-span counts.
- Documents and tests the keep-last callback contract.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no concrete blocking or independently actionable non-blocking issue was identified.

The new path deterministically retains the final valid span for each duplicate identifier, preserves unrelated spans, applies patches to the retained span, and exports the resulting batch as documented.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[OTel export batch] --> B[Process span attributes and media]
  B --> C[Discard spans with invalid context]
  C --> D[Key spans by trace ID and span ID]
  D --> E{Duplicate identifier?}
  E -->|Yes| F[Replace prior entry with last span]
  E -->|No| G[Retain span]
  F --> H[Emit aggregate warning]
  G --> I[Build masking callback parameters]
  H --> I
  I --> J[Apply returned patches]
  J --> K[Clone retained spans]
  K --> L[Underlying exporter]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): keep last duplicate span in m..."](https://github.com/langfuse/langfuse-python/commit/e49d8abb4c6321429ad1a4f94cc09573998abccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50755957)</sub>

**Context used:**

- Knowledge Base — [OTel Span Processing and Export Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/otel-pipeline.md)
- Knowledge Base — [Utils and Support Types](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/utils-support.md)

<!-- /greptile_comment -->