### PR TITLE
fix(openai): trace responses.retrieve so background responses get output and usage

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -194,6 +194,22 @@ OPENAI_METHODS_V1 = [
         min_version="1.66.0",
     ),
     OpenAiDefinition(
+        module="openai.resources.responses",
+        object="Responses",
+        method="retrieve",
+        type="chat",
+        sync=True,
+        min_version="1.66.0",
+    ),
+    OpenAiDefinition(
+        module="openai.resources.responses",
+        object="AsyncResponses",
+        method="retrieve",
+        type="chat",
+        sync=False,
+        min_version="1.66.0",
+    ),
+    OpenAiDefinition(
         module="openai.resources.embeddings",
         object="Embeddings",
         method="create",
@@ -550,7 +566,11 @@ def _get_langfuse_data_from_kwargs(resource: OpenAiDefinition, kwargs: Any) -> A
 
     prompt = None
 
-    if resource.type == "completion":
+    if resource.method == "retrieve":
+        # retrieve() only knows the id of a response created earlier; the model,
+        # output and usage are filled in from the response itself.
+        prompt = {"response_id": kwargs.get("response_id", None)}
+    elif resource.type == "completion":
         prompt = kwargs.get("prompt", None)
     elif resource.object == "Responses" or resource.object == "AsyncResponses":
         prompt = _extract_responses_prompt(kwargs)

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -1399,3 +1399,74 @@ def test_with_raw_response_streaming_passes_through_untraced(
         span.name != "OpenAI-generation"
         for span in memory_exporter.get_finished_spans()
     )
+
+
+def test_response_retrieve_exports_generation_span(
+    langfuse_memory_client, get_span, json_attr
+):
+    """Background responses complete through retrieve(), which must be traced."""
+    openai_client = lf_openai.OpenAI(api_key="test")
+    response = SimpleNamespace(
+        model="gpt-4o-mini",
+        output=[{"role": "assistant", "content": "2"}],
+        usage=SimpleNamespace(input_tokens=3, output_tokens=1, total_tokens=4),
+    )
+
+    with patch.object(openai_client.responses, "_get", return_value=response):
+        result = openai_client.responses.retrieve(
+            response_id="resp_123",
+            name="unit-openai-response-retrieve",
+        )
+
+    assert result is response
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-response-retrieve")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] == "generation"
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL] == "gpt-4o-mini"
+    )
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_INPUT) == {
+        "response_id": "resp_123"
+    }
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT) == {
+        "role": "assistant",
+        "content": "2",
+    }
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS) == {
+        "input_tokens": 3,
+        "output_tokens": 1,
+        "total_tokens": 4,
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_response_retrieve_exports_generation_span(
+    langfuse_memory_client, get_span, json_attr
+):
+    openai_client = lf_openai.AsyncOpenAI(api_key="test")
+    response = SimpleNamespace(
+        model="gpt-4o-mini",
+        output=[{"role": "assistant", "content": "2"}],
+        usage=SimpleNamespace(input_tokens=3, output_tokens=1, total_tokens=4),
+    )
+
+    async def _get(*args, **kwargs):
+        return response
+
+    with patch.object(openai_client.responses, "_get", side_effect=_get):
+        result = await openai_client.responses.retrieve(
+            response_id="resp_123",
+            name="unit-openai-async-response-retrieve",
+        )
+
+    assert result is response
+
+    langfuse_memory_client.flush()
+    span = get_span("unit-openai-async-response-retrieve")
+
+    assert span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] == "generation"
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_INPUT) == {
+        "response_id": "resp_123"
+    }


### PR DESCRIPTION
## What does this PR do?

Instruments `Responses.retrieve` and `AsyncResponses.retrieve`, so background responses get their output, token counts and cost.

`create` and `parse` are instrumented, `retrieve` is not. With `background=True` the create call returns `status="queued"` with no usage, and the real result arrives through `retrieve()` — either directly, or via `responses.stream(response_id=...)`, which delegates to `retrieve(stream=True)`. The generation therefore stays in the trace with an input and a model but no output, no `usage_details` and no cost, which reads as a free call rather than a missing one.

The response id is recorded as the generation input, since `retrieve()` carries no prompt of its own. Model, output and usage come from the response, so both the streaming and non-streaming paths are handled by the existing extraction code.

A key-free reproduction of the routing is in the issue.

**Open question:** retrieving a response that was already traced at creation time (non-background usage) will now record its usage a second time. This PR implements the straightforward version — instrument every `retrieve` — but restricting it to `stream=True`, or skipping usage when the response was not `queued`, are both easy to switch to if you prefer one of those.

Fixes #1834

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

Both new tests fail on `main` and pass with the change.

```bash
uv run --frozen pytest tests/unit/test_openai.py -q -k retrieve   # 2 passed (2 failed before the fix)
uv run --frozen pytest tests/unit/test_openai.py -q               # 36 passed
bash scripts/codex/quick-check.sh                                 # ruff, mypy, 670 passed, 2 skipped, 18 errors
uv run --frozen ruff format --check langfuse/openai.py tests/unit/test_openai.py
```

The 18 errors in the unit run come from `tests/unit/test_prompt.py`, which needs Langfuse credentials in the environment. They reproduce unchanged on `main`.

Not run: `tests/e2e` and `tests/live_provider`, which need a Langfuse server and provider keys. Per AGENTS.md this change is covered by exporter-local unit assertions, so no e2e or live-provider coverage was added.

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs, examples, or `.env.template` if needed. (Not needed: no public API surface or env variable changes.)
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Instruments synchronous and asynchronous OpenAI Responses retrieval so completed background responses produce Langfuse generation telemetry.
- Registers `Responses.retrieve` and `AsyncResponses.retrieve` for tracing.
- Records the response ID as retrieval input while extracting model, output, and usage from the returned response.
- Adds unit coverage for synchronous and asynchronous retrieval.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no unacknowledged blocking or independently actionable issues identified.

The new retrieval registrations use the existing synchronous, asynchronous, and Responses API extraction paths, and the added tests cover the primary non-streaming behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(openai): trace responses.retrieve so..."](https://github.com/langfuse/langfuse-python/commit/e3b0671ecb39bd322779cf63187873029d6fc53c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56175108)</sub>

<!-- /greptile_comment -->