### PR TITLE
fix: cancel media uploads when mask_otel_spans drops the batch

### DIFF
--- a/langfuse/_client/span_exporter.py
+++ b/langfuse/_client/span_exporter.py
@@ -106,12 +106,14 @@ class LangfuseTransformingSpanExporter(SpanExporter):
         self._mask_otel_spans = mask_otel_spans
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        enqueued_media_ids: set[str] = set()
         span_attributes = [
             (
                 span,
                 self._process_media_attributes(
                     span=span,
                     attributes=dict(span.attributes or {}),
+                    enqueued_media_ids=enqueued_media_ids,
                 ),
             )
             for span in spans
@@ -123,6 +125,14 @@ class LangfuseTransformingSpanExporter(SpanExporter):
             )
 
             if masked_span_attributes is None:
+                # The mask hook dropped the whole batch. The media bytes were
+                # already queued for upload during attribute processing, so
+                # cancel those uploads too -- "drops the whole export batch"
+                # must mean all of it, including the media behind the spans.
+                if enqueued_media_ids and self._media_manager is not None:
+                    self._media_manager.cancel_pending_uploads(
+                        media_ids=enqueued_media_ids
+                    )
                 return SpanExportResult.SUCCESS
 
             span_attributes = masked_span_attributes
@@ -144,7 +154,11 @@ class LangfuseTransformingSpanExporter(SpanExporter):
         return self._exporter.force_flush(timeout_millis=timeout_millis)
 
     def _process_media_attributes(
-        self, *, span: ReadableSpan, attributes: Dict[str, AttributeValue]
+        self,
+        *,
+        span: ReadableSpan,
+        attributes: Dict[str, AttributeValue],
+        enqueued_media_ids: Optional[set[str]] = None,
     ) -> Dict[str, AttributeValue]:
         if self._media_manager is None:
             return attributes
@@ -157,6 +171,7 @@ class LangfuseTransformingSpanExporter(SpanExporter):
                     span=span,
                     attribute_key=key,
                     value=value,
+                    enqueued_media_ids=enqueued_media_ids,
                 )
             except Exception as error:
                 langfuse_logger.warning(
@@ -175,12 +190,14 @@ class LangfuseTransformingSpanExporter(SpanExporter):
         span: ReadableSpan,
         attribute_key: str,
         value: AttributeValue,
+        enqueued_media_ids: Optional[set[str]] = None,
     ) -> AttributeValue:
         if isinstance(value, str):
             return self._process_media_string(
                 span=span,
                 attribute_key=attribute_key,
                 value=value,
+                enqueued_media_ids=enqueued_media_ids,
             )
 
         if _is_attribute_sequence(value):
@@ -193,6 +210,7 @@ class LangfuseTransformingSpanExporter(SpanExporter):
                         span=span,
                         attribute_key=attribute_key,
                         value=item,
+                        enqueued_media_ids=enqueued_media_ids,
                     )
                     if isinstance(item, str)
                     else item
@@ -208,6 +226,7 @@ class LangfuseTransformingSpanExporter(SpanExporter):
         span: ReadableSpan,
         attribute_key: str,
         value: str,
+        enqueued_media_ids: Optional[set[str]] = None,
     ) -> str:
         media_manager = cast(MediaManager, self._media_manager)
         field = _media_field_for_attribute(attribute_key)
@@ -219,6 +238,11 @@ class LangfuseTransformingSpanExporter(SpanExporter):
                 trace_id=trace_id,
                 observation_id=observation_id,
                 field=field,
+            )
+
+            _collect_enqueued_media_ids(
+                value=processed_direct_value,
+                media_ids=enqueued_media_ids,
             )
 
             direct_reference = _media_reference_string(processed_direct_value)
@@ -251,6 +275,11 @@ class LangfuseTransformingSpanExporter(SpanExporter):
             trace_id=trace_id,
             observation_id=observation_id,
             field=field,
+        )
+
+        _collect_enqueued_media_ids(
+            value=processed_json_value,
+            media_ids=enqueued_media_ids,
         )
 
         if processed_json_value == parsed_value:
@@ -561,6 +590,32 @@ def _media_reference_string(value: Any) -> Optional[str]:
         return None
 
     return value._reference_string
+
+
+def _collect_enqueued_media_ids(value: Any, media_ids: Optional[set[str]]) -> None:
+    """Collect media IDs enqueued for upload from a processed attribute value.
+
+    _find_and_process_media enqueues an upload job for every LangfuseMedia it
+    builds, but the processed value it returns is what the attribute becomes.
+    Walk it so the exporter knows which media uploads a batch triggered, and can
+    cancel them if the mask hook later drops the batch.
+    """
+    if media_ids is None:
+        return
+
+    if isinstance(value, LangfuseMedia):
+        if value._media_id is not None:
+            media_ids.add(value._media_id)
+        return
+
+    if isinstance(value, dict):
+        for item in value.values():
+            _collect_enqueued_media_ids(item, media_ids)
+        return
+
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _collect_enqueued_media_ids(item, media_ids)
 
 
 def _media_upload_failed_marker(content_type: Any) -> str:

--- a/langfuse/_task_manager/media_manager.py
+++ b/langfuse/_task_manager/media_manager.py
@@ -45,6 +45,7 @@ class MediaManager:
         self._enabled = os.environ.get(
             LANGFUSE_MEDIA_UPLOAD_ENABLED, "True"
         ).lower() not in ("false", "0")
+        self._cancelled_media_ids: set[str] = set()
 
     def reinitialize(
         self,
@@ -65,6 +66,14 @@ class MediaManager:
                 self._queue.task_done()
                 return
 
+            if upload_job["media_id"] in self._cancelled_media_ids:
+                self._cancelled_media_ids.discard(upload_job["media_id"])
+                logger.debug(
+                    f"Media: Skipping cancelled upload for media_id={upload_job['media_id']} in trace_id={upload_job['trace_id']}"
+                )
+                self._queue.task_done()
+                return
+
             logger.debug(
                 f"Media: Processing upload for media_id={upload_job['media_id']} in trace_id={upload_job['trace_id']}"
             )
@@ -78,6 +87,16 @@ class MediaManager:
                 f"Media upload error: Failed to upload media due to unexpected error. Queue item marked as done. Error: {e}"
             )
             self._queue.task_done()
+
+    def cancel_pending_uploads(self, *, media_ids: set[str]) -> None:
+        """Cancel media uploads enqueued for a batch that was dropped.
+
+        The mask hook runs after media attributes are processed, so upload jobs
+        for a batch are already queued by the time the hook decides to drop it.
+        Mark those media IDs so the consumer skips them instead of uploading the
+        bytes the hook just redacted.
+        """
+        self._cancelled_media_ids.update(media_ids)
 
     def signal_shutdown(self, *, count: int = 1) -> None:
         for _ in range(count):

--- a/tests/unit/test_mask_otel_spans.py
+++ b/tests/unit/test_mask_otel_spans.py
@@ -196,6 +196,50 @@ def test_mask_otel_spans_receives_post_media_batch_and_applies_sparse_patch():
     assert not media_queue.empty()
 
 
+def test_mask_otel_spans_drop_batch_cancels_enqueued_media_uploads():
+    # Media attributes are processed before the mask hook runs, so upload jobs
+    # are already queued when the hook drops the batch. The dropped batch must
+    # not upload the media behind it -- the consumer should skip those jobs.
+    exporter = InMemorySpanExporter()
+    media_manager, media_queue = _media_manager()
+    image_base64 = base64.b64encode(b"image-bytes").decode("utf-8")
+    uploads_processed: list[str] = []
+
+    def mask_otel_spans(*, params):
+        # The fail-closed pattern: a hook error drops the whole export batch.
+        raise RuntimeError("masking function blew up")
+
+    original_process_upload = media_manager._process_upload_media_job
+
+    def recording_process_upload(*, data):
+        uploads_processed.append(data["media_id"])
+
+    media_manager._process_upload_media_job = recording_process_upload
+
+    provider = _tracer_provider(
+        exporter=exporter,
+        media_manager=media_manager,
+        mask_otel_spans=mask_otel_spans,
+    )
+    tracer = provider.get_tracer("openinference.instrumentation.openai")
+
+    with tracer.start_as_current_span("third-party-media-span") as span:
+        span.set_attribute("gen_ai.prompt", f"data:image/jpeg;base64,{image_base64}")
+
+    provider.force_flush()
+
+    assert exporter.get_finished_spans() == []
+    assert not media_queue.empty()
+
+    # The consumer must skip the cancelled upload: drain the queue and verify
+    # nothing was actually uploaded.
+    media_manager.process_next_media_upload()
+    assert uploads_processed == []
+    assert media_queue.empty()
+
+    media_manager._process_upload_media_job = original_process_upload
+
+
 def test_export_stage_media_prefilter_skips_json_without_media_hints(monkeypatch):
     exporter = InMemorySpanExporter()
     media_manager, media_queue = _media_manager()


### PR DESCRIPTION
## What does this PR do?

Fixes #16102

`EventSerializer` handles media extraction before the `mask_otel_spans` hook runs, and that ordering is deliberate (the hook must see `@@@langfuseMedia:` reference strings, not raw bytes). The problem is the consequence: when the hook raises or returns an invalid result, the whole batch is dropped as documented, but the media upload jobs were already enqueued during attribute processing and still get uploaded. The fail-closed guarantee that "dropping the batch" covers the spans does not extend to the media behind them.

This tracks the media IDs enqueued while processing a batch's attributes and cancels them when the mask hook drops the batch. The upload consumer skips cancelled media IDs, so a redacted attribute never produces an upload.

## Type of change

- [x] Bug fix

## Verification

```bash
pytest tests/unit/test_mask_otel_spans.py tests/unit/test_serializer.py -q -k "not path"   # 81 passed
pytest tests/unit/test_otel.py tests/unit/test_media.py -q                                  # 85 passed, 2 skipped
ruff check langfuse/_client/span_exporter.py langfuse/_task_manager/media_manager.py tests/unit/test_mask_otel_spans.py
ruff format --check <same files>
mypy langfuse/_client/span_exporter.py langfuse/_task_manager/media_manager.py --no-error-summary
```

The new regression test `test_mask_otel_spans_drop_batch_cancels_enqueued_media_uploads` fails without the fix (the upload job is processed despite the batch being dropped) and passes with it. `test_path` fails on this machine only (POSIX-vs-Windows path separators) and passes in CI's Linux runner.

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs, examples, or `.env.template` if needed.
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR attempts to extend fail-closed OpenTelemetry span masking to separately queued media uploads.
- Tracks media IDs produced while transforming an export batch.
- Marks those IDs as cancelled when the masking hook drops the batch.
- Makes the media consumer skip jobs whose IDs are marked as cancelled.
- Adds a sequential regression test for the cancellation path.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

This PR is not yet safe to merge because dropped spans can still upload media under normal consumer concurrency, and content-based cancellation can suppress or misapply uploads across batches.

Media jobs are visible to background consumers before masking completes, and the sole pre-upload cancellation check can be passed before cancellation is recorded; additionally, deterministic media IDs cannot distinguish individual queued jobs from different batches.

**Files Needing Attention:** langfuse/_task_manager/media_manager.py, langfuse/_client/span_exporter.py, tests/unit/test_mask_otel_spans.py
</details>

<details open><summary><h3>Security Review</h3></summary>

The new cancellation check does not close the concurrent upload window: a background consumer can dequeue and begin uploading media before the masking failure records the cancellation, allowing media from a dropped span to leave the process.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant E as Export thread
    participant Q as Media queue
    participant C as Media consumer
    participant M as Mask hook
    participant B as Backend
    E->>Q: Enqueue extracted media
    Q-->>C: Dequeue job
    C->>C: Check cancellation marker
    E->>M: Invoke mask_otel_spans
    C->>B: Begin media upload
    M-->>E: Raise / invalid result
    E->>C: Record cancelled media ID
    Note over C,B: Cancellation arrives after the only check
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
langfuse/_task_manager/media_manager.py:69-75
**Cancellation misses active uploads**

When a media consumer dequeues a job before or while `mask_otel_spans` runs, it can pass this sole cancellation check and begin the network upload before the hook drops the batch, causing media from a redacted span to be uploaded. **How this was verified:** Media is enqueued before the synchronous mask hook runs, while independent consumer threads dequeue jobs and never re-check cancellation inside the upload path.

### Issue 2
langfuse/_task_manager/media_manager.py:69-70
**Content IDs misroute cancellation**

When an exported batch and a dropped batch enqueue identical media bytes, both jobs have the same deterministic `media_id`, so this one-shot marker can skip the earlier legitimate job and then allow the dropped job to upload. A stale marker can likewise suppress a later legitimate upload of the same content.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: cancel media uploads when mask\_otel..."](https://github.com/langfuse/langfuse-python/commit/a026c7b39a7bb98a7636434dd6dc1ef87581ae77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53540139)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [OTel Span Processing and Export Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/otel-pipeline.md)
- Knowledge Base — [Task Manager: Media Upload and Score Ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/task-manager.md)

<!-- /greptile_comment -->