### PR TITLE
fix: serialize NaN/Inf floats nested in pydantic models as JSON-safe strings

### DIFF
--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -136,7 +136,10 @@ class EventSerializer(JSONEncoder):
                 if isinstance(raw := getattr(obj, "raw", None), BaseModel):
                     raw.model_rebuild()
 
-                return obj.model_dump()
+                # model_dump() returns plain dicts/lists/scalars, so route it back
+                # through default() to keep nested non-finite floats (NaN/Inf) and
+                # other non-JSON-safe values sanitized like the dict branch does.
+                return self.default(obj.model_dump())
 
             # if langchain is not available, the Serializable type is NoneType
             if Serializable is not type(None) and isinstance(obj, Serializable):  # type: ignore

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -71,6 +71,26 @@ def test_pydantic_model():
     assert json.loads(serializer.encode(model)) == {"field": "test"}
 
 
+def test_pydantic_model_with_non_finite_float_serializes_to_valid_json():
+    # model_dump() returns a plain dict; the previous BaseModel branch returned
+    # it directly, so nested NaN/Inf floats bypassed the sanitizer and produced
+    # bare NaN/Infinity tokens that strict JSON parsers reject. See #16048.
+    class Scores(BaseModel):
+        confidence: float
+
+    serializer = EventSerializer()
+    encoded = serializer.encode(Scores(confidence=float("nan")))
+
+    # Strict parse must succeed and the NaN token must be a quoted string.
+    assert json.loads(
+        encoded, parse_constant=lambda t: (_ for _ in ()).throw(ValueError(t))
+    ) == {"confidence": "NaN"}
+    assert (
+        serializer.encode(Scores(confidence=float("inf")))
+        == '{"confidence": "Infinity"}'
+    )
+
+
 def test_langfuse_media_reference_serializes_to_reference_string():
     # Resolved references must round-trip back to their original reference string
     # rather than falling through to asdict() and emitting an opaque dict.


### PR DESCRIPTION
## What does this PR do?

Fixes #16048

`EventSerializer`'s `BaseModel` branch returned `obj.model_dump()` directly, so non-finite floats nested inside a pydantic model bypassed the NaN/Inf sanitizer that the dict/list branches already apply. Python's JSON C encoder then emitted bare `NaN`/`Infinity` tokens, which strict JSON parsers reject. On the tracing path, any traced pydantic object carrying a NaN/Inf float (common with ML/scoring payloads) produced an event body that failed ingestion.

The fix routes the dumped dict back through `default()`, so the same sanitization applies at every nesting depth:

```python
from pydantic import BaseModel
from langfuse._utils.serializer import EventSerializer

class Scores(BaseModel):
    confidence: float

# before: {"confidence": NaN}  (bare NaN, invalid JSON)
# after:  {"confidence": "NaN"}
EventSerializer().encode(Scores(confidence=float("nan")))
```

## Type of change

- [x] Bug fix

## Verification

```bash
pytest tests/unit/test_serializer.py -q -k "not path"     # 29 passed
ruff check langfuse/_utils/serializer.py tests/unit/test_serializer.py  # all checks passed
ruff format --check langfuse/_utils/serializer.py tests/unit/test_serializer.py
```

The new regression test `test_pydantic_model_with_non_finite_float_serializes_to_valid_json` fails before the fix (strict parse raises `ValueError: NaN`) and passes after. `test_path` fails on this machine only (POSIX-vs-Windows path separators) and passes in CI's Linux runner; the same pre-existing mypy `import-not-found` note for `langchain_core` is present on the unmodified file.

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Routes Pydantic `model_dump()` output back through `EventSerializer` so nested non-finite floats become JSON-safe strings.
- Sanitizes nested `NaN` and infinity values consistently with existing dict/list handling.
- Adds regression coverage using strict JSON parsing for Pydantic payloads.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the intended Pydantic serialization behavior covered by a focused strict-JSON regression test.

The changed branch reuses the established recursive normalization path, ensuring non-finite floats nested in Pydantic models no longer produce invalid bare JSON constants, and no concrete blocking or non-blocking defect remains.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Pydantic BaseModel] --> B[model_dump]
  B --> C[EventSerializer recursive normalization]
  C --> D[NaN and Infinity converted to strings]
  D --> E[Valid JSON ingestion payload]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: serialize NaN/Inf floats nested in ..."](https://github.com/langfuse/langfuse-python/commit/605f49bf087ef76c8a315381066212b582d1adbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53534352)</sub>

**Context used:**

- Knowledge Base — [Utils and Support Types](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/utils-support.md)

<!-- /greptile_comment -->