### PR TITLE
fix: propagate control-flow exceptions from async helper thread

### DIFF
--- a/langfuse/_client/utils.py
+++ b/langfuse/_client/utils.py
@@ -96,13 +96,13 @@ class _RunAsyncThread(threading.Thread):
         self.coro = coro
         self.context = contextvars.copy_context()
         self.result: Any = None
-        self.exception: Exception | None = None
+        self.exception: BaseException | None = None
         super().__init__()
 
     def run(self) -> None:
         try:
             self.result = self.context.run(asyncio.run, self.coro)
-        except Exception as e:
+        except BaseException as e:
             self.exception = e
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,6 +13,37 @@ from langfuse._client.utils import run_async_safely
 class TestRunAsyncSafely:
     """Test suite for the run_async_safely function."""
 
+    @pytest.mark.parametrize(
+        "error_type", [asyncio.CancelledError, SystemExit, KeyboardInterrupt]
+    )
+    def test_control_flow_exception_in_sync_context(self, error_type):
+        """Control-flow exceptions retain their identity without an active loop."""
+        error = error_type("operation interrupted")
+
+        async def interrupted():
+            raise error
+
+        with pytest.raises(error_type) as caught:
+            run_async_safely(interrupted())
+
+        assert caught.value is error
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error_type", [asyncio.CancelledError, SystemExit, KeyboardInterrupt]
+    )
+    async def test_control_flow_exception_from_thread(self, error_type):
+        """A worker's cancellation or exit is propagated to the calling thread."""
+        error = error_type("operation interrupted")
+
+        async def interrupted():
+            raise error
+
+        with pytest.raises(error_type) as caught:
+            run_async_safely(interrupted())
+
+        assert caught.value is error
+
     def test_run_sync_context_simple(self):
         """Test run_async_safely in sync context with simple coroutine."""
 


### PR DESCRIPTION
## What does this PR do?

`run_async_safely` now propagates cancellation and exit exceptions when it runs a coroutine in its helper thread. Previously, `CancelledError`, `SystemExit` and `KeyboardInterrupt` escaped the worker while the caller received `None`, unlike the direct `asyncio.run` path. The original exception object reaches the caller in both contexts.

## Type of change

- [x] Bug fix

## Verification

Refreshed against main `65392c7` and checked on Python 3.13:

```bash
uv run --frozen pytest tests/unit/test_utils.py tests/unit/test_resource_manager.py tests/unit/test_otel.py -q
uv run --frozen pytest -n 4 --dist worksteal tests/unit -q
uv run --frozen ruff check .
uv run --frozen ruff format --check langfuse/_client/utils.py tests/unit/test_utils.py
uv run --frozen mypy langfuse --no-error-summary
```

The targeted run passed 99 tests with 2 skips. Ruff, changed-file formatting and mypy pass. The three new threaded regression cases failed before the original fix.

The full unit suite on native Windows produced 682 passes, 2 skips, 3 failures and 18 fixture errors. All 21 failing/error cases were reproduced on untouched current main: two prompt atexit subprocess tests, a Windows path assertion and prompt-client initialization fixtures. Tests used a private writable temporary directory. Server and live-provider suites were not run because this bridge behavior is covered without external services.

## Checklist

- [x] Self-reviewed the diff using `code_review.md`.
- [x] Added tests for behavior changes.
- [x] Checked docs, examples and `.env.template`; the existing exception contract already describes the intended behavior.
- [x] Did not hand-edit generated files.
- [x] Did not commit secrets or credentials.

No service deployment or new telemetry is involved in this SDK fix.

Agent-assisted: Codex prepared the patch, refreshed the branch and ran the local checks listed above.


---

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `run_async_safely` so control-flow exceptions raised in its helper thread reach the caller, consistent with its direct execution path.

- Stores helper-thread failures as `BaseException` rather than only `Exception`.
- Propagates cancellation and process-control exceptions without replacing the original object.
- Adds parameterized coverage for synchronous and helper-thread execution.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the implementation matching the existing exception contract and direct execution behavior.

No actionable failures remain; the worker is joined before the original captured exception is re-raised, and the new tests cover all control-flow exceptions targeted by the fix.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: propagate control-flow exceptions f..."](https://github.com/langfuse/langfuse-python/commit/de707fd464dd08bd10f2441d35fdc139a9a081d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61608003)</sub>

<!-- /greptile_comment -->
