### PR TITLE
fix(langchain): handle empty llm generations

### DIFF
--- a/langfuse/langchain/CallbackHandler.py
+++ b/langfuse/langchain/CallbackHandler.py
@@ -1327,12 +1327,7 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
             self._log_debug_event(
                 "on_llm_end", run_id, parent_run_id, response=response, kwargs=kwargs
             )
-            response_generation = response.generations[-1][-1]
-            extracted_response = (
-                self._convert_message_to_dict(response_generation.message)
-                if isinstance(response_generation, ChatGeneration)
-                else _extract_raw_response(response_generation)
-            )
+            extracted_response = self._extract_llm_result_response(response)
 
             llm_usage = _parse_usage(response)
 
@@ -1500,6 +1495,20 @@ class LangchainCallbackHandler(LangchainBaseCallbackHandler):
         langfuse_logger.debug(
             f"Event: {event_name}, run_id: {run_id}, parent_run_id: {parent_run_id}"
         )
+
+    def _extract_llm_result_response(self, response: LLMResult) -> Any:
+        for generation in reversed(response.generations):
+            if not generation:
+                continue
+
+            response_generation = generation[-1]
+            return (
+                self._convert_message_to_dict(response_generation.message)
+                if isinstance(response_generation, ChatGeneration)
+                else _extract_raw_response(response_generation)
+            )
+
+        return None
 
 
 def _extract_raw_response(last_response: Any) -> Any:

--- a/tests/unit/test_langchain.py
+++ b/tests/unit/test_langchain.py
@@ -132,6 +132,44 @@ def test_llm_callback_exports_generation_span(langfuse_memory_client, get_span):
     )
 
 
+def test_llm_callback_ends_generation_with_empty_generations(
+    langfuse_memory_client, get_span, json_attr
+):
+    handler = CallbackHandler()
+    run_id = uuid4()
+    response = LLMResult(
+        generations=[[]],
+        llm_output={
+            "token_usage": {
+                "prompt_tokens": 2,
+                "completion_tokens": 0,
+                "total_tokens": 2,
+            },
+            "model_name": "empty-model",
+        },
+    )
+
+    handler.on_llm_start(
+        {"name": "EmptyLLM"},
+        ["hello"],
+        run_id=run_id,
+        invocation_params={"model_name": "empty-model"},
+    )
+    handler.on_llm_end(response, run_id=run_id)
+
+    langfuse_memory_client.flush()
+    span = get_span("EmptyLLM")
+
+    assert (
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL] == "empty-model"
+    )
+    assert json_attr(span, LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS) == {
+        "prompt_tokens": 2,
+        "completion_tokens": 0,
+        "total_tokens": 2,
+    }
+
+
 def test_lcel_chain_exports_intermediate_chain_spans(
     langfuse_memory_client, get_span, find_spans
 ):


### PR DESCRIPTION
﻿### Problem
`CallbackHandler.on_llm_end()` assumes every LangChain `LLMResult` contains at least one generation in the last generation batch. If a provider returns an empty generation batch but still includes model and usage metadata, the callback raises `IndexError`, logs the error, and never ends the generation span.

### Reproducer
```python
handler.on_llm_start(
    {"name": "EmptyLLM"},
    ["hello"],
    run_id=run_id,
    invocation_params={"model_name": "empty-model"},
)
handler.on_llm_end(
    LLMResult(
        generations=[[]],
        llm_output={"token_usage": {"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2}},
    ),
    run_id=run_id,
)
# before: IndexError is logged and no span is exported
# after: span ends with output=None and preserved usage/model metadata
```

### Fix
Extract the last available generation by skipping empty generation batches, and use `None` as the output when no generation is present. This keeps the span lifecycle correct while preserving existing output extraction for normal chat and text generations.

### Testing
- `python -m pytest tests\\unit\\test_langchain.py::test_llm_callback_ends_generation_with_empty_generations -q` failed before the fix and passed after.
- `python -m pytest tests\\unit\\test_langchain.py -q` -> 24 passed.
- `ruff format langfuse\\langchain\\CallbackHandler.py tests\\unit\\test_langchain.py --check` -> passed after formatting.
- `ruff check langfuse\\langchain\\CallbackHandler.py tests\\unit\\test_langchain.py` -> All checks passed.

Note: full offline `tests\\unit` baseline still has pre-existing Windows/environment failures unrelated to this change (`test_path`, prompt subprocess missing `opentelemetry`, and prompt mock errors).


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes LangChain LLM completion handling tolerate empty generation batches so generation spans can still finish with model and usage metadata.

- Moves LLM result extraction into a helper that selects the last available generation and returns `None` when none exists.
- Adds regression coverage for an empty generation result carrying model and token-usage metadata.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The empty-result path now avoids indexing an empty batch, safely passes `None` through the observation update, preserves model and usage metadata, and ends the generation span.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): handle empty llm generat..."](https://github.com/langfuse/langfuse-python/commit/3b5fb79ef03b17633e356e5ba37dd7b65dd0f7d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57333502)</sub>

<!-- /greptile_comment -->