### PR TITLE
fix(serializer): handle cyclic dataclasses

### DIFF
--- a/langfuse/_utils/serializer.py
+++ b/langfuse/_utils/serializer.py
@@ -5,7 +5,7 @@ import enum
 import math
 from asyncio import Queue
 from collections.abc import Sequence
-from dataclasses import asdict, is_dataclass
+from dataclasses import fields, is_dataclass
 from datetime import date, datetime
 from json import JSONEncoder
 from logging import getLogger
@@ -127,7 +127,19 @@ class EventSerializer(JSONEncoder):
                 return f"<{type(obj).__name__}>"
 
             if is_dataclass(obj):
-                return asdict(obj)  # type: ignore
+                obj_id = id(obj)
+
+                if obj_id in self.seen:
+                    return type(obj).__name__
+
+                self.seen.add(obj_id)
+                try:
+                    return {
+                        field.name: self.default(getattr(obj, field.name))
+                        for field in fields(obj)
+                    }
+                finally:
+                    self.seen.remove(obj_id)
 
             if isinstance(obj, BaseModel):
                 obj.model_rebuild()

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -165,6 +165,23 @@ def test_circular_reference():
     assert result == {"next": {"next": "Node"}}
 
 
+def test_circular_dataclass_reference():
+    @dataclass
+    class Node:
+        name: str
+        next: "Node | None" = None
+
+    node1 = Node("first")
+    node2 = Node("second")
+    node1.next = node2
+    node2.next = node1
+
+    serializer = EventSerializer()
+    result = json.loads(serializer.encode(node1))
+
+    assert result == {"name": "first", "next": {"name": "second", "next": "Node"}}
+
+
 def test_not_serializable():
     class NotSerializable:
         def __init__(self):


### PR DESCRIPTION
﻿### Problem
Serializing a dataclass that contains a cycle currently falls through to the top-level fallback instead of preserving the serializable fields. `dataclasses.asdict()` recurses without using the serializer's cycle guard, so a cyclic dataclass becomes a quoted fallback string.

### Reproducer
```python
@dataclass
class Node:
    name: str
    next: "Node | None" = None

node1 = Node("first")
node2 = Node("second")
node1.next = node2
node2.next = node1

EventSerializer().encode(node1)
# before: '"\\"<not serializable object of type: Node>\\""'
# after:  '{"name":"first","next":{"name":"second","next":"Node"}}'
```

### Fix
Serialize dataclass fields through `EventSerializer.default()` instead of `asdict()`, and reuse the existing `seen` guard so recursive dataclass references are represented by their type name like other cyclic objects.

### Testing
- `python -m pytest tests\\unit\\test_serializer.py::test_circular_dataclass_reference -q` failed before the fix and passed after.
- `python -m pytest tests\\unit\\test_serializer.py -k "not test_path" -q` -> 30 passed, 1 deselected.
- `ruff format langfuse\\_utils\\serializer.py tests\\unit\\test_serializer.py --check` -> 2 files already formatted.
- `ruff check langfuse\\_utils\\serializer.py tests\\unit\\test_serializer.py` -> All checks passed.

Note: full offline `tests\\unit` baseline has pre-existing Windows/environment failures unrelated to this change (`test_path`, prompt subprocess missing `opentelemetry`, and prompt mock errors); the changed serializer subset passes.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces `dataclasses.asdict()` with field-wise serialization guarded by the serializer’s existing cycle tracking and adds coverage for direct cyclic dataclass references.
- Serializes each dataclass field through `EventSerializer.default()`.
- Emits a dataclass type name when a directly repeated instance is encountered.
- Adds a unit test for a two-node direct-reference cycle.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The cyclic-dataclass fix should be completed for tuple, set, and frozenset fields before merging because those supported containers can still bypass cycle detection.

Field-wise serialization handles direct and recursively traversed container references, but raw elements returned from tuple, set, and frozenset conversion are encoded only after the enclosing dataclass has been removed from the cycle guard.

**Files Needing Attention:** langfuse/_utils/serializer.py
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Encode dataclass] --> B[Add object ID to seen]
  B --> C[Serialize each field]
  C --> D{Field container type}
  D -->|dict, list, Sequence| E[Recursively call default]
  D -->|tuple, set, frozenset| F[Return list with raw elements]
  E --> G[Repeated dataclass becomes type marker]
  F --> H[Remove enclosing dataclass from seen]
  H --> I[JSONEncoder encounters raw dataclass again]
  I --> A
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
langfuse/_utils/serializer.py:137-138
**Container cycles escape guard**

When a cyclic dataclass reference passes through a tuple, set, or frozenset field, that container returns the repeated dataclass as a raw element and the enclosing `finally` removes it from `seen` before `JSONEncoder` encounters it, causing serialization to recurse instead of emitting the type marker and preserving the structured fields.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(serializer): handle cyclic dataclass..."](https://github.com/langfuse/langfuse-python/commit/a4082239fef2c1aebaa337583d324045eeb22106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57325840)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared models and data serialization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/shared-models-and-data-serialization.md)

<!-- /greptile_comment -->