### PR TITLE
fix(client): route span-activation detach through safe helper

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -1339,12 +1339,20 @@ class Langfuse:
         cost_details: Optional[Dict[str, float]] = None,
         prompt: Optional[PromptClient] = None,
     ) -> Any:
-        with self._otel_tracer.start_as_current_span(
-            name=name,
-            end_on_exit=end_on_exit if end_on_exit is not None else True,
-        ) as otel_span:
-            baggage_token = None
+        # We manage span-context activation ourselves instead of using
+        # otel_tracer.start_as_current_span so that the context detach runs
+        # through _detach_context_token_safely. OTel's own detach is unguarded
+        # and logs "Failed to detach context" whenever __enter__ and __exit__
+        # straddle different async contexts (e.g. end_on_exit=False with a
+        # manual close), even though the observation is already complete.
+        otel_span = self._otel_tracer.start_span(name=name)
+        end_span = end_on_exit if end_on_exit is not None else True
+        span_context_token = otel_context_api.attach(
+            otel_trace_api.set_span_in_context(otel_span)
+        )
+        baggage_token = None
 
+        try:
             if otel_span.is_recording():
                 context_with_app_root_claim = _set_langfuse_trace_id_in_baggage(
                     trace_id=self._get_otel_trace_id(otel_span),
@@ -1356,41 +1364,54 @@ class Langfuse:
                 as_type or "generation"
             )  # default was "generation"
 
-            try:
-                common_args = {
-                    "otel_span": otel_span,
-                    "langfuse_client": self,
-                    "environment": self._environment,
-                    "release": self._release,
-                    "input": input,
-                    "output": output,
-                    "metadata": metadata,
-                    "version": version,
-                    "level": level,
-                    "status_message": status_message,
-                }
+            common_args = {
+                "otel_span": otel_span,
+                "langfuse_client": self,
+                "environment": self._environment,
+                "release": self._release,
+                "input": input,
+                "output": output,
+                "metadata": metadata,
+                "version": version,
+                "level": level,
+                "status_message": status_message,
+            }
 
-                if span_class in [
-                    LangfuseGeneration,
-                    LangfuseEmbedding,
-                ]:
-                    common_args.update(
-                        {
-                            "completion_start_time": completion_start_time,
-                            "model": model,
-                            "model_parameters": model_parameters,
-                            "usage_details": usage_details,
-                            "cost_details": cost_details,
-                            "prompt": prompt,
-                        }
+            if span_class in [
+                LangfuseGeneration,
+                LangfuseEmbedding,
+            ]:
+                common_args.update(
+                    {
+                        "completion_start_time": completion_start_time,
+                        "model": model,
+                        "model_parameters": model_parameters,
+                        "usage_details": usage_details,
+                        "cost_details": cost_details,
+                        "prompt": prompt,
+                    }
+                )
+            # For span-like types (span, agent, tool, chain, retriever, evaluator, guardrail), no generation properties needed
+
+            yield span_class(**common_args)  # type: ignore[arg-type]
+
+        except Exception as exc:
+            if otel_span.is_recording():
+                otel_span.record_exception(exc)
+                otel_span.set_status(
+                    otel_trace_api.Status(
+                        status_code=otel_trace_api.StatusCode.ERROR,
+                        description=f"{type(exc).__name__}: {exc}",
                     )
-                # For span-like types (span, agent, tool, chain, retriever, evaluator, guardrail), no generation properties needed
+                )
+            raise
 
-                yield span_class(**common_args)  # type: ignore[arg-type]
-
-            finally:
-                if baggage_token is not None:
-                    _detach_context_token_safely(baggage_token)
+        finally:
+            if baggage_token is not None:
+                _detach_context_token_safely(baggage_token)
+            _detach_context_token_safely(span_context_token)
+            if end_span:
+                otel_span.end()
 
     def _get_current_otel_span(self) -> Optional[otel_trace_api.Span]:
         current_span = otel_trace_api.get_current_span()

--- a/tests/unit/test_context_detach.py
+++ b/tests/unit/test_context_detach.py
@@ -1,0 +1,41 @@
+"""Regression tests for cross-context span detach (langfuse/langfuse#13590).
+
+`start_as_current_observation(end_on_exit=False)` lets `__enter__` and `__exit__`
+run in different execution contexts (a manual close on another asyncio task). The
+OpenTelemetry span-activation token is then detached in a context it was not
+created in, and OTel's own `context.detach` logs `Failed to detach context` on
+every such close. The Langfuse span-activation detach must go through
+`_detach_context_token_safely`, which swallows that expected mismatch.
+"""
+
+import asyncio
+import logging
+
+from langfuse import Langfuse
+
+
+def _enter_and_close_across_contexts(client: Langfuse) -> None:
+    # Attach happens here, in the current (root) context.
+    observation = client.start_as_current_observation(
+        name="cross-context-span", end_on_exit=False
+    )
+    observation.__enter__()
+
+    async def _close_on_other_task() -> None:
+        # create_task copies the context, so __exit__ (and its detach) run in a
+        # different context than the one __enter__ attached in.
+        await asyncio.create_task(_do_exit())
+
+    async def _do_exit() -> None:
+        observation.__exit__(None, None, None)
+
+    asyncio.run(_close_on_other_task())
+
+
+def test_cross_context_close_does_not_log_detach_error(
+    langfuse_memory_client: Langfuse, caplog
+) -> None:
+    with caplog.at_level(logging.ERROR, logger="opentelemetry.context"):
+        _enter_and_close_across_contexts(langfuse_memory_client)
+
+    assert "Failed to detach context" not in caplog.text


### PR DESCRIPTION
## Bug

When `start_as_current_observation(end_on_exit=False)` is closed from a different execution context than the one it opened in (normal in async code where the manual close runs on another task), the span-activation context token is detached in a context it was not created in. `_start_as_current_otel_span_with_processed_media` relied on OTel's `start_as_current_span`, whose internal `context.detach` is unguarded, so OTel logs `Failed to detach context` (`ValueError: Token was created in a different Context`) on every such close. Langfuse only guarded its own baggage token.

Fixes langfuse/langfuse#13590.

## Fix

Activate the span directly (`start_span` + `context.attach`) and detach the span-activation token through the existing `_detach_context_token_safely` helper, which was built for exactly this case and already guards the baggage token. The span is ended explicitly when `end_on_exit` is set. Exception handling matches OTel's `start_as_current_span` defaults (`record_exception` + error status), so error observations are unchanged.

## Verification

New unit test `tests/unit/test_context_detach.py` opens an observation, closes it on a copied asyncio context, and asserts no detach error is logged. Fails on `main`, passes with this change. Existing `tests/unit` otel/propagation/app-root suites stay green (221 passed, 2 skipped).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces OpenTelemetry’s unguarded current-span context manager with explicit span activation and safe token detachment, preserving exception recording and conditional span ending.

- Creates spans with `start_span` and activates them through the OTel context API.
- Routes baggage and span tokens through the existing safe-detach helper.
- Adds an async cross-context regression test for detach-error logging.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with a non-blocking test-isolation issue that should be addressed to prevent ambient span leakage between tests.

The production lifecycle change preserves the prior span behavior while safely handling cross-context detachment; only the regression test leaves stale ambient context after it returns.

**Files Needing Attention:** tests/unit/test_context_detach.py
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Langfuse
    participant Context as OTel Context
    participant Span as OTel Span
    Caller->>Langfuse: Enter current observation
    Langfuse->>Span: start_span()
    Langfuse->>Context: attach(span context)
    Langfuse-->>Caller: observation wrapper
    Caller->>Langfuse: Exit from copied async context
    Langfuse->>Context: safely detach baggage token
    Langfuse->>Context: safely detach span token
    Langfuse->>Span: end() when end_on_exit
    Note over Context: Opening context remains unchanged when exit occurs in a copy
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tests/unit/test_context_detach.py:32
**Test leaks the active span**

The observation is entered in the test's root context but exited only in a copied task context, so safe detachment cannot reset the token in the opening context. The test therefore returns with an ended span still current, making later context-sensitive tests order-dependent or assigning new observations the wrong parent.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(client): route span-activation detac..."](https://github.com/langfuse/langfuse-python/commit/fedbb53ce01e399be0b61cfdecee1eba248b3996) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52070704)</sub>

**Context used:**

- Knowledge Base — [Client Core](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/client-core.md)
- Knowledge Base — [OTel Span Processing and Export Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/otel-pipeline.md)

<!-- /greptile_comment -->