### PR TITLE
fix: keep interleaved n>1 streamed choices separate in OpenAI extraction

### DIFF
--- a/langfuse/openai.py
+++ b/langfuse/openai.py
@@ -760,7 +760,10 @@ def _extract_streamed_response_api_response(chunks: Any) -> Any:
 
 
 def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
-    completion: Any = defaultdict(lambda: None) if resource.type == "chat" else ""
+    # Streamed chunks of an n > 1 completion interleave choices, so every choice
+    # accumulates into its own completion keyed by its choice index instead of
+    # merging into a single corrupted output.
+    completions: dict[int, Any] = {}
     model, usage, finish_reason, service_tier = None, None, None, None
 
     for chunk in chunks:
@@ -778,7 +781,15 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
         for choice in choices:
             if _is_openai_v1():
                 choice = choice.__dict__
+
+            choice_index = choice.get("index", None)
+            if not isinstance(choice_index, int):
+                choice_index = 0
+
             if resource.type == "chat":
+                completion = completions.setdefault(
+                    choice_index, defaultdict(lambda: None)
+                )
                 delta = choice.get("delta", None)
                 choice_finish_reason = choice.get("finish_reason", None)
                 if choice_finish_reason is not None:
@@ -868,9 +879,10 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
                             ) + tool_arguments
 
             if resource.type == "completion":
-                completion += choice.get("text", "")
+                completions.setdefault(choice_index, "")
+                completions[choice_index] += choice.get("text", "")
 
-    def get_response_for_chat() -> Any:
+    def get_response_for_chat(completion: Any) -> Any:
         content = completion["content"]
 
         if completion["tool_calls"]:
@@ -897,9 +909,25 @@ def _extract_streamed_openai_response(resource: Any, chunks: Any) -> Any:
 
         return content or None
 
+    # Match the non-streaming behavior: a single choice keeps its scalar
+    # output shape, multiple choices are returned as a list in choice order.
+    if len(completions) > 1:
+        ordered = [completions[index] for index in sorted(completions)]
+        completion = (
+            [get_response_for_chat(item) for item in ordered]
+            if resource.type == "chat"
+            else ordered
+        )
+    elif resource.type == "chat":
+        completion = get_response_for_chat(
+            next(iter(completions.values()), defaultdict(lambda: None))
+        )
+    else:
+        completion = next(iter(completions.values()), "")
+
     return (
         model,
-        get_response_for_chat() if resource.type == "chat" else completion,
+        completion,
         usage,
         {"finish_reason": finish_reason} if finish_reason is not None else None,
         service_tier,

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -401,6 +401,141 @@ def test_streaming_chat_completion_preserves_tool_calls_after_content():
     assert metadata == {"finish_reason": "tool_calls"}
 
 
+def _make_multi_choice_stream_chunks():
+    def choice(index, delta=None, finish_reason=None):
+        return SimpleNamespace(index=index, delta=delta, finish_reason=finish_reason)
+
+    return [
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            usage=None,
+            choices=[
+                choice(0, delta=SimpleNamespace(content="A", tool_calls=None)),
+                choice(1, delta=SimpleNamespace(content="B", tool_calls=None)),
+            ],
+        ),
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            usage=None,
+            choices=[
+                choice(
+                    1,
+                    delta=SimpleNamespace(
+                        content=None,
+                        tool_calls=[
+                            SimpleNamespace(
+                                index=0,
+                                id="call_paris",
+                                type="function",
+                                function=SimpleNamespace(
+                                    name="get_weather",
+                                    arguments='{"city": "Par',
+                                ),
+                            )
+                        ],
+                    ),
+                ),
+                choice(
+                    0,
+                    delta=SimpleNamespace(
+                        content=None,
+                        tool_calls=[
+                            SimpleNamespace(
+                                index=0,
+                                id="call_berlin",
+                                type="function",
+                                function=SimpleNamespace(
+                                    name="get_weather",
+                                    arguments='{"city": "Berli',
+                                ),
+                            )
+                        ],
+                    ),
+                ),
+            ],
+        ),
+        SimpleNamespace(
+            model="gpt-4o-mini",
+            usage=None,
+            choices=[
+                choice(
+                    0,
+                    delta=SimpleNamespace(
+                        content=None,
+                        tool_calls=[
+                            SimpleNamespace(
+                                index=0,
+                                id="call_berlin",
+                                type="function",
+                                function=SimpleNamespace(name=None, arguments='n"}'),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                ),
+                choice(
+                    1,
+                    delta=SimpleNamespace(
+                        content=None,
+                        tool_calls=[
+                            SimpleNamespace(
+                                index=0,
+                                id="call_paris",
+                                type="function",
+                                function=SimpleNamespace(name=None, arguments='is"}'),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                ),
+            ],
+        ),
+    ]
+
+
+def test_streaming_chat_completion_keeps_interleaved_choices_separate():
+    model, completion, usage, metadata, _service_tier = (
+        lf_openai_module._extract_streamed_openai_response(
+            SimpleNamespace(type="chat"),
+            _make_multi_choice_stream_chunks(),
+        )
+    )
+
+    assert model == "gpt-4o-mini"
+    assert completion == [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_berlin",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city": "Berlin"}',
+                    },
+                }
+            ],
+            "content": "A",
+        },
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_paris",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city": "Paris"}',
+                    },
+                }
+            ],
+            "content": "B",
+        },
+    ]
+    assert usage is None
+    assert metadata == {"finish_reason": "tool_calls"}
+
+
 def test_response_api_output_serializes_openai_parsed_response_objects():
     class ParsedOutput(BaseModel):
         name: str


### PR DESCRIPTION
### What

`_extract_streamed_openai_response` accumulated every streamed choice into a single completion object. With `n > 1`, choices interleave in the stream, so content from different choices and tool-call arguments from different choices were merged into one corrupted output.

This change accumulates each choice separately, keyed by its `choice.index` (defaulting to 0 when a provider omits it):

- single-choice streams keep the exact same output shape as before;
- multi-choice streams now return a list ordered by choice index, matching the existing non-streaming behavior in `_get_langfuse_data_from_default_response`, which already returns a list for `len(choices) > 1`.

### Why

Reported in langfuse/langfuse#16998: with an interleaved two-choice stream (`n=2, stream=True`), the recorded output contained merged content and tool arguments from both choices.

### How tested

- Added `test_streaming_chat_completion_keeps_interleaved_choices_separate`: an interleaved two-choice stream with tool calls now produces two separate outputs, each with its own content and tool-call arguments.
- `pytest tests/unit/test_openai.py`: 35 passed.
- `ruff check`, `ruff format --check`, `mypy langfuse --no-error-summary`: clean.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR separates interleaved streamed OpenAI choices by their choice index instead of merging them into one corrupted output.

- Accumulates chat content, function calls, tool calls, and text completions independently per choice.
- Preserves scalar output for a single observed choice and returns index-ordered lists for multiple choices.
- Adds a regression test for interleaved multi-choice chat streams with tool calls.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking test-coverage gap for multi-choice streamed legacy text completions.

The indexed chat accumulation is consistent with the intended fix and is covered by an interleaving regression test; only the newly changed text-completion branch lacks direct coverage.

**Files Needing Attention:** langfuse/openai.py, tests/unit/test_openai.py
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Receive streamed chunk] --> B[Iterate choices]
    B --> C[Read choice index]
    C --> D[Select per-index accumulator]
    D --> E[Append content or tool-call fragments]
    E --> F{More chunks?}
    F -->|Yes| A
    F -->|No| G[Sort accumulators by choice index]
    G --> H{Number of choices}
    H -->|One| I[Return scalar output]
    H -->|Multiple| J[Return ordered list]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
langfuse/openai.py:881-883
**Text Completion Branch Untested**

This refactor also changes streamed legacy text completions with multiple choices from one merged string to an ordered list, while the non-streaming path still returns one string. The new regression test covers only chat completions. Add an `n > 1` text-completion test to define this new output shape and prevent the untested branch from silently regressing or diverging further from the non-streaming path.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep interleaved n&gt;1 streamed choic..."](https://github.com/langfuse/langfuse-python/commit/1956f779c35a4af164349134d525fa2776565dea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60720431)</sub>

<!-- /greptile_comment -->