### PR TITLE
perf(span-processor): skip span_formatter when debug logging is off

### DIFF
--- a/langfuse/_client/span_processor.py
+++ b/langfuse/_client/span_processor.py
@@ -12,6 +12,7 @@ Key features:
 """
 
 import base64
+import logging
 import os
 import threading
 from typing import Callable, Dict, List, Optional, cast
@@ -218,9 +219,13 @@ class LangfuseSpanProcessor(BatchSpanProcessor):
                 )
                 return
 
-            langfuse_logger.debug(
-                f"Trace: Processing span name='{span._name}' | Full details:\n{span_formatter(span)}"
-            )
+            # span_formatter serializes the full span; skip it unless DEBUG is on
+            if langfuse_logger.isEnabledFor(logging.DEBUG):
+                langfuse_logger.debug(
+                    "Trace: Processing span name='%s' | Full details:\n%s",
+                    span.name,
+                    span_formatter(span),
+                )
 
             super().on_end(span)
         finally:

--- a/tests/unit/test_span_processor.py
+++ b/tests/unit/test_span_processor.py
@@ -1,8 +1,12 @@
+import logging
 from typing import Sequence
+from unittest.mock import patch
 
-from opentelemetry.sdk.trace import ReadableSpan
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
+import langfuse._client.span_processor as span_processor_module
 from langfuse._client.environment_variables import (
     LANGFUSE_FLUSH_AT,
     LANGFUSE_FLUSH_INTERVAL,
@@ -54,3 +58,41 @@ def test_span_processor_uses_env_flush_settings_when_constructor_omits_them(
         assert processor._batch_processor._schedule_delay_millis == 3250
     finally:
         processor.shutdown()
+
+
+@pytest.fixture
+def tracer_with_processor():
+    processor = LangfuseSpanProcessor(
+        public_key="pk-test",
+        secret_key="sk-test",
+        base_url="http://localhost:3000",
+        span_exporter=NoOpSpanExporter(),
+    )
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+    yield provider.get_tracer("test-instrumentor")
+    processor.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("level", "expected_formatter_calls"),
+    [(logging.WARNING, 0), (logging.DEBUG, 1)],
+)
+def test_on_end_formats_span_only_when_debug_enabled(
+    caplog, tracer_with_processor, level, expected_formatter_calls
+):
+    caplog.set_level(level, logger="langfuse")
+
+    with patch.object(
+        span_processor_module, "span_formatter", return_value="{}"
+    ) as span_formatter:
+        # gen_ai.* attribute makes the span pass the default export filter
+        with tracer_with_processor.start_as_current_span(
+            "llm-call", attributes={"gen_ai.system": "test"}
+        ):
+            pass
+
+    assert span_formatter.call_count == expected_formatter_calls
+    assert ("Processing span name='llm-call'" in caplog.text) == bool(
+        expected_formatter_calls
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes langfuse/langfuse#15339

`LangfuseSpanProcessor.on_end` built its debug message with an f-string:

```python
langfuse_logger.debug(
    f"Trace: Processing span name='{span._name}' | Full details:\n{span_formatter(span)}"
)
```

f-strings are evaluated before `debug()` is called, so `span_formatter(span)` -- a `json.dumps(indent=2)` of the span's attributes, events, links, resource and scope -- ran on every span end even though the `langfuse` logger defaults to `WARNING` and the string was then discarded. `on_end` runs on the thread that ends the span, the event loop in async apps, so this was a per-span CPU cost proportional to span throughput that no log-level setting could switch off.

Measured locally, `span_formatter` costs 28 us on a small span and 167 us on a 100 KB one; the linked issue reports ~0.27 ms/span. The `isEnabledFor` check costs 0.02 us.

This guards the call so the serialization only runs when the record would be emitted, and passes the message as lazy `%`-style args. Output at DEBUG is unchanged.

Adds a parametrized unit test that drives a real span through the processor and asserts `span_formatter` is not called at `WARNING` and is called once at `DEBUG`. The `WARNING` case fails on `main`.

Related: #1846 converts the SDK's remaining f-string log calls to lazy formatting and enables ruff `G004`. It touches this same call to make it lazy but does not add the guard, so whichever merges second needs a trivial rebase here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Tooling, CI, or repo maintenance

## Verification

```bash
uv run --frozen ruff check .                                        # All checks passed!
uv run --frozen ruff format --check .                              # no drift in changed files
uv run --frozen mypy langfuse --no-error-summary                    # exit 0
uv run --frozen pytest tests/unit/test_span_processor.py            # 4 passed
uv run --frozen pytest -n auto --dist worksteal tests/unit          # 688 passed, 2 skipped
```

e2e / live_provider were not run: unit-testable change, no network behavior touched.

## Checklist

- [x] I self-reviewed the diff using `code_review.md`.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs, examples, or `.env.template` if needed. (n/a, internal-only change)
- [x] I did not hand-edit generated files; if generated files changed, I used the upstream regeneration path.
- [x] I did not commit secrets or credentials.
