### PR TITLE
fix(docs): SEO improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,8 +154,10 @@ If you change CI bootstrap:
 
 ```bash
 uv build --no-sources
-uv run --group docs pdoc -o docs/ --docformat google --logo "https://langfuse.com/langfuse_logo.svg" langfuse
+bash scripts/build_reference_docs.sh
 ```
+
+Build the reference through that script, not by calling pdoc directly -- it applies the `pdoc-templates/` overrides and the 404 page that the hosted site needs. See "SDK Reference" in `CONTRIBUTING.md`.
 
 Releases are handled by GitHub Actions. Do not build an ad hoc local release flow into repository instructions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,15 +133,6 @@ To build the reference into `docs/`, run:
 bash scripts/build_reference_docs.sh
 ```
 
-Build it through the script rather than calling pdoc directly. The script applies the template overrides in `pdoc-templates/` and copies the 404 page, both of which the hosted site needs:
-
-- `pdoc-templates/index.html.jinja2` replaces pdoc's default `index.html`, which is a bare `<meta http-equiv="refresh">` stub with no title, no links and no canonical URL, with a real landing page.
-- `pdoc-templates/module.html.jinja2` adds a self-referencing canonical URL to every module page. The `.html` suffix is dropped on purpose: the site is served with clean URLs, so `/langfuse.html` 308-redirects to `/langfuse`.
-- `pdoc-templates/404.html` is copied into the output because the host serves the landing page with a `200` for any unmatched path when no `404.html` is present, which makes every stale URL an indexable duplicate.
-- `--no-show-source` keeps `langfuse.html` at roughly 480 KB instead of 2.7 MB. `--edit-url` puts a link to the module's source on GitHub on each page instead.
-
-Set `PDOC_CANONICAL_BASE_URL` to build for an origin other than `https://python.reference.langfuse.com/`.
-
 To browse the reference locally with live reload, run pdoc's dev server:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,18 +125,27 @@ The workflow will automatically:
 
 Note: The generated SDK reference is currently work in progress.
 
-The SDK reference is generated via pdoc. The docs dependency group is installed on demand when you run the documentation commands.
+The SDK reference is generated via pdoc and published at [python.reference.langfuse.com](https://python.reference.langfuse.com). The docs dependency group is installed on demand when you run the documentation commands.
 
-To update the reference, run the following command:
+To build the reference into `docs/`, run:
 
 ```sh
-uv run --group docs pdoc -o docs/ --docformat google --logo "https://langfuse.com/langfuse_logo.svg" langfuse
+bash scripts/build_reference_docs.sh
 ```
 
-To run the reference locally, you can use the following command:
+Build it through the script rather than calling pdoc directly. The script applies the template overrides in `pdoc-templates/` and copies the 404 page, both of which the hosted site needs:
+
+- `pdoc-templates/index.html.jinja2` replaces pdoc's default `index.html`, which is a bare `<meta http-equiv="refresh">` stub with no title, no links and no canonical URL, with a real landing page.
+- `pdoc-templates/module.html.jinja2` adds a self-referencing canonical URL to every module page. The `.html` suffix is dropped on purpose: the site is served with clean URLs, so `/langfuse.html` 308-redirects to `/langfuse`.
+- `pdoc-templates/404.html` is copied into the output because the host serves the landing page with a `200` for any unmatched path when no `404.html` is present, which makes every stale URL an indexable duplicate.
+- `--no-show-source` keeps `langfuse.html` at roughly 480 KB instead of 2.7 MB. `--edit-url` puts a link to the module's source on GitHub on each page instead.
+
+Set `PDOC_CANONICAL_BASE_URL` to build for an origin other than `https://python.reference.langfuse.com/`.
+
+To browse the reference locally with live reload, run pdoc's dev server:
 
 ```sh
-uv run --group docs pdoc --docformat google --logo "https://langfuse.com/langfuse_logo.svg" langfuse
+uv run --group docs pdoc --docformat google --logo "https://langfuse.com/langfuse_logo.svg" --template-directory pdoc-templates langfuse
 ```
 
 ## Credits

--- a/pdoc-templates/404.html
+++ b/pdoc-templates/404.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Page not found &ndash; Langfuse Python SDK API reference</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family:
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          "Helvetica Neue",
+          Arial,
+          sans-serif;
+        color: #212529;
+        background: #fff;
+      }
+      main {
+        max-width: 32rem;
+        padding: 2rem;
+        text-align: center;
+      }
+      img {
+        max-width: 12rem;
+        margin-bottom: 2rem;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin: 0 0 0.75rem;
+      }
+      p {
+        margin: 0 0 1.5rem;
+        line-height: 1.6;
+        color: #495057;
+      }
+      a {
+        color: #0d6efd;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <img src="https://langfuse.com/langfuse_logo.svg" alt="Langfuse" />
+      <h1>Page not found</h1>
+      <p>
+        This page is not part of the Langfuse Python SDK API reference. The
+        symbol may have been renamed or removed in a later release.
+      </p>
+      <p>
+        <a href="/">Browse the API reference</a> &middot;
+        <a href="https://langfuse.com/docs">Langfuse documentation</a>
+      </p>
+    </main>
+  </body>
+</html>

--- a/pdoc-templates/index.html.jinja2
+++ b/pdoc-templates/index.html.jinja2
@@ -1,0 +1,62 @@
+{#
+Root page of https://python.reference.langfuse.com.
+
+pdoc's default index is a bare `<meta http-equiv="refresh">` stub with no
+title, no links and no canonical URL, because a single root module makes
+`langfuse.html` the entry point. Search engines read that stub as a
+soft-redirecting duplicate of `/index.html`. Setting `root_module_name` to
+false -- the escape hatch the default template documents -- renders the real
+module list instead, and the `content` block below gives that page something
+to say, since pdoc's own version leaves the main column empty.
+#}
+{% set canonical_base_url = env.get("PDOC_CANONICAL_BASE_URL", "https://python.reference.langfuse.com/") %}
+{% set root_module_name = false %}
+{% extends "default/index.html.jinja2" %}
+
+{% block title %}Langfuse Python SDK API reference{% endblock %}
+
+{% block head %}
+    <link rel="canonical" href="{{ canonical_base_url }}"/>
+    <meta name="description"
+          content="Generated API reference for the Langfuse Python SDK: clients, tracing, prompt management, datasets, evaluation and the underlying API models."/>
+{% endblock %}
+
+{% block content %}
+    <header class="pdoc">
+        {{ self.logo() }}
+        {% if search %}
+            <input type="search" placeholder="Search API Documentation..." aria-label="search box">
+        {% endif %}
+    </header>
+    <main class="pdoc">
+        <section>
+            <h1>Langfuse Python SDK API reference</h1>
+            <p>
+                Generated reference for the <code>langfuse</code> package. It documents
+                every public symbol; the hand-written guides on
+                <a href="https://langfuse.com/docs">langfuse.com/docs</a> are the better
+                starting point if you are setting Langfuse up for the first time.
+            </p>
+            <h2>Start here</h2>
+            <ul>
+                <li><a href="langfuse.html"><code>langfuse</code></a> &mdash; the
+                    <code>Langfuse</code> client, tracing decorators and context helpers.
+                    Most code only needs this module.</li>
+                <li><a href="langfuse/experiment.html"><code>langfuse.experiment</code></a>
+                    &mdash; running experiments over datasets and scoring the results.</li>
+                <li><a href="langfuse/api.html"><code>langfuse.api</code></a> &mdash; the
+                    generated low-level API client and its request and response models.</li>
+            </ul>
+            <h2>Elsewhere</h2>
+            <ul>
+                <li><a href="https://langfuse.com/docs/observability/sdk/python/overview">Python SDK documentation</a></li>
+                <li><a href="https://github.com/langfuse/langfuse-python">langfuse-python on GitHub</a></li>
+                <li><a href="https://pypi.org/project/langfuse/">langfuse on PyPI</a></li>
+            </ul>
+            <p>Every module is listed in the sidebar, and the search box covers all of them.</p>
+        </section>
+    </main>
+    {% if search %}
+        {% include "search.html.jinja2" %}
+    {% endif %}
+{% endblock %}

--- a/pdoc-templates/index.html.jinja2
+++ b/pdoc-templates/index.html.jinja2
@@ -9,7 +9,7 @@ false -- the escape hatch the default template documents -- renders the real
 module list instead, and the `content` block below gives that page something
 to say, since pdoc's own version leaves the main column empty.
 #}
-{% set canonical_base_url = env.get("PDOC_CANONICAL_BASE_URL", "https://python.reference.langfuse.com/") %}
+{% set canonical_base_url = env.get("PDOC_CANONICAL_BASE_URL", "https://python.reference.langfuse.com/").rstrip("/") ~ "/" %}
 {% set root_module_name = false %}
 {% extends "default/index.html.jinja2" %}
 
@@ -38,6 +38,14 @@ to say, since pdoc's own version leaves the main column empty.
                 starting point if you are setting Langfuse up for the first time.
             </p>
             <h2>Start here</h2>
+            {#
+            These keep the `.html` suffix even though the hosted site serves
+            clean URLs. pdoc generates its own sidebar links that way, and
+            extensionless paths 404 both under pdoc's dev server and when the
+            built output is served locally, so the one 308 hop in production is
+            the cheaper trade. Canonical URLs are a different case -- those must
+            not point at a redirect, which is why they drop the suffix.
+            #}
             <ul>
                 <li><a href="langfuse.html"><code>langfuse</code></a> &mdash; the
                     <code>Langfuse</code> client, tracing decorators and context helpers.

--- a/pdoc-templates/module.html.jinja2
+++ b/pdoc-templates/module.html.jinja2
@@ -1,0 +1,15 @@
+{#
+Adds a self-referencing canonical URL to every module page.
+
+The `.html` suffix is deliberately dropped: Cloudflare Pages serves this site
+with clean URLs and 308-redirects `/langfuse.html` to `/langfuse`, so a
+canonical pointing at the `.html` path would point at a redirect.
+#}
+{% set canonical_base_url = env.get("PDOC_CANONICAL_BASE_URL", "https://python.reference.langfuse.com/") %}
+{% extends "default/module.html.jinja2" %}
+
+{% block head %}
+    {{ super() }}
+    <link rel="canonical"
+          href="{{ canonical_base_url }}{{ module.modulename.replace('.', '/') }}"/>
+{% endblock %}

--- a/pdoc-templates/module.html.jinja2
+++ b/pdoc-templates/module.html.jinja2
@@ -5,7 +5,7 @@ The `.html` suffix is deliberately dropped: Cloudflare Pages serves this site
 with clean URLs and 308-redirects `/langfuse.html` to `/langfuse`, so a
 canonical pointing at the `.html` path would point at a redirect.
 #}
-{% set canonical_base_url = env.get("PDOC_CANONICAL_BASE_URL", "https://python.reference.langfuse.com/") %}
+{% set canonical_base_url = env.get("PDOC_CANONICAL_BASE_URL", "https://python.reference.langfuse.com/").rstrip("/") ~ "/" %}
 {% extends "default/module.html.jinja2" %}
 
 {% block head %}

--- a/scripts/build_reference_docs.sh
+++ b/scripts/build_reference_docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Builds the API reference published at https://python.reference.langfuse.com.
+#
+# Use this instead of calling pdoc directly: it applies the template overrides
+# in pdoc-templates/ and ships the 404 page, both of which the hosted site
+# needs. Set PDOC_CANONICAL_BASE_URL to build for a different origin.
+set -euo pipefail
+
+OUT_DIR="${1:-docs}"
+
+cd "$(dirname "$0")/.."
+
+uv run --group docs pdoc \
+  -o "$OUT_DIR" \
+  --docformat google \
+  --logo "https://langfuse.com/langfuse_logo.svg" \
+  --logo-link "https://langfuse.com" \
+  --template-directory pdoc-templates \
+  --edit-url "langfuse=https://github.com/langfuse/langfuse-python/blob/main/langfuse/" \
+  --no-show-source \
+  langfuse
+
+# Cloudflare Pages serves the closest index.html with a 200 for any unmatched
+# path unless the output contains a 404.html, which turns every stale or
+# mistyped URL into an indexable duplicate of the landing page.
+cp pdoc-templates/404.html "$OUT_DIR/404.html"
+
+echo "Reference docs written to $OUT_DIR/"

--- a/scripts/build_reference_docs.sh
+++ b/scripts/build_reference_docs.sh
@@ -8,6 +8,14 @@ set -euo pipefail
 
 OUT_DIR="${1:-docs}"
 
+# Resolve a relative output path against the caller's working directory before
+# cd'ing to the repo root, so `build_reference_docs.sh out` from elsewhere does
+# not silently write to <repo>/out.
+case "$OUT_DIR" in
+  /*) ;;
+  *) OUT_DIR="$PWD/$OUT_DIR" ;;
+esac
+
 cd "$(dirname "$0")/.."
 
 uv run --group docs pdoc \


### PR DESCRIPTION
Four of the errors in the September Ahrefs Site Audit of langfuse.com land on `python.reference.langfuse.com` (the crawl runs in subdomains mode). None of them come from the SDK — all four come from how pdoc's output is generated and served.

> [!IMPORTANT]
> **This PR alone does not change the live site.** The published build command lives outside this repo — `docs/` is gitignored, and no workflow here references pdoc. Whoever owns the Cloudflare Pages project needs to point its build command at `bash scripts/build_reference_docs.sh` (output directory `docs`). Details in "Deploying this" below.

## What's wrong

**1. `/` is a stub with no title, no links and no canonical.** With a single root module, pdoc makes `langfuse.html` the entry point and writes an `index.html` that is nothing but a redirect:

```html
<!doctype html>
<html>
<head>
    <meta charset="utf-8">
    <meta http-equiv="refresh" content="0; url=./langfuse.html"/>
</head>
</html>
```

That accounts for three audit errors at once: `Title tag missing or empty`, `Page has no outgoing links`, and `Duplicate pages without canonical` (`/` and `/index.html` are byte-identical with nothing marking either canonical).

**2. Every unmatched path returns that stub with HTTP 200.** The host has no `404.html` in the output, so it falls back to the landing page for anything it cannot match:

```
$ for p in /nope-does-not-exist /langfuse/nope.html /langfuse/concepts/models.md /404.html; do
    curl -s -o /dev/null -w "%{http_code} %{size_download}b  $p\n" "https://python.reference.langfuse.com$p"; done
200 1077b  /nope-does-not-exist
200 1077b  /langfuse/nope.html
200 1077b  /langfuse/concepts/models.md
200 1077b  /404.html
```

Every stale or mistyped URL is therefore an indexable duplicate. That is how two paths that have never existed — `…/langfuse/concepts/models.md` and `…/langfuse/api/concepts/models.md` — ended up in the crawl as real pages. For comparison, `js.reference.langfuse.com` returns a proper `404` for the same request.

**3. `/langfuse` is 2.7 MB.** pdoc inlines the full source of every symbol. That is over Ahrefs' 2 MB crawl limit, so the single most important page on the reference site is not crawled at all — and it is slow for readers regardless of crawlers.

## The fix

| # | Change | Effect |
| --- | --- | --- |
| 1 | `pdoc-templates/index.html.jinja2` sets `root_module_name` to false — the escape hatch pdoc's own template documents — and fills the main column, which pdoc's version leaves empty | `/` becomes a real landing page: title, meta description, canonical, and links to `langfuse`, `langfuse.experiment`, `langfuse.api` plus the docs, GitHub and PyPI |
| 2 | `pdoc-templates/module.html.jinja2` adds a self-referencing canonical to every module page | 50/50 pages now carry one |
| 3 | `pdoc-templates/404.html` is copied into the output | unmatched paths get a real 404 instead of a 200 |
| 4 | `--no-show-source`, with `--edit-url` adding a GitHub source link per module in its place | `langfuse.html` 2.7 MB → 484 KB |
| 5 | `scripts/build_reference_docs.sh` wraps all of the above | the site cannot be built incorrectly by accident |

On (2): the `.html` suffix is deliberately dropped from the canonical. The site is served with clean URLs, and `/langfuse.html` 308-redirects to `/langfuse` — so a canonical pointing at the `.html` path would point at a redirect, which is its own audit error:

```
$ curl -so /dev/null -w "%{http_code} -> %{redirect_url}\n" https://python.reference.langfuse.com/langfuse.html
308 -> https://python.reference.langfuse.com/langfuse
```

On (4): losing the inline source is a real trade, which is why `--edit-url` is added alongside it — every module page now links to its source on GitHub (verified: `/langfuse/__init__.py` and `/langfuse/experiment.py` both 200). 2.7 MB of HTML on one page is worse for readers than one click through to GitHub.

`PDOC_CANONICAL_BASE_URL` overrides the canonical origin for local or preview builds.

## Verification

`bash scripts/build_reference_docs.sh <tmpdir>` with pdoc 15.0.4, then served locally and driven in a browser.

**Every page now has a title and a clean-URL canonical:**

```
51 html pages, 404.html present: True
pages without a canonical:            none
canonicals ending in .html:           none
pages without a title:                none

index.html                title: Langfuse Python SDK API reference
                      canonical: https://python.reference.langfuse.com/
                          links: 49
langfuse.html             title: langfuse API documentation
                      canonical: https://python.reference.langfuse.com/langfuse
langfuse/experiment.html  title: langfuse.experiment API documentation
                      canonical: https://python.reference.langfuse.com/langfuse/experiment
```

**Page sizes** — nothing over 2 MB any more (was 2669 KB):

```
  484 KB  langfuse.html
  196 KB  langfuse/api.html
  120 KB  langfuse/experiment.html
    0     pages over 2 MB
```

**Search still works**, and pdoc's restore-on-clear behaviour keeps the new landing content intact — the `content` block writes into `main.pdoc`, which is exactly what pdoc's search captures as `originalContent`:

```
query "start_observation" → 10 results, first: "def langfuse.Langfuse.start_observation(…"
cleared query             → main restored to "Langfuse Python SDK API reference", 7 links
```

**Rendered** the landing page, a module page and the 404 page in a browser; all three look correct, logo and styling intact. Every link on the landing page checked: the three module targets exist in the output, and the three external links return 200.

`uv run --frozen ruff check .` passes, `bash -n scripts/build_reference_docs.sh` clean. Nothing here is touched by the pre-commit hooks or CI (they cover Python under `langfuse/` only).

## Deploying this

`docs/` is gitignored and no workflow in this repo builds it, so the published site is built from outside — the host is Cloudflare Pages (it strips `.html`, 308-redirects trailing slashes, and falls back to the landing page when no `404.html` exists; `js.reference` by contrast is on Vercel).

To make this PR take effect, the Pages project's build command needs to become:

```sh
bash scripts/build_reference_docs.sh
```

with output directory `docs`. If the site is instead deployed by hand, run that script before `wrangler pages deploy docs`.

Fix (3) — the `404.html` — is the highest-value item, since it stops *every* stale URL from being indexed, not just the two the crawl happened to find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a standardized pdoc reference-site build that generates an indexable landing page, clean canonical metadata, a static 404 response, smaller module pages, and GitHub source links. It also updates contributor guidance to require the new build script.

- Replaces pdoc’s redirect-only root page with navigable reference content and metadata.
- Adds canonical links to generated module pages.
- Copies a dedicated noindex 404 page into the deployment output.
- Disables large inline source listings while retaining source links.
- Documents the required reference-site build path.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until alternate canonical origins are normalized, because the documented override can generate incorrect metadata across every module page.

The default production origin works, but supplying the documented override without a trailing slash concatenates the hostname and module name, breaking all generated module canonicals for that build.

**Files Needing Attention:** pdoc-templates/module.html.jinja2
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Script["build_reference_docs.sh"] --> Pdoc["pdoc 15.0.4"]
  Templates["pdoc-templates"] --> Pdoc
  Pdoc --> Index["docs/index.html"]
  Pdoc --> Modules["docs/module pages"]
  ErrorPage["pdoc-templates/404.html"] --> Copy["Copy step"]
  Copy --> NotFound["docs/404.html"]
  Index --> Pages["Cloudflare Pages output"]
  Modules --> Pages
  NotFound --> Pages
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
pdoc-templates/module.html.jinja2:14
**Canonical URLs Can Merge**

If `PDOC_CANONICAL_BASE_URL` is set to a normal origin without a trailing slash, this direct concatenation joins the hostname and module path. For example, `https://preview.example` produces `https://preview.examplelangfuse`, so every module page in that build receives an incorrect canonical URL.

```suggestion
          href="{{ canonical_base_url.rstrip('/') }}/{{ module.modulename.replace('.', '/') }}"/>
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): make the generated reference ..."](https://github.com/langfuse/langfuse-python/commit/56082f117b8b2ca247334461b0041a0526c9affa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60339216)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->