### PR TITLE
fix: treat empty-string credentials as missing and skip malformed media reference segments

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -379,7 +379,7 @@ class Langfuse:
             langfuse_logger.setLevel(logging.DEBUG)
 
         public_key = public_key or os.environ.get(LANGFUSE_PUBLIC_KEY)
-        if public_key is None:
+        if not public_key:
             langfuse_logger.warning(
                 "Authentication error: Langfuse client initialized without public_key. Client will be disabled. "
                 "Provide a public_key parameter or set LANGFUSE_PUBLIC_KEY environment variable. "
@@ -388,7 +388,7 @@ class Langfuse:
             return
 
         secret_key = secret_key or os.environ.get(LANGFUSE_SECRET_KEY)
-        if secret_key is None:
+        if not secret_key:
             langfuse_logger.warning(
                 "Authentication error: Langfuse client initialized without secret_key. Client will be disabled. "
                 "Provide a secret_key parameter or set LANGFUSE_SECRET_KEY environment variable. "

--- a/langfuse/media.py
+++ b/langfuse/media.py
@@ -253,6 +253,8 @@ class LangfuseMedia:
         parsed_data = {}
 
         for pair in pairs:
+            if "=" not in pair:
+                continue
             key, value = pair.split("=", 1)
             parsed_data[key] = value
 

--- a/tests/unit/test_initialization.py
+++ b/tests/unit/test_initialization.py
@@ -7,6 +7,7 @@ environment variables work correctly for initializing the Langfuse client.
 import os
 
 import pytest
+from opentelemetry.trace import NoOpTracer
 
 from langfuse import Langfuse
 from langfuse._client.resource_manager import LangfuseResourceManager
@@ -313,3 +314,23 @@ class TestClientInitialization:
             secret_key="test_sk",
         )
         assert client2._base_url == "http://insecure.com"
+
+    def test_empty_public_key_env_disables_client(self, cleanup_env_vars, monkeypatch):
+        """Test that an empty LANGFUSE_PUBLIC_KEY env var disables the client."""
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+
+        client = Langfuse()
+
+        assert isinstance(client._otel_tracer, NoOpTracer)
+        assert client._resources is None
+
+    def test_empty_secret_key_env_disables_client(self, cleanup_env_vars, monkeypatch):
+        """Test that an empty LANGFUSE_SECRET_KEY env var disables the client."""
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "")
+
+        client = Langfuse()
+
+        assert isinstance(client._otel_tracer, NoOpTracer)
+        assert client._resources is None

--- a/tests/unit/test_media.py
+++ b/tests/unit/test_media.py
@@ -275,3 +275,28 @@ def test_init_with_urlsafe_base64_data_uri():
     assert media._content_type == "application/octet-stream"
     assert media._content_bytes == original_bytes
 
+
+def test_parse_reference_string_skips_segment_without_equals():
+    ref = "@@@langfuseMedia:type=image/jpeg|badpair|id=x|source=y@@@"
+    result = LangfuseMedia.parse_reference_string(ref)
+
+    assert result["media_id"] == "x"
+    assert result["content_type"] == "image/jpeg"
+    assert result["source"] == "y"
+
+
+def test_parse_reference_string_skips_trailing_empty_segment():
+    ref = "@@@langfuseMedia:type=image/jpeg|id=x|source=y|@@@"
+    result = LangfuseMedia.parse_reference_string(ref)
+
+    assert result["media_id"] == "x"
+    assert result["content_type"] == "image/jpeg"
+    assert result["source"] == "y"
+
+
+def test_parse_reference_string_missing_required_fields_after_skipping_malformed_pair():
+    with pytest.raises(ValueError, match="Missing required fields in reference string"):
+        LangfuseMedia.parse_reference_string(
+            "@@@langfuseMedia:type=image/jpeg|badpair@@@"
+        )
+


### PR DESCRIPTION
Fixes langfuse/langfuse#15280

## What does this PR do?

Treats empty-string credentials as missing so `Langfuse` disables itself at initialization with the existing warning instead of building a fully-wired client and failing later with an opaque auth error on the first request. An unset `LANGFUSE_PUBLIC_KEY` or `LANGFUSE_SECRET_KEY` rendered as `""` by a templated Docker/Kubernetes env file previously bypassed the `is None` guard; the guard now checks falsiness, restoring the pre-v3.0.0 behavior.

Also makes `LangfuseMedia.parse_reference_string` skip pipe-separated segments without `=`, so a malformed segment or a trailing `|` no longer raises a raw `ValueError: not enough values to unpack`. Genuinely incomplete references still raise the documented `ValueError: Missing required fields in reference string`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

```bash
pytest tests/unit/test_initialization.py tests/unit/test_media.py -q -p no:xdist
```

- 44 passed on the two touched test files.
- The 5 new regression tests fail on `main` and pass with this change.

## Checklist

- [ ] I self-reviewed the diff using `code_review.md`.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [ ] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [ ] I did not commit secrets or credentials.

Note: #1772 also addresses this issue with a broader scope; this PR keeps the change minimal and focused on the two behaviors described in the issue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes client initialization fail closed when either credential resolves to an empty string and makes media-reference parsing tolerate malformed pipe-separated segments while retaining required-field validation.

- Empty public or secret keys now produce a disabled no-op client instead of a fully initialized client that later fails authentication.
- Media-reference segments without `=` are ignored, including trailing empty segments.
- Regression tests cover both credential cases and malformed media references.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed behavior.

Empty credentials now follow the established disabled-client path, and malformed media segments are skipped without bypassing required-field validation.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: treat empty-string credentials as m..."](https://github.com/langfuse/langfuse-python/commit/8933f457fa06fa956273cfab17a7e0c215401a9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52007001)</sub>

**Context used:**

- Knowledge Base — [Client Core](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/client-core.md)
- Knowledge Base — [Media Module](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/media-module.md)

<!-- /greptile_comment -->