### PR TITLE
fix(prompt): preserve langchain placeholder messages

### DIFF
--- a/langfuse/model.py
+++ b/langfuse/model.py
@@ -279,6 +279,15 @@ class TextPromptClient(BasePromptClient):
 
 
 class ChatPromptClient(BasePromptClient):
+    _LANGCHAIN_MESSAGE_ROLE_MAP = {
+        "human": "user",
+        "ai": "assistant",
+        "system": "system",
+        "tool": "tool",
+        "function": "function",
+        "chat": "chat",
+    }
+
     def __init__(self, prompt: Prompt_Chat, is_fallback: bool = False):
         super().__init__(prompt, is_fallback)
         self.prompt: List[ChatMessageWithPlaceholdersDict] = []
@@ -346,17 +355,12 @@ class ChatPromptClient(BasePromptClient):
                     placeholder_value = kwargs[placeholder_name]
                     if isinstance(placeholder_value, list):
                         for msg in placeholder_value:
-                            if isinstance(msg, dict):
-                                # Preserve all fields from the original message, such as tool calls
-                                compiled_msg = dict(msg)  # type: ignore
-                                # Ensure role and content are always present
-                                compiled_msg["role"] = msg.get("role", "NOT_GIVEN")
-                                compiled_msg["content"] = (
-                                    TemplateParser.compile_template(
-                                        msg.get("content", ""),  # type: ignore
-                                        kwargs,
-                                    )
-                                )
+                            compiled_msg = self._compile_placeholder_message(
+                                msg=msg,
+                                kwargs=kwargs,
+                            )
+
+                            if compiled_msg is not None:
                                 compiled_messages.append(compiled_msg)
                             else:
                                 compiled_messages.append(
@@ -386,6 +390,47 @@ class ChatPromptClient(BasePromptClient):
             langfuse_logger.warning(unresolved_placeholders_message)
 
         return compiled_messages  # type: ignore
+
+    def _compile_placeholder_message(
+        self, *, msg: Any, kwargs: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        if isinstance(msg, dict):
+            # Preserve all fields from the original message, such as tool calls
+            compiled_msg = dict(msg)
+            # Ensure role and content are always present
+            compiled_msg["role"] = msg.get("role", "NOT_GIVEN")
+            compiled_msg["content"] = TemplateParser.compile_template(
+                msg.get("content", ""),
+                kwargs,
+            )
+            return compiled_msg
+
+        if not hasattr(msg, "content"):
+            return None
+
+        role = getattr(msg, "role", None)
+        if role is None:
+            role = self._LANGCHAIN_MESSAGE_ROLE_MAP.get(
+                str(getattr(msg, "type", "")),
+            )
+
+        if role is None:
+            return None
+
+        content = getattr(msg, "content")
+        compiled_msg = {
+            "role": role,
+            "content": TemplateParser.compile_template(content, kwargs)
+            if isinstance(content, str)
+            else content,
+        }
+
+        for key in ("name", "tool_call_id", "tool_calls", "invalid_tool_calls"):
+            value = getattr(msg, key, None)
+            if value:
+                compiled_msg[key] = value
+
+        return compiled_msg
 
     @property
     def variables(self) -> List[str]:

--- a/tests/unit/test_prompt_compilation.py
+++ b/tests/unit/test_prompt_compilation.py
@@ -1,4 +1,5 @@
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
 
 from langfuse.api import ChatMessage, Prompt_Chat
@@ -932,3 +933,34 @@ def test_tool_calls_preservation_in_message_placeholder():
     # Final user message with compiled variable
     assert compiled_messages[4]["role"] == "user"
     assert compiled_messages[4]["content"] == "Help me with weather inquiry"
+
+
+def test_langchain_messages_in_message_placeholder_are_preserved():
+    prompt_client = ChatPromptClient(
+        Prompt_Chat(
+            type="chat",
+            name="langchain_message_placeholder_test",
+            version=1,
+            config={},
+            tags=[],
+            labels=[],
+            prompt=[
+                {"type": "placeholder", "name": "history"},
+                {"role": "user", "content": "Question for {{name}}"},
+            ],
+        )
+    )
+
+    compiled_messages = prompt_client.compile(
+        name="Ada",
+        history=[
+            HumanMessage(content="Hello {{name}}"),
+            AIMessage(content="Hi {{name}}"),
+        ],
+    )
+
+    assert compiled_messages == [
+        {"role": "user", "content": "Hello Ada"},
+        {"role": "assistant", "content": "Hi Ada"},
+        {"role": "user", "content": "Question for Ada"},
+    ]


### PR DESCRIPTION
﻿## Problem

`ChatPromptClient.compile()` supports chat placeholders and already preserves dict messages, but it treats LangChain `BaseMessage` instances passed to a placeholder as invalid objects. Passing a natural LangChain history like `[HumanMessage(...), AIMessage(...)]` therefore emits a warning and appends the stringified entire history with role `NOT_GIVEN`, losing message roles and content structure.

## Reproducer

Added `test_langchain_messages_in_message_placeholder_are_preserved`, which compiles a chat prompt placeholder with `HumanMessage(content="Hello {{name}}")` and `AIMessage(content="Hi {{name}}")`.

Before the fix, the regression failed because the compiled output contained `role="NOT_GIVEN"` and a stringified placeholder list instead of separate user/assistant messages.

## Fix

Add placeholder-message compilation for LangChain-style message objects by reading their `content`, mapping LangChain message `type` values such as `human` and `ai` to chat roles, compiling string content variables, and preserving optional tool-related fields.

## Testing

- Before fix: `python -m pytest tests\unit\test_prompt_compilation.py::test_langchain_messages_in_message_placeholder_are_preserved -q` failed with the placeholder warning and incorrect `NOT_GIVEN`/stringified output.
- After fix: `.\.venv\Scripts\python.exe -m pytest tests\unit\test_prompt_compilation.py::test_langchain_messages_in_message_placeholder_are_preserved -q` passed.
- After fix: `.\.venv\Scripts\python.exe -m pytest tests\unit\test_prompt_compilation.py -q` passed (`33 passed`).
- After fix: `.\.venv\Scripts\python.exe -m ruff format langfuse\model.py tests\unit\test_prompt_compilation.py --check` passed.
- After fix: `.\.venv\Scripts\python.exe -m ruff check langfuse\model.py tests\unit\test_prompt_compilation.py` passed.

Full `tests\unit` has pre-existing Windows/env failures unrelated to this change, previously observed in serializer path assertions, prompt atexit subprocess environment, and prompt mock setup.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds support for expanding LangChain message objects supplied to chat placeholders and tests variable interpolation for human and AI messages.

- Maps LangChain message types to chat roles.
- Compiles string content and carries selected tool-related attributes into the output.
- Adds regression coverage for `HumanMessage` and `AIMessage` placeholder history.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until LangChain message metadata outside the current allowlist is preserved during placeholder compilation.

The new object-conversion path can silently remove provider-specific function or tool context before compiled messages are sent to a model.

**Files Needing Attention:** langfuse/model.py
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
langfuse/model.py:427-430
**Message metadata is dropped**

When a LangChain message stores provider or subtype data outside `name`, `tool_call_id`, `tool_calls`, and `invalid_tool_calls`, this allowlist removes that data from the compiled history, causing downstream model calls to receive incomplete function or tool context.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(prompt): preserve langchain placehol..."](https://github.com/langfuse/langfuse-python/commit/6f3556a10ad56188e0fbbb534d68aee59c2d31fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57349374)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Prompt retrieval, compilation, and caching](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/prompt-retrieval-compilation-and-cache.md)
- Knowledge Base — [Prompts and framework integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/prompts-and-framework-integrations.md)

<!-- /greptile_comment -->