### PR TITLE
fix(openai): treat openai Omit sentinels like NotGiven when logging

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -32,7 +32,8 @@ from datetime import datetime
 from inspect import isawaitable, isclass
 from typing import Any, Optional, cast
 
-from openai._types import NotGiven, Omit
+from openai import _types as openai_types
+from openai._types import NotGiven
 from packaging.version import Version
 from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
@@ -59,6 +60,13 @@ try:
     from openai._constants import RAW_RESPONSE_HEADER
 except ImportError:
     RAW_RESPONSE_HEADER = "X-Stainless-Raw-Response"
+
+_openai_omit_type = getattr(openai_types, "Omit", None)
+_OPENAI_UNSET_TYPES: tuple[type[Any], ...] = (
+    (NotGiven, _openai_omit_type)
+    if isinstance(_openai_omit_type, type)
+    else (NotGiven,)
+)
 
 
 @dataclass
@@ -207,7 +215,7 @@ _STRUCTURED_OUTPUT_METADATA_FIELDS = ("response_format", "text_format")
 
 
 def _is_not_given(value: Any) -> bool:
-    return isinstance(value, (NotGiven, Omit))
+    return isinstance(value, _OPENAI_UNSET_TYPES)
 
 
 def _get_attr_or_item(value: Any, key: str, default: Any = None) -> Any:

--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -32,7 +32,7 @@ from datetime import datetime
 from inspect import isawaitable, isclass
 from typing import Any, Optional, cast
 
-from openai._types import NotGiven
+from openai._types import NotGiven, Omit
 from packaging.version import Version
 from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
@@ -207,7 +207,7 @@ _STRUCTURED_OUTPUT_METADATA_FIELDS = ("response_format", "text_format")
 
 
 def _is_not_given(value: Any) -> bool:
-    return isinstance(value, NotGiven)
+    return isinstance(value, (NotGiven, Omit))
 
 
 def _get_attr_or_item(value: Any, key: str, default: Any = None) -> Any:
@@ -356,13 +356,13 @@ def _extract_responses_prompt(kwargs: Any) -> Any:
     for key in _RESPONSES_PROMPT_FIELDS:
         value = kwargs.get(key, None)
 
-        if value is not None and not isinstance(value, NotGiven):
+        if value is not None and not _is_not_given(value):
             prompt_fields[key] = _serialize_openai_value(value)
 
-    if isinstance(input_value, NotGiven):
+    if _is_not_given(input_value):
         input_value = None
 
-    if isinstance(instructions, NotGiven):
+    if _is_not_given(instructions):
         instructions = None
 
     if instructions is None:
@@ -395,14 +395,11 @@ def _extract_chat_prompt(kwargs: Any) -> Any:
     """Extracts the user input from prompts. Returns an array of messages or dict with messages and functions"""
     prompt = {}
 
-    if kwargs.get("functions") is not None:
-        prompt.update({"functions": kwargs["functions"]})
+    for key in ("functions", "function_call", "tools"):
+        value = kwargs.get(key)
 
-    if kwargs.get("function_call") is not None:
-        prompt.update({"function_call": kwargs["function_call"]})
-
-    if kwargs.get("tools") is not None:
-        prompt.update({"tools": kwargs["tools"]})
+        if value is not None and not _is_not_given(value):
+            prompt.update({key: value})
 
     if prompt:
         # uf user provided functions, we need to send these together with messages to langfuse
@@ -533,7 +530,7 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
     metadata = kwargs.get("metadata", {})
     if (
         metadata is not None
-        and not isinstance(metadata, NotGiven)
+        and not _is_not_given(metadata)
         and not isinstance(metadata, dict)
     ):
         if isinstance(metadata, BaseModel):
@@ -556,63 +553,61 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
 
     parsed_temperature = (
         kwargs.get("temperature", 1)
-        if not isinstance(kwargs.get("temperature", 1), NotGiven)
+        if not _is_not_given(kwargs.get("temperature", 1))
         else 1
     )
 
     parsed_max_tokens = (
         kwargs.get("max_tokens", float("inf"))
-        if not isinstance(kwargs.get("max_tokens", float("inf")), NotGiven)
+        if not _is_not_given(kwargs.get("max_tokens", float("inf")))
         else float("inf")
     )
 
     parsed_max_completion_tokens = (
         kwargs.get("max_completion_tokens", None)
-        if not isinstance(kwargs.get("max_completion_tokens", float("inf")), NotGiven)
+        if not _is_not_given(kwargs.get("max_completion_tokens", float("inf")))
         else None
     )
 
     parsed_top_p = (
-        kwargs.get("top_p", 1)
-        if not isinstance(kwargs.get("top_p", 1), NotGiven)
-        else 1
+        kwargs.get("top_p", 1) if not _is_not_given(kwargs.get("top_p", 1)) else 1
     )
 
     parsed_frequency_penalty = (
         kwargs.get("frequency_penalty", 0)
-        if not isinstance(kwargs.get("frequency_penalty", 0), NotGiven)
+        if not _is_not_given(kwargs.get("frequency_penalty", 0))
         else 0
     )
 
     parsed_presence_penalty = (
         kwargs.get("presence_penalty", 0)
-        if not isinstance(kwargs.get("presence_penalty", 0), NotGiven)
+        if not _is_not_given(kwargs.get("presence_penalty", 0))
         else 0
     )
 
     parsed_seed = (
         kwargs.get("seed", None)
-        if not isinstance(kwargs.get("seed", None), NotGiven)
+        if not _is_not_given(kwargs.get("seed", None))
         else None
     )
 
-    parsed_n = kwargs.get("n", 1) if not isinstance(kwargs.get("n", 1), NotGiven) else 1
+    parsed_n = kwargs.get("n", 1) if not _is_not_given(kwargs.get("n", 1)) else 1
 
     parsed_service_tier = (
         kwargs.get("service_tier", None)
-        if not isinstance(kwargs.get("service_tier", None), NotGiven)
+        if not _is_not_given(kwargs.get("service_tier", None))
         else None
     )
 
     if resource.type == "embedding":
         parsed_dimensions = (
             kwargs.get("dimensions", None)
-            if not isinstance(kwargs.get("dimensions", None), NotGiven)
+            if not _is_not_given(kwargs.get("dimensions", None))
             else None
         )
         parsed_encoding_format = (
             kwargs.get("encoding_format", "float")
-            if not isinstance(kwargs.get("encoding_format", "float"), NotGiven)
+            if not _is_not_given(kwargs.get("encoding_format", "float"))
             else "float"
         )
 
@@ -1195,7 +1190,7 @@ def _get_raw_response_mode(kwargs: Any) -> Optional[str]:
     """
     extra_headers = kwargs.get("extra_headers", None)
 
-    if extra_headers is None or isinstance(extra_headers, NotGiven):
+    if extra_headers is None or _is_not_given(extra_headers):
         return None
 
     try:

--- a/tests/unit/test_openai_prompt_extraction.py
+++ b/tests/unit/test_openai_prompt_extraction.py
@@ -11,13 +11,18 @@ try:
 except ImportError:
     from openai._types import NOT_GIVEN
 
+from openai._types import Omit
+
 from langfuse.openai import (
     OpenAiArgsExtractor,
     OpenAiDefinition,
+    _extract_chat_prompt,
     _extract_responses_prompt,
     _get_langfuse_data_from_kwargs,
     _serialize_openai_value,
 )
+
+OMIT = Omit()
 
 
 @pytest.mark.parametrize(
@@ -51,6 +56,22 @@ from langfuse.openai import (
         ),
         ({"instructions": NOT_GIVEN, "input": "Hello!"}, "Hello!"),
         ({"instructions": NOT_GIVEN, "input": NOT_GIVEN}, None),
+        (
+            {"instructions": "You are helpful.", "input": OMIT},
+            {"instructions": "You are helpful."},
+        ),
+        ({"instructions": OMIT, "input": "Hello!"}, "Hello!"),
+        ({"instructions": OMIT, "input": OMIT}, None),
+        (
+            {
+                "instructions": OMIT,
+                "input": "Hello!",
+                "tool_choice": OMIT,
+                "parallel_tool_calls": OMIT,
+                "tools": OMIT,
+            },
+            "Hello!",
+        ),
         (
             {
                 "input": "Search for the weather in Berlin.",
@@ -193,6 +214,64 @@ def test_store_preserves_user_structured_output_metadata_keys_for_openai():
 
     assert openai_args["metadata"] == metadata
     assert openai_args["metadata"] is not metadata
+
+
+def test_serialize_openai_value_treats_omit_as_not_given():
+    assert _serialize_openai_value(OMIT) is None
+    assert _serialize_openai_value({"tool_choice": OMIT, "keep": 1}) == {"keep": 1}
+
+
+@pytest.mark.parametrize("sentinel", [NOT_GIVEN, OMIT], ids=["not_given", "omit"])
+def test_extract_chat_prompt_excludes_unset_sentinel_tool_fields(sentinel):
+    messages = [{"role": "user", "content": "Hello!"}]
+
+    prompt = _extract_chat_prompt(
+        {
+            "messages": messages,
+            "functions": sentinel,
+            "function_call": sentinel,
+            "tools": sentinel,
+        }
+    )
+
+    assert prompt == messages
+
+
+@pytest.mark.parametrize("sentinel", [NOT_GIVEN, OMIT], ids=["not_given", "omit"])
+def test_unset_sentinel_kwargs_do_not_leak_into_langfuse_data(sentinel):
+    resource = OpenAiDefinition(
+        module="",
+        object="Completions",
+        method="create",
+        type="chat",
+        sync=True,
+    )
+    args = OpenAiArgsExtractor(
+        model="gpt-4.1",
+        messages=[{"role": "user", "content": "Hello!"}],
+        metadata=sentinel,
+        temperature=sentinel,
+        top_p=sentinel,
+        max_tokens=sentinel,
+        frequency_penalty=sentinel,
+        presence_penalty=sentinel,
+        seed=sentinel,
+        n=sentinel,
+        service_tier=sentinel,
+        tools=sentinel,
+    ).get_langfuse_args()
+
+    langfuse_data = _get_langfuse_data_from_kwargs(resource, args)
+
+    assert langfuse_data["input"] == [{"role": "user", "content": "Hello!"}]
+    assert langfuse_data["metadata"] is None
+    assert langfuse_data["model_parameters"] == {
+        "temperature": 1,
+        "max_tokens": float("inf"),
+        "top_p": 1,
+        "frequency_penalty": 0,
+        "presence_penalty": 0,
+    }
 
 
 def test_store_does_not_forward_instrumentation_structured_output_metadata():

--- a/tests/unit/test_openai_prompt_extraction.py
+++ b/tests/unit/test_openai_prompt_extraction.py
@@ -27,26 +27,6 @@ from langfuse.openai import (
 OMIT = Omit()
 
 
-def test_openai_integration_does_not_require_omit_type():
-    script = "; ".join(
-        (
-            "import importlib",
-            "import openai._types",
-            "import langfuse.openai",
-            "del openai._types.Omit",
-            "importlib.reload(langfuse.openai)",
-        )
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stderr
-
-
 @pytest.mark.parametrize(
     "kwargs, expected",
     [

--- a/tests/unit/test_openai_prompt_extraction.py
+++ b/tests/unit/test_openai_prompt_extraction.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
@@ -23,6 +25,26 @@ from langfuse.openai import (
 )
 
 OMIT = Omit()
+
+
+def test_openai_integration_does_not_require_omit_type():
+    script = "; ".join(
+        (
+            "import importlib",
+            "import openai._types",
+            "import langfuse.openai",
+            "del openai._types.Omit",
+            "importlib.reload(langfuse.openai)",
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_openai_prompt_extraction.py
+++ b/tests/unit/test_openai_prompt_extraction.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum


### PR DESCRIPTION
## What does this PR do?

Addresses langfuse/langfuse#10057

openai v2 ships the `Omit` sentinel alongside `NotGiven` for unset params, and callers commonly forward it: the openai-agents SDK (>= 0.4.0) passes `Omit` for unset params such as `temperature`, `top_p`, `tool_choice`, `parallel_tool_calls`, and `instructions` (see `_non_null_or_omit` in `agents/models/openai_responses.py`), and langchain-openai does too (the linked issue reproduces with langchain-openai + openai 2.6.1, no agents SDK involved). The `isinstance(metadata, NotGiven)` TypeError crash in the linked issue's traceback is already guarded on current main; what remains is that the OpenAI instrumentation only filtered `NotGiven`, so `Omit` sentinels leaked into logged generations as junk like `"<openai.Omit object at 0x...>"` (str-repr paths) or `{}` (EventSerializer output):

- `_extract_responses_prompt`: an `Omit` `instructions` fabricated a system message whose content was the `Omit` repr; `Omit` `tool_choice` / `parallel_tool_calls` / `tools` / `input` leaked into the logged input.
- Model-parameter extraction in `_get_langfuse_data_from_kwargs`: `Omit` `temperature`, `top_p`, etc. were logged as sentinel objects instead of falling back to defaults.
- `_serialize_openai_value` / metadata handling: `Omit` serialized to its `str()` repr.
- `_extract_chat_prompt` (Chat Completions path): `functions` / `function_call` / `tools` were only checked against `None`, so both `NotGiven` and `Omit` sentinels leaked into the logged input.

This PR treats `Omit` exactly like `NotGiven` on all logging paths: `_is_not_given` now checks against `(NotGiven, Omit)`, all direct `isinstance(..., NotGiven)` checks route through `_is_not_given`, and `_extract_chat_prompt` filters sentinels too.

Relation to #1426: that PR only patches the metadata validation path in `_get_langfuse_data_from_kwargs` (which no longer raises on current main). This PR is a superset — it covers that metadata case plus the prompt/input fields, model parameters, and the chat-completions path, with unit tests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

List the main commands you ran:

```bash
uv sync --locked
uv run --frozen ruff check .            # All checks passed!
uv run --frozen ruff format .           # no-op on changed files
uv run --frozen mypy langfuse --no-error-summary  # exit 0
uv run --frozen pytest tests/unit/test_openai_prompt_extraction.py  # 23 passed (9 of the new cases fail without the fix)
uv run --frozen pytest tests/unit/test_openai.py tests/unit/test_openai_prompt_extraction.py  # 57 passed
uv run --frozen pytest -n auto --dist worksteal tests/unit  # 685 passed, 2 skipped
```

Note: `uv run --frozen ruff format --check .` flags `tests/unit/test_media.py`, but that drift pre-exists on `main` and is untouched here. e2e / live_provider suites were not run (unit-testable instrumentation change).

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the OpenAI integration’s prompt, metadata, model-parameter, serialization, and raw-response extraction paths to treat `Omit` as an unset sentinel alongside `NotGiven`.
- Centralizes both sentinel checks in `_is_not_given`.
- Filters unset tool-related fields from Responses and Chat Completions logging.
- Adds unit coverage for top-level, nested, prompt, metadata, and model-parameter handling.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until the `Omit` import is made compatible with supported older OpenAI SDK versions.

The sentinel filtering itself is consistently implemented and tested, but importing the integration now fails before its existing version-specific compatibility paths can run when `Omit` is unavailable.

**Files Needing Attention:** langfuse/openai.py
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
langfuse/openai.py:35
**Legacy SDK import breaks**

When `langfuse.openai` is imported with a supported OpenAI SDK version that predates `Omit`, the unconditional `openai._types.Omit` import raises `ImportError` before the existing version-specific compatibility paths run, preventing all OpenAI instrumentation from loading.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(openai): treat openai Omit sentinels..."](https://github.com/langfuse/langfuse-python/commit/fa50c2f8d249b1592ffedd957a302bac6dd10a18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52007112)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [OpenAI Integration (langfuse/openai.py)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/openai-integration.md)

<!-- /greptile_comment -->