### PR TITLE
fix(docs): preserve PyPI hero image aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img width="2400" height="600" alt="hero-b" src="https://github.com/user-attachments/assets/4005eb1b-539d-4d35-9683-3a61ec9d9301" />
+![Langfuse product overview](https://github.com/user-attachments/assets/4005eb1b-539d-4d35-9683-3a61ec9d9301)
 
 # Langfuse Python SDK
 


### PR DESCRIPTION
## What changed

Replace the README hero's fixed-size HTML `img` element with standard Markdown image syntax.

## Why

PyPI constrains project-description images to the content column with `max-width: 100%`, but the explicit `height="600"` remained fixed when the declared 2400 px width was reduced. The current listing therefore renders the 4:1 source image with a distorted aspect ratio.

Using dimension-free Markdown lets the renderer derive height from the image's intrinsic 2400×600 dimensions while keeping it responsive on GitHub and PyPI.

Fixes [LFE-15269](https://linear.app/clickhouse/issue/LFE-15269/fix-langfuse-pypi-listing-image).

## Impact

The Langfuse PyPI listing will show the README hero at its intended aspect ratio after the next package release.

## Verification

- `git diff --check`
- `uv build --out-dir /tmp/lfe-15269-pr-dist --no-sources`
- `twine check /tmp/lfe-15269-pr-dist/*`
- Inspected the wheel `METADATA` to confirm the dimension-free Markdown image is included in the published description

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the fixed-dimension HTML hero image with standard Markdown image syntax so renderers can preserve its intrinsic aspect ratio.

- Keeps the existing image URL.
- Adds descriptive alternative text.
- Removes explicit width and height attributes that distorted the image on PyPI.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no blocking or non-blocking issues identified.

The standard Markdown image syntax is already used elsewhere in the README, preserves the existing asset URL, and is compatible with the README’s package-description role.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): preserve PyPI hero image aspe..."](https://github.com/langfuse/langfuse-python/commit/fab074187a36c951bd6c0731c679343d7b168c65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54428296)</sub>

<!-- /greptile_comment -->