### PR TITLE
fix: log non-retryable 4xx batch drops and warn on silently ignored sample_rate

### DIFF
--- a/langfuse/_client/resource_manager.py
+++ b/langfuse/_client/resource_manager.py
@@ -677,6 +677,11 @@ def _init_tracer_provider(
         otel_trace_api.set_tracer_provider(provider)
 
     else:
+        if sample_rate is not None and sample_rate < 1:
+            langfuse_logger.warning(
+                "Configuration: sample_rate was ignored because an OpenTelemetry TracerProvider is already registered. "
+                "Configure the sampler on your own TracerProvider instead."
+            )
         if id_generator is not None:
             langfuse_logger.warning(
                 "Configuration: id_generator was ignored because an OpenTelemetry TracerProvider is already registered. "

--- a/langfuse/_task_manager/score_ingestion_consumer.py
+++ b/langfuse/_task_manager/score_ingestion_consumer.py
@@ -187,7 +187,10 @@ class ScoreIngestionConsumer(threading.Thread):
                     and 400 <= int(e.status) < 500
                     and int(e.status) != 429  # retry if rate-limited
                 ):
-                    return
+                    # Non-retryable 4xx: the batch is permanently lost.
+                    # Raise so handle_exception logs the loss instead of
+                    # silently pretending the batch was delivered.
+                    raise e
 
                 raise e
 


### PR DESCRIPTION
## Summary

Two fixes:

1. **Silent batch loss**: `execute_task_with_backoff` returned without logging when a non-retryable 4xx (401 after key rotation, 400 validation) hit the score/trace ingestion API. Every event in the batch was permanently lost with no signal — `flush()` even reported success. Now raises so `handle_exception` logs the loss.

2. **Silently ignored `sample_rate`**: when an OTel global TracerProvider is already registered, `sample_rate` was dropped without warning while the init log claimed it was active. Added an explicit warning matching the existing `id_generator` ignored-warning pattern.

## Test plan

Both fixes are logging/warning additions that don't change data flow. Existing behavior for correctly-configured setups is unchanged.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63141348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until permanent 4xx responses are logged without being retried as transient failures.

<details open><summary><h3>Summary</h3></summary>

- Warns when a non-default `sample_rate` cannot be applied because an OpenTelemetry provider is already registered.
- Propagates permanent score-ingestion 4xx failures to the existing exception logger.
- The ingestion change currently causes those non-retryable failures to pass through the retry decorator repeatedly before they are logged.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(client): warn when sample\_rate is s..."](https://github.com/langfuse/langfuse-python/commit/870f0f27804c590c5819a34daffb571b433a7e67)</sub>

<!-- /greptile_comment -->