### PR TITLE
fix(experiments): await future and custom awaitable results

### DIFF
--- a/langfuse/_client/client.py
+++ b/langfuse/_client/client.py
@@ -4,6 +4,7 @@ This module implements Langfuse's core observability functionality on top of the
 """
 
 import asyncio
+import inspect
 import logging
 import os
 import re
@@ -3183,7 +3184,7 @@ class Langfuse:
                                         evaluations=evaluations,
                                     )
 
-                                    if asyncio.iscoroutine(result):
+                                    if inspect.isawaitable(result):
                                         result = await result
 
                                     composite_evals = _normalize_evaluator_result(

--- a/langfuse/experiment.py
+++ b/langfuse/experiment.py
@@ -5,7 +5,7 @@ allowing users to run experiments on datasets with automatic tracing, evaluation
 and result formatting.
 """
 
-import asyncio
+import inspect
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
@@ -1007,7 +1007,7 @@ async def _run_evaluator(
         result = evaluator(**kwargs)
 
         # Handle async evaluators
-        if asyncio.iscoroutine(result):
+        if inspect.isawaitable(result):
             result = await result
 
         return _normalize_evaluator_result(result)
@@ -1026,7 +1026,7 @@ async def _run_task(task: TaskFunction, item: ExperimentItem) -> Any:
     result = task(item=item)
 
     # Handle async tasks
-    if asyncio.iscoroutine(result):
+    if inspect.isawaitable(result):
         result = await result
 
     return result

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -1,5 +1,6 @@
 """Tests for ``langfuse.experiment`` — ``RunnerContext`` and ``RegressionError``."""
 
+import asyncio
 import inspect
 import typing
 from datetime import datetime
@@ -13,6 +14,70 @@ from langfuse import Evaluation, RegressionError, RunnerContext
 from langfuse._client.attributes import LangfuseOtelSpanAttributes
 from langfuse._client.client import Langfuse
 from langfuse.batch_evaluation import CompositeEvaluatorFunction
+
+
+@pytest.fixture(params=["value", "coroutine", "future", "task", "awaitable"])
+def wrap_result(request):
+    """Return equivalent results through each supported awaitable shape."""
+
+    def wrap(value):
+        async def resolve():
+            return value
+
+        class CustomAwaitable:
+            def __await__(self):
+                return resolve().__await__()
+
+        if request.param == "value":
+            return value
+        if request.param == "coroutine":
+            return resolve()
+        if request.param == "task":
+            return asyncio.create_task(resolve())
+        if request.param == "awaitable":
+            return CustomAwaitable()
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        loop.call_soon(future.set_result, value)
+        return future
+
+    return wrap
+
+
+class TestExperimentAwaitableResults:
+    def test_task_output_is_resolved(self, langfuse_memory_client, wrap_result):
+        def task(*, item):
+            return wrap_result("answer")
+
+        result = langfuse_memory_client.run_experiment(
+            name="awaitable-task", data=[{"input": "question"}], task=task
+        )
+
+        assert result.item_results[0].output == "answer"
+
+    def test_item_and_run_evaluations_are_resolved(
+        self, langfuse_memory_client, wrap_result, monkeypatch
+    ):
+        monkeypatch.setattr(langfuse_memory_client, "create_score", MagicMock())
+
+        def task(*, item):
+            return "answer"
+
+        def evaluator(**kwargs):
+            return wrap_result({"name": "quality", "value": 1.0})
+
+        result = langfuse_memory_client.run_experiment(
+            name="awaitable-evaluators",
+            data=[{"input": "question"}],
+            task=task,
+            evaluators=[evaluator],
+            run_evaluators=[evaluator],
+        )
+
+        assert [(e.name, e.value) for e in result.item_results[0].evaluations] == [
+            ("quality", 1.0)
+        ]
+        assert [(e.name, e.value) for e in result.run_evaluations] == [("quality", 1.0)]
 
 
 def _noop_task(*, item, **kwargs):  # pragma: no cover - never invoked via mock

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -79,6 +79,38 @@ class TestExperimentAwaitableResults:
         ]
         assert [(e.name, e.value) for e in result.run_evaluations] == [("quality", 1.0)]
 
+    def test_composite_evaluation_is_resolved_and_scored(
+        self, langfuse_memory_client, wrap_result, monkeypatch
+    ):
+        create_score = MagicMock()
+        monkeypatch.setattr(langfuse_memory_client, "create_score", create_score)
+
+        def task(*, item):
+            return "answer"
+
+        def evaluator(**kwargs):
+            return {"name": "quality", "value": 1.0}
+
+        def composite_evaluator(*, evaluations, **kwargs):
+            return wrap_result({"name": "aggregate", "value": evaluations[0].value})
+
+        result = langfuse_memory_client.run_experiment(
+            name="awaitable-composite",
+            data=[{"input": "question"}],
+            task=task,
+            evaluators=[evaluator],
+            composite_evaluator=composite_evaluator,
+        )
+
+        assert [(e.name, e.value) for e in result.item_results[0].evaluations] == [
+            ("quality", 1.0),
+            ("aggregate", 1.0),
+        ]
+        assert [
+            (call.kwargs["name"], call.kwargs["value"])
+            for call in create_score.call_args_list
+        ] == [("quality", 1.0), ("aggregate", 1.0)]
+
 
 def _noop_task(*, item, **kwargs):  # pragma: no cover - never invoked via mock
     return None


### PR DESCRIPTION
## What does this PR do?

Experiments now resolve `Future`, `Task` and custom awaitable results before recording task output or evaluating scores. Previously, task output could contain the awaitable object itself, and evaluator scores could be dropped, even though the callback protocols allow `Awaitable` results.

Task callbacks, item evaluators, run evaluators and composite evaluators all use the corrected handling. Direct values and coroutines retain their existing behavior.

## Type of change

- [x] Bug fix

## Verification

Refreshed against main `65392c7` and checked on Python 3.13:

```bash
uv run --frozen pytest tests/unit/test_experiment.py -q
uv run --frozen pytest -n 4 --dist worksteal tests/unit -q
uv run --frozen ruff check .
uv run --frozen ruff format --check langfuse/experiment.py langfuse/_client/client.py tests/unit/test_experiment.py
uv run --frozen mypy langfuse --no-error-summary
```

All 35 experiment tests pass, including public `run_experiment` cases for values, coroutines, pending Futures, Tasks and custom awaitables. Composite tests assert both returned evaluations and score creation. The original six task/item/run regression variants and three composite variants failed before their respective fixes. Ruff, changed-file formatting and mypy pass.

The full unit suite on native Windows produced 691 passes, 2 skips, 3 failures and 18 fixture errors. All 21 failing/error cases were reproduced on untouched current main: two prompt atexit subprocess tests, a Windows path assertion and prompt-client initialization fixtures. Tests used a private writable temporary directory. Server and live-provider suites were not run; these cases use the existing in-memory fixture.

## Checklist

- [x] Self-reviewed the diff using `code_review.md`.
- [x] Added tests for behavior changes.
- [x] Checked docs, examples and `.env.template`; callback protocols already document awaitable results.
- [x] Did not hand-edit generated files.
- [x] Did not commit secrets or credentials.

No service deployment or new monitoring is needed for this SDK result-handling fix.

Agent-assisted: Codex prepared the patch, refreshed the branch and ran the local checks listed above.


---

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR broadens experiment callback result handling from coroutine-only detection to all Python awaitables.

- Resolves Futures, Tasks, and custom awaitables returned by experiment tasks.
- Applies the same handling to item and run evaluators.
- Adds parameterized unit coverage for direct values, coroutines, Futures, Tasks, and custom awaitables.
- Leaves the separate composite-evaluator path using coroutine-only detection.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because composite evaluators can still silently lose valid Future, Task, and custom-awaitable results.

Item and run evaluator results are now resolved correctly, but the third supported experiment evaluation layer bypasses the corrected helper and retains the same coroutine-only behavior this PR is intended to fix.

**Files Needing Attention:** langfuse/experiment.py and langfuse/_client/client.py
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
langfuse/experiment.py:1010
**Composite awaitables remain unresolved**

The new awaitable handling only covers item and run evaluators. Composite evaluators use a separate coroutine-only check, so a composite evaluator returning a Future, Task, or custom awaitable allowed by its callback protocol passes the unresolved object to normalization. The result is silently discarded, and its composite evaluation and score are missing.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): await future and custo..."](https://github.com/langfuse/langfuse-python/commit/e174598e20b6509f7a2c54f6764603179e9bcbb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61608052)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Experiments and batch evaluation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-python/-/docs/experiments-and-batch-evaluation.md)

<!-- /greptile_comment -->
