### PR TITLE
fix(cache): prevent over-invalidation of similarly named prompt prefixes in PromptCache

### DIFF
--- a/langfuse/_utils/prompt_cache.py
+++ b/langfuse/_utils/prompt_cache.py
@@ -180,10 +180,15 @@ class PromptCache:
         """Invalidate all cached prompts with the given prompt name."""
         if not prompt_name:
             return
-        prefix = f"{prompt_name}-"
+        version_prefix = f"{prompt_name}-version:"
+        label_prefix = f"{prompt_name}-label:"
         with self._lock:
             for key in list(self._cache):
-                if key == prompt_name or key.startswith(prefix):
+                if (
+                    key == prompt_name
+                    or key.startswith(version_prefix)
+                    or key.startswith(label_prefix)
+                ):
                     del self._cache[key]
 
     def add_refresh_prompt_task(self, key: str, fetch_func: Callable[[], None]) -> None:

--- a/langfuse/_utils/prompt_cache.py
+++ b/langfuse/_utils/prompt_cache.py
@@ -178,9 +178,12 @@ class PromptCache:
 
     def invalidate(self, prompt_name: str) -> None:
         """Invalidate all cached prompts with the given prompt name."""
+        if not prompt_name:
+            return
+        prefix = f"{prompt_name}-"
         with self._lock:
             for key in list(self._cache):
-                if key.startswith(prompt_name):
+                if key == prompt_name or key.startswith(prefix):
                     del self._cache[key]
 
     def add_refresh_prompt_task(self, key: str, fetch_func: Callable[[], None]) -> None:

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -762,7 +762,7 @@ def test_prompt_cache_invalidate_exact_prefix_match(langfuse: Langfuse):
         tags=[],
     )
     prompt2 = Prompt_Text(
-        name="summary_detailed",
+        name="summary-detailed",
         version=1,
         prompt="Summarize in detail",
         labels=[],
@@ -772,7 +772,7 @@ def test_prompt_cache_invalidate_exact_prefix_match(langfuse: Langfuse):
     )
 
     key1 = PromptCache.generate_cache_key("summary", version=1, label=None)
-    key2 = PromptCache.generate_cache_key("summary_detailed", version=1, label=None)
+    key2 = PromptCache.generate_cache_key("summary-detailed", version=1, label=None)
 
     cache.set(key1, TextPromptClient(prompt1), ttl_seconds=60)
     cache.set(key2, TextPromptClient(prompt2), ttl_seconds=60)
@@ -782,7 +782,7 @@ def test_prompt_cache_invalidate_exact_prefix_match(langfuse: Langfuse):
 
     cache.invalidate("summary")
 
-    # summary should be invalidated, but summary_detailed must be preserved
+    # summary should be invalidated, but summary-detailed must be preserved
     assert cache.get(key1) is None
     assert cache.get(key2) is not None
 

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -748,3 +748,41 @@ def test_get_fresh_prompt_when_version_changes(langfuse: Langfuse):
     result_call_2 = langfuse.get_prompt(prompt_name, version=2)
     assert mock_server_call.call_count == 2
     assert result_call_2 == version_changed_prompt_client
+
+
+def test_prompt_cache_invalidate_exact_prefix_match(langfuse: Langfuse):
+    cache = PromptCache()
+    prompt1 = Prompt_Text(
+        name="summary",
+        version=1,
+        prompt="Summarize this",
+        labels=[],
+        type="text",
+        config={},
+        tags=[],
+    )
+    prompt2 = Prompt_Text(
+        name="summary_detailed",
+        version=1,
+        prompt="Summarize in detail",
+        labels=[],
+        type="text",
+        config={},
+        tags=[],
+    )
+
+    key1 = PromptCache.generate_cache_key("summary", version=1, label=None)
+    key2 = PromptCache.generate_cache_key("summary_detailed", version=1, label=None)
+
+    cache.set(key1, TextPromptClient(prompt1), ttl_seconds=60)
+    cache.set(key2, TextPromptClient(prompt2), ttl_seconds=60)
+
+    assert cache.get(key1) is not None
+    assert cache.get(key2) is not None
+
+    cache.invalidate("summary")
+
+    # summary should be invalidated, but summary_detailed must be preserved
+    assert cache.get(key1) is None
+    assert cache.get(key2) is not None
+


### PR DESCRIPTION
## Summary

Fixes cache invalidation in `PromptCache.invalidate()`:
- Checks for exact prompt name matches or keys prefixed with `{prompt_name}-` instead of bare substring prefix matching (`key.startswith(prompt_name)`).
- Added unit test `test_prompt_cache_invalidate_exact_prefix_match`.

## Motivation

Previously, `PromptCache.invalidate("summary")` would unintentionally evict other prompt keys sharing the same name prefix (for example `"summary_detailed-version:1"` or `"summary_qa-label:production"`). Checking exact key match or hyphen-delimited prefix ensures only the target prompt is evicted.

## Changes

- `langfuse/_utils/prompt_cache.py`: Refactored `invalidate()` to match `key == prompt_name or key.startswith(f"{prompt_name}-")`.
- `tests/unit/test_prompt.py`: Added test ensuring sibling prompts with similar prefixes are not accidentally evicted.

## Tests

- Added `test_prompt_cache_invalidate_exact_prefix_match` verifying selective invalidation.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR narrows prompt-cache invalidation to exact keys and hyphen-delimited prefixes and adds a regression test for similarly prefixed names. The delimiter remains ambiguous for valid prompt names containing hyphens.

- Updates `PromptCache.invalidate()` to avoid bare prefix matching.
- Adds coverage showing that invalidating `summary` preserves `summary_detailed`.
- Does not cover or preserve a sibling such as `summary-detailed`.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge with a non-blocking cache-correctness improvement recommended for hyphen-prefixed sibling prompt names.

The change fixes underscore-style prefix collisions, but the shared hyphen delimiter still causes distinct names such as `summary-detailed` to be evicted when `summary` is invalidated.

**Files Needing Attention:** langfuse/_utils/prompt_cache.py, tests/unit/test_prompt.py
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
langfuse/_utils/prompt_cache.py:186
**Hyphen-delimited names still collide**

For cached prompts named `summary` and `summary-detailed`, invalidating `summary` also matches `summary-detailed-version:1`, unnecessarily evicting the distinct sibling and forcing another API fetch on its next access. The added underscore case does not cover this collision because prompt names accept hyphens and cache metadata uses the same delimiter.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(prompt): add unit test for exact pr..."](https://github.com/langfuse/langfuse-python/commit/686e392c66da8c82bb6773924396954d17c2d2b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55777721)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Utils and Support Types](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/utils-support.md)

<!-- /greptile_comment -->