### PR TITLE
fix(otel): do not set AS_ROOT on child spans with parent_span_id

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -723,7 +723,8 @@ class Langfuse:
                     cast(otel_trace_api.Span, remote_parent_span)
                 ):
                     otel_span = self._otel_tracer.start_span(name=name)
-                    otel_span.set_attribute(LangfuseOtelSpanAttributes.AS_ROOT, True)
+                    if parent_span_id is None:
+                        otel_span.set_attribute(LangfuseOtelSpanAttributes.AS_ROOT, True)
 
                     return self._create_observation_from_otel_span(
                         otel_span=otel_span,
@@ -1099,6 +1100,7 @@ class Langfuse:
                             as_type=as_type,
                             name=name,
                             remote_parent_span=remote_parent_span,
+                            is_root=parent_span_id is None,
                             parent=None,
                             end_on_exit=end_on_exit,
                             input=input,
@@ -1164,6 +1166,7 @@ class Langfuse:
                             as_type=as_type,
                             name=name,
                             remote_parent_span=remote_parent_span,
+                            is_root=parent_span_id is None,
                             parent=None,
                             end_on_exit=end_on_exit,
                             input=input,
@@ -1270,6 +1273,15 @@ class Langfuse:
 
         return observation_type if isinstance(observation_type, str) else "span"
 
+    def _get_observation_type(
+        self,
+        span_class: Type[Any],
+    ) -> ObservationTypeLiteralNoEvent:
+        """Get the observation type string from a span class."""
+        observation_type = getattr(span_class, "_observation_type", "span")
+
+        return observation_type if isinstance(observation_type, str) else "span"
+
     @_agnosticcontextmanager
     def _create_span_with_parent_context(
         self,
@@ -1277,6 +1289,7 @@ class Langfuse:
         name: str,
         parent: Optional[otel_trace_api.Span] = None,
         remote_parent_span: Optional[otel_trace_api.Span] = None,
+        is_root: bool = False,
         as_type: ObservationTypeLiteralNoEvent,
         end_on_exit: Optional[bool] = None,
         input: Optional[Any] = None,
@@ -1312,7 +1325,7 @@ class Langfuse:
                 cost_details=cost_details,
                 prompt=prompt,
             ) as langfuse_span:
-                if remote_parent_span is not None:
+                if is_root:
                     langfuse_span._otel_span.set_attribute(
                         LangfuseOtelSpanAttributes.AS_ROOT, True
                     )
@@ -1693,7 +1706,8 @@ class Langfuse:
                     otel_span = self._otel_tracer.start_span(
                         name=name, start_time=timestamp
                     )
-                    otel_span.set_attribute(LangfuseOtelSpanAttributes.AS_ROOT, True)
+                    if parent_span_id is None:
+                        otel_span.set_attribute(LangfuseOtelSpanAttributes.AS_ROOT, True)
 
                     return cast(
                         LangfuseEvent,

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -882,7 +882,7 @@ class TestBasicSpans(TestOTelBase):
         spans = self.get_spans_by_name(memory_exporter, "custom-parent-span")
         assert len(spans) == 1, "Expected one span"
         assert spans[0]["trace_id"] == trace_id
-        assert spans[0]["attributes"][LangfuseOtelSpanAttributes.AS_ROOT] is True
+        assert LangfuseOtelSpanAttributes.AS_ROOT not in spans[0]["attributes"]
 
     def test_multiple_generations_in_trace(self, langfuse_client, memory_exporter):
         """Test creating multiple generation spans within the same trace."""


### PR DESCRIPTION
### Problem
When creating spans using `start_as_current_observation()` or `start_observation()` within an existing trace or with a `trace_context` containing a `parent_span_id`, the client stamped `LangfuseOtelSpanAttributes.AS_ROOT: True` on the child span. This caused the Langfuse ingestion processor on the server to treat every child span as the root of the trace, overwriting the parent trace's name (and trace-level IO) with the child span's name during trace updates.

### Root cause
`_create_span_with_parent_context`, `start_observation`, and `create_event` set `LangfuseOtelSpanAttributes.AS_ROOT = True` whenever `remote_parent_span is not None`, without checking whether `parent_span_id` was provided or whether the span was a non-root child span in an existing trace.

### Solution
- Updated `start_observation`, `create_event`, `start_as_current_observation`, and `_create_span_with_parent_context` to only set `LangfuseOtelSpanAttributes.AS_ROOT = True` when `parent_span_id is None` (i.e. only on true trace root spans).
- Updated unit test assertions in `tests/unit/test_otel.py` so child spans with custom `parent_span_id` are not marked as `AS_ROOT`.

### Proof

#### Test Run
```
PS C:\Users\erijo\Downloads\claude> python test_reproduce_langfuse_16272.py
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```

### Reference
Fixes https://github.com/langfuse/langfuse/issues/16272

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects Langfuse root-span metadata so observations with an explicit parent span are not marked as trace roots.

- Gates `AS_ROOT` on the absence of `parent_span_id` across observation and event creation paths.
- Threads explicit root status through the shared parent-context span helper.
- Updates the OTel unit assertion for an explicitly parented span.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after removing the non-blocking duplicate method definition.

The root-marker changes consistently distinguish explicitly parented observations, while the only accepted concern is an identical method definition that silently shadows its predecessor.

**Files Needing Attention:** langfuse/_client/client.py
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
langfuse/_client/client.py:1276-1283
**Duplicate observation-type method**

This adds a second identical `_get_observation_type` definition that silently replaces the existing method, leaving dead and misleading code that can diverge when this helper is updated later.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): do not set AS\_ROOT on child s..."](https://github.com/langfuse/langfuse-python/commit/94668950caf5ca0d5f08e51c1bdd72904b20833b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54551177)</sub>

**Context used:**

- Knowledge Base — [Client Core](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/client-core.md)
- Knowledge Base — [OTel Span Processing and Export Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/otel-pipeline.md)

<!-- /greptile_comment -->