### PR TITLE
fix(serializer): handle NaN/Inf floats nested in pydantic models

### DIFF
--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -136,7 +136,11 @@ class EventSerializer(JSONEncoder):
                 if isinstance(raw := getattr(obj, "raw", None), BaseModel):
                     raw.model_rebuild()
 
-                return obj.model_dump()
+                # Recurse the dumped model back through default() so nested
+                # non-finite floats (NaN/Inf) are converted to safe strings.
+                # Returning model_dump() directly lets the json C-encoder emit
+                # bare NaN/Infinity tokens, which are invalid JSON.
+                return self.default(obj.model_dump())
 
             # if langchain is not available, the Serializable type is NoneType
             if Serializable is not type(None) and isinstance(obj, Serializable):  # type: ignore

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -196,6 +196,39 @@ def test_infinity_floats():
     assert serializer.encode(float("-inf")) == '"-Infinity"'
 
 
+def test_pydantic_model_with_non_finite_floats():
+    # Non-finite floats nested inside a pydantic model must be converted to
+    # safe string tokens rather than emitted as bare NaN/Infinity, which are
+    # invalid JSON and are rejected by the ingestion server's strict parser.
+    class ModelWithFloats(BaseModel):
+        nan: float
+        inf: float
+        neg_inf: float
+        finite: float
+
+    model = ModelWithFloats(
+        nan=float("nan"),
+        inf=float("inf"),
+        neg_inf=float("-inf"),
+        finite=1.5,
+    )
+    serializer = EventSerializer()
+    encoded = serializer.encode(model)
+
+    # Must be strict JSON: json.loads accepts bare NaN/Infinity by default, so
+    # use parse_constant to reject them the way the ingestion server does.
+    def _reject(token):
+        raise ValueError(f"invalid JSON constant emitted: {token}")
+
+    parsed = json.loads(encoded, parse_constant=_reject)
+    assert parsed == {
+        "nan": "NaN",
+        "inf": "Infinity",
+        "neg_inf": "-Infinity",
+        "finite": 1.5,
+    }
+
+
 def test_slots():
     class SlotClass:
         __slots__ = ["field"]


### PR DESCRIPTION
## What does this PR do?

`EventSerializer`'s `BaseModel` branch returned `obj.model_dump()` directly, so non-finite floats (NaN/Inf) nested inside a pydantic model skipped the NaN/Inf-to-string conversion that the manual dict/list recursion applies. Python's json C-encoder then emitted bare `NaN`/`Infinity` tokens — invalid JSON that the ingestion server's strict parser rejects. This affects the core tracing path (span input/output/metadata serialization).

Fix: recurse the dumped model back through `default()` (`return self.default(obj.model_dump())`) so nested non-finite floats get the same safe-string handling as every other path. Behavior for datetimes, enums, UUIDs, dataclasses, media refs, etc. is unchanged (they continue to flow through `default()`).

## Type of change

- [X] Bug fix

## Verification

```bash
uv sync --locked
uv run --frozen pytest tests/unit/test_serializer.py tests/unit/test_json.py   # 38 passed
uv run --frozen ruff check langfuse/_utils/serializer.py tests/unit/test_serializer.py
uv run --frozen ruff format --check langfuse/_utils/serializer.py tests/unit/test_serializer.py
uv run --frozen mypy langfuse/_utils/serializer.py --no-error-summary
```

Added regression test `test_pydantic_model_with_non_finite_floats` which fails on `main` (bare `NaN` emitted) and passes with this change.

## Checklist

- [X] I self-reviewed the diff.
- [X] I added or updated tests for behavior changes.
- [X] I did not hand-edit generated files.
- [X] I did not commit secrets or credentials.

Closes langfuse/langfuse#16048

<details><summary>Greptile Summary</summary>

The PR fixes serialization of non-finite floats inside Pydantic models by recursively normalizing `model_dump()` output before JSON encoding.

* Converts nested `NaN`, `Infinity`, and `-Infinity` values to safe string tokens.
* Adds a regression test that validates output with strict JSON parsing.

</details>

<details><summary>Confidence Score: 5/5</summary>

The PR appears safe to merge, with the changed Pydantic serialization path consistently applying the existing JSON-safe normalization.

The recursive call processes dumped model dictionaries and sequences through established serializer branches, and the regression test verifies that non-finite floats no longer reach the JSON encoder as invalid bare constants.

</details>

Reviews (1): Last reviewed commit: ["fix(serializer): handle NaN/Inf floats n..."](<https://github.com/langfuse/langfuse-python/commit/1d223bdfba100baaace4c50a6426b340e72ffcca>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=52661533>)

**Context used:**

* Knowledge Base — [Utils and Support Types](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/utils-support.md>)