### PR TITLE
fix(errors): handle non-numeric API statuses

### DIFF
--- a/langfuse/_utils/parse_error.py
+++ b/langfuse/_utils/parse_error.py
@@ -44,6 +44,16 @@ errorResponseByCode = {
 }
 
 
+def _error_response_for_status(status: Union[int, str]) -> str:
+    if isinstance(status, str):
+        try:
+            status = int(status)
+        except ValueError:
+            return defaultErrorResponse
+
+    return errorResponseByCode.get(status, defaultErrorResponse)
+
+
 def generate_error_message_fern(error: Error) -> str:
     if isinstance(error, AccessDeniedError):
         return errorResponseByCode.get(403, defaultErrorResponse)
@@ -74,19 +84,10 @@ def handle_fern_exception(exception: Error) -> None:
 
 def generate_error_message(exception: Union[APIError, APIErrors, Exception]) -> str:
     if isinstance(exception, APIError):
-        status_code = (
-            int(exception.status)
-            if isinstance(exception.status, str)
-            else exception.status
-        )
-        return f"API error occurred: {errorResponseByCode.get(status_code, defaultErrorResponse)}"
+        return f"API error occurred: {_error_response_for_status(exception.status)}"
     elif isinstance(exception, APIErrors):
         error_messages = [
-            errorResponseByCode.get(
-                int(error.status) if isinstance(error.status, str) else error.status,
-                defaultErrorResponse,
-            )
-            for error in exception.errors
+            _error_response_for_status(error.status) for error in exception.errors
         ]
         return "API errors occurred: " + "\n".join(error_messages)
     else:

--- a/tests/unit/test_error_parsing.py
+++ b/tests/unit/test_error_parsing.py
@@ -35,6 +35,32 @@ def test_generate_error_message_api_errors():
     assert expected_message in generate_error_message(exception)
 
 
+def test_generate_error_message_handles_non_numeric_api_status():
+    exception = APIError(message="Test API error", status="failed")
+
+    assert generate_error_message(exception) == (
+        "API error occurred: Unexpected error occurred. Please check your request "
+        "and contact support: https://langfuse.com/support."
+    )
+
+
+def test_generate_error_message_handles_non_numeric_batch_api_status():
+    exception = APIErrors(
+        [
+            APIError(status="failed", message="First failure"),
+            APIError(status="401", message="Unauthorized"),
+        ]
+    )
+
+    assert generate_error_message(exception) == (
+        "API errors occurred: Unexpected error occurred. Please check your request "
+        "and contact support: https://langfuse.com/support.\n"
+        "Unauthorized. Please check your public/private host settings. Refer to our "
+        "installation and setup guide: https://langfuse.com/docs/sdk/typescript/guide "
+        "for details on SDK configuration."
+    )
+
+
 def test_generate_error_message_generic_exception():
     exception = Exception("Generic error")
     expected_message = "Unexpected error occurred. Please check your request and contact support: https://langfuse.com/support."


### PR DESCRIPTION
## What

Prevent error-message generation from raising `ValueError` when an API error contains a non-numeric status such as `"failed"`. Non-numeric values now use the existing generic response, while integer and numeric-string status handling remains unchanged.

## Why

`APIError.status` accepts both `int` and `str`, but the formatter converted every string with `int(status)`. Transport or upstream failures can carry descriptive string statuses, causing the formatter to mask the original API failure with a conversion exception. Batch errors had the same behavior.

## Validation

- `uv run --frozen pytest tests/unit/test_error_parsing.py -q` (11 passed)
- `uv run --frozen pytest -n auto --dist worksteal tests/unit -q -o log_cli=false --tb=short --disable-warnings` with placeholder test credentials (687 passed, 2 skipped)
- `uv run --frozen ruff check langfuse tests`
- `uv run --frozen ruff format --check langfuse tests`
- `uv run --frozen mypy langfuse`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents error formatting from masking API failures when a status is non-numeric.
- Centralizes integer and numeric-string status lookup in `_error_response_for_status`.
- Falls back to the existing generic response for non-numeric strings.
- Adds coverage for single and batched API errors.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The helper preserves integer and numeric-string mappings, safely handles non-numeric strings, and is covered for both single and batched errors.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(errors): handle non-numeric API stat..."](https://github.com/langfuse/langfuse-python/commit/1a6069b2f248498f668f568f84b236c286ba388d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52881604)</sub>

**Context used:**

- Knowledge Base — [Utils and Support Types](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/utils-support.md)

<!-- /greptile_comment -->